### PR TITLE
User/invite user to team

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Users/InviteUserCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/InviteUserCommand.swift
@@ -78,7 +78,7 @@ struct InviteUserCommand: ParsableCommand {
             roles: roles,
             allAppsVisible: allAppsVisible,
             provisioningAllowed: provisioningAllowed,
-            appsVisibleIds: appsVisibleIds) // appsVisibleIds should not have value when allAppsVisible is true
+            appsVisibleIds: appsVisibleIds) // appsVisibleIds should be empty when allAppsVisible is true
 
         _ = api.request(request)
             .map { $0.data }


### PR DESCRIPTION
### Finish invite user to team feature

##### This PR is related to issues 3 #3 

This PR includes features 
- Invite user to a development team 

Usage:  
`appstoreconnect-cli users invite [--auth <auth>] <email> <first-name> <last-name> [--roles <roles> ...] [--all-apps-visible] [--provisioning-allowed] [--apps-visible-ids <apps-visible-ids> ...]`

Examples:  
Multiple roles and app visible ids:  
`swift run appstoreconnect-cli users invite dechengma.au@gmail.com decheng ma --roles "DEVELOPER" "MARKETING" --all-apps-visible --provisioning-allowed --apps-visible-ids "321" "456" `

One roles with no app visible ids:
`swift run appstoreconnect-cli users invite dechengma.au@gmail.com decheng ma --roles "DEVELOPER" --all-apps-visible --provisioning-allowed`