### PR TITLE
Add macOS git ignore copied from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,32 @@
+# General
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# SwiftPM Project Specific
 /.build
-/bin
 /Packages
 /*.xcodeproj
 xcuserdata/


### PR DESCRIPTION
Reference: https://github.com/github/gitignore/blob/master/Global/macOS.gitignore

I was getting a lot of unnecessary files in my repo, specifically `._` files but I thought it was prudent to add all the entire macOS git ignore from github