### PR TITLE
Remove `print` from completion renderer

### DIFF
--- a/Sources/AppStoreConnectCLI/Helpers/Renderers+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Renderers+Helpers.swift
@@ -17,7 +17,7 @@ enum Renderers {
         func render(_ input: Subscribers.Completion<Error>) {
             switch input {
                 case .finished:
-                    print("Completed successfully")
+                    break
                 case .failure(let error):
                     print("Completed with error: \(error)")
             }


### PR DESCRIPTION
Generally speaking, completed tasks should only output their results, and nothing else. We should expect the output of our program to become the input to another, as yet unknown, program. 

Unless there’s been an error, we don’t want to change the output in any way. This means we can take the rendered result from STDOUT, be it JSON, YML or what have you, and use it right away. 

### Example

Before the change, piping to `jq` would result in a parse error because `jq` didn't understand the `Completed successfully` message: 

``` 
./appstoreconnect-cli devices list --filter-name Huw --output-format json | jq ".devices[].model"
"iPhone X"
parse error: Invalid numeric literal at line 14, column 10
```
