### PR TITLE
Introduce CSV output format with `CodableCSV`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "CodableCSV",
+        "repositoryURL": "https://github.com/dehesa/CodableCSV.git",
+        "state": {
+          "branch": null,
+          "revision": "c010320df5a18d963718236da694a044ae832c42",
+          "version": "0.5.1"
+        }
+      },
+      {
         "package": "Files",
         "repositoryURL": "https://github.com/johnsundell/files.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,10 @@ let package = Package(
         .package(
             url: "https://github.com/scottrhoyt/SwiftyTextTable.git",
             from: "0.5.0"
+        ),
+        .package(
+            url: "https://github.com/dehesa/CodableCSV.git",
+            from: "0.5.1"
         )
     ],
     targets: [
@@ -42,7 +46,8 @@ let package = Package(
                            .product(name: "AppStoreConnect-Swift-SDK", package: "AppStoreConnect-Swift-SDK"),
                            .product(name: "Yams", package: "Yams"),
                            .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                           .product(name: "SwiftyTextTable", package: "SwiftyTextTable")]
+                           .product(name: "SwiftyTextTable", package: "SwiftyTextTable"),
+                           .product(name: "CodableCSV", package: "CodableCSV")]
         ),
         .testTarget(
             name: "appstoreconnect-cliTests",

--- a/Sources/AppStoreConnectCLI/Model/OutputFormat.swift
+++ b/Sources/AppStoreConnectCLI/Model/OutputFormat.swift
@@ -4,10 +4,10 @@ import ArgumentParser
 import Foundation
 
 enum OutputFormat: String, CaseIterable, Codable {
+    case csv
     case json
-    case yaml
     case table
-//    case csv = "csv"
+    case yaml
 }
 
 extension OutputFormat: ExpressibleByArgument {


### PR DESCRIPTION
Add a new output format: CSV. We have brought in the `CodableCSV` package to help us.

# 📝 Summary of Changes
Despite its name, `CodableCSV`, does not have an `Encoder` for making CSVs. Instead, I have re-used the `TableInfoProvider` protocol to provide its `CSVWriter` type with the data it needs. This gets us CSV support with relatively little effort.

In future, if `CodableCSV` is updated to support `Encodable`, we could possibly revisit this and make encoding a CSV more like encoding JSON or YAML.

# ⚠️ Items of Note

This is _output_ only. The issue https://github.com/ittybittyapps/appstoreconnect-cli/issues/24 specifies input as well.

# 🧐🗒 Reviewer Notes

## 💁 Example

```
./appstoreconnect-cli devices list --output-format csv
```

You can pipe values into other tools. Eg: `xsv`:

```
 ./appstoreconnect-cli devices list --output-format csv | xsv select Name,Model | xsv sample 2 | xsv table
 Name                 Model
 Itty Bitty 4         iPhone 4 GSM
 Boardroom Apple TV   The new Apple TV
```

## 🔨 How To Test

Anywhere that supports outputting to tables can now be outputted as CSV. You can open the output directly in Numbers:

```
./appstoreconnect-cli devices list --output-format csv > file.csv && open -a Numbers file.csv
```
