### PR TITLE
Use AppStoreConnect-Swift-SDK from version `1.0.0`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "AppStoreConnect-Swift-SDK",
         "repositoryURL": "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
         "state": {
-          "branch": "master",
-          "revision": "163c04ba5d7c921888be19913092901d5ace8dad",
-          "version": null
+          "branch": null,
+          "revision": "f1d3e0d62f6c18023c626629f7f326739534c262",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
-            .branch("master")
+            from: "1.0.0"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/Sources/AppStoreConnectCLI/Model/Device.swift
+++ b/Sources/AppStoreConnectCLI/Model/Device.swift
@@ -8,8 +8,6 @@ struct Device: ResultRenderable {
     var id: String
     var addedDate: Date?
     var name: String?
-    // Returns nil for valid results probably because the attribute
-    // property is misnamed. Issue has been raised in the repository
     var deviceClass: DeviceClass?
     var model: String?
     var udid: String?
@@ -27,7 +25,7 @@ extension Device {
         return Device(id: apiDevice.id,
                       addedDate: attributes.addedDate,
                       name: attributes.name,
-                      deviceClass: attributes.devicesClass,
+                      deviceClass: attributes.deviceClass,
                       model: attributes.model,
                       udid: attributes.udid,
                       platform: attributes.platform,


### PR DESCRIPTION
Use AppStoreConnect-Swift-SDK from version `1.0.0`

We were on `master`, but should be more specific. The latest releases of the package have bug and compatibility fixes.

Examples of issues pertaining to us today:

- deviceClass property was mis-named https://github.com/AvdLee/appstoreconnect-swift-sdk/issues/76
- `UNIVERSAL` bundle platform type https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/70

