### PR TITLE
Sync will invite, uninvited, remove and ignore users

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
@@ -29,7 +29,7 @@ struct GetUserInfoCommand: ParsableCommand {
         let request = APIEndpoint.users(filter: filters)
 
         _ = api.request(request)
-            .map(User.fromAPIResponse)
+            .map(Array<User>.init)
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
                 receiveValue: Renderers.ResultRenderer(format: outputFormat).render

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/CancelUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/CancelUserInvitationsCommand.swift
@@ -21,7 +21,7 @@ struct CancelUserInvitationsCommand: ParsableCommand {
 
         let cancelInvitation = { api.request(APIEndpoint.cancel(userInvitationWithId: $0)) }
 
-        _ = try api
+        _ = api
             .invitationIdentifier(matching: email)
             .flatMap(cancelInvitation)
             .sink(

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -78,7 +78,7 @@ public struct ListUsersCommand: ParsableCommand {
             next: nil)
 
         _ = api.request(request)
-            .map(User.fromAPIResponse)
+            .map(Array<User>.init)
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
                 receiveValue: Renderers.ResultRenderer(format: outputFormat).render

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -103,7 +103,7 @@ struct SyncUsersCommand: ParsableCommand {
     private func usersInAppStoreConnect(_ client: HTTPClient) -> AnyPublisher<[User], Error> {
         client
             .request(.users())
-            .map(User.fromAPIResponse)
+            .map(Array<User>.init)
             .eraseToAnyPublisher()
     }
 

--- a/Sources/AppStoreConnectCLI/Model/User.swift
+++ b/Sources/AppStoreConnectCLI/Model/User.swift
@@ -20,10 +20,22 @@ struct User: ResultRenderable {
 // MARK: - API conveniences
 
 extension User {
-    static func fromAPIResponse(_ response: UsersResponse) -> [User] {
+    init(attributes: AppStoreConnect_Swift_SDK.User.Attributes, visibleApps: [AppStoreConnect_Swift_SDK.App]? = nil) {
+        self.username = attributes.username ?? ""
+        self.firstName = attributes.firstName ?? ""
+        self.lastName = attributes.lastName ?? ""
+        self.roles = attributes.roles ?? []
+        self.provisioningAllowed = attributes.provisioningAllowed ?? false
+        self.allAppsVisible = attributes.allAppsVisible ?? false
+        self.visibleApps = visibleApps?.compactMap{ $0.attributes?.bundleId }
+    }
+}
+
+extension Array where Element == User {
+    init(_ response: UsersResponse) {
         let users: [AppStoreConnect_Swift_SDK.User] = response.data
 
-        return users.compactMap { (user: AppStoreConnect_Swift_SDK.User) -> User in
+        let sequence = users.compactMap { (user: AppStoreConnect_Swift_SDK.User) -> User in
             let userVisibleAppIds = user.relationships?.visibleApps?.data?.compactMap { $0.id }
             let userVisibleApps = response.include?.filter {
                 userVisibleAppIds?.contains($0.id) ?? false
@@ -33,16 +45,8 @@ extension User {
 
             return User(attributes: attributes, visibleApps: userVisibleApps)
         }
-    }
 
-    init(attributes: AppStoreConnect_Swift_SDK.User.Attributes, visibleApps: [AppStoreConnect_Swift_SDK.App]? = nil) {
-        self.username = attributes.username ?? ""
-        self.firstName = attributes.firstName ?? ""
-        self.lastName = attributes.lastName ?? ""
-        self.roles = attributes.roles ?? []
-        self.provisioningAllowed = attributes.provisioningAllowed ?? false
-        self.allAppsVisible = attributes.allAppsVisible ?? false
-        self.visibleApps = visibleApps?.compactMap{ $0.attributes?.bundleId }
+        self.init(sequence)
     }
 }
 

--- a/Sources/AppStoreConnectCLI/Model/User.swift
+++ b/Sources/AppStoreConnectCLI/Model/User.swift
@@ -20,22 +20,6 @@ struct User: ResultRenderable {
 // MARK: - API conveniences
 
 extension User {
-    static func fromAPIUser(_ apiUser: AppStoreConnect_Swift_SDK.User) -> User? {
-        guard let attributes = apiUser.attributes,
-              let username = attributes.username else {
-            // TODO: Error handling
-            return nil
-        }
-        let visibleApps = apiUser.relationships?.visibleApps?.data?.map { $0.type }
-        return User(username: username,
-                    firstName: attributes.firstName ?? "",
-                    lastName: attributes.lastName ?? "",
-                    roles: attributes.roles ?? [],
-                    provisioningAllowed: attributes.provisioningAllowed ?? false,
-                    allAppsVisible: attributes.allAppsVisible ?? false,
-                    visibleApps: visibleApps)
-    }
-
     static func fromAPIResponse(_ response: UsersResponse) -> [User] {
         let users: [AppStoreConnect_Swift_SDK.User] = response.data
 

--- a/Sources/AppStoreConnectCLI/Model/UserInvitation.swift
+++ b/Sources/AppStoreConnectCLI/Model/UserInvitation.swift
@@ -52,7 +52,7 @@ extension HTTPClient {
     /// Find the opaque internal identifier for this invitation; search by email adddress.
     ///
     /// This is an App Store Connect internal identifier
-    func invitationIdentifier(matching email: String) throws -> AnyPublisher<String, Error> {
+    func invitationIdentifier(matching email: String) -> AnyPublisher<String, Error> {
         let endpoint = APIEndpoint.invitedUsers(
             filter: [
                 ListInvitedUsers.Filter.email([email])


### PR DESCRIPTION
Previously, we were only looking at the users list, and inviting people who were not on it. This causes trouble when run twice. If we had invited someone, but they have not yet accepted their invitation, the code would attempt to invite them again. That is not allowed by the API. It would return an error and the program would end.

The reason the code would attempt to invite them twice is because it only checked the Users API endpoint. It also needed to check the Pending Invitations to see who has been invited.

Now, we look at not only who is in the users list, but also who has been invited. This means you can run the program many times with the same list, and it will have the [same effect](https://en.wikipedia.org/wiki/Idempotence). A user who has already invited won't be invited a second time.

For everyone in the input list, we check if they are in either the existing users or the invited users lists. If they are, we can ignore that entry. If they are not, we invite them.

For everyone in the existing users list that we want to remove, there are two things we might have to do: remove them from the users list, or remove them from the invited users list. Since the users and invited users are separate API calls there are two separate operations for deleting users or uninviting them. 

This does everything in https://github.com/ittybittyapps/appstoreconnect-cli/issues/5 except for _modification_. If a user in the input file has a role that they do not have in the API, we should be adding that role. 

## 📝 Summary of Changes

Changes proposed in this pull request:

- Make sync remove and ignore invitations

## ⚠️ Items of Note

Please don't do this on the IBA users list. :+1:

## 🧐🗒 Reviewer Notes

### 💁 Example

Say this is our current user list:

| User | email | Accepted Invation? |
|------| ------| ------|
| Carol | carol@example.com | true |  
| Edith | edith@example.com | false |  
| Fran | fran@example.com | true |  

We wish to remove `Edith`, who never accepted the invitation, and `Fran`, who no longer works here.

Start by grabbing all my existing users. We'll use this as our input file: 

```
./appstoreconnect-cli users list --output-format json > users.json
```

I'll add `Alice`, `Bob` and `Dave` to `users.json`, and remove `Edith` and `Fran`.

```
./appstoreconnect-cli users sync --input-format json users.json
invited alice@example.com
invited bob@example.com
ignored carol@example.com
invited dave@example.com
uninvited edith@example.com
removed fran@example.com
```

If I run that a second, third, or fourth time it becomes:

```
./appstoreconnect-cli users sync --input-format json users.json
ignored alice@example.com
ignored bob@example.com
ignored carol@example.com
ignored dave@example.com
```

All the entries are now `ignored`. They already exist as users or have pending invitations.

### 🔨 How To Test

Please do not do this on IBA's users list. I recommend doing it on your own App Store Connect account. Remember _uninviting_ and _removing_ are separate operations. 

