### PR TITLE
Implement ListBetaTestersCommand

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
         "state": {
           "branch": null,
-          "revision": "f2aede09763be2532478f9de318f1d134603aedf",
-          "version": "1.0.2"
+          "revision": "51bef14ba42e13babd7a81136893536d55a29702",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
-            from: "1.0.0"
+            from: "1.0.3"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -81,7 +81,7 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
         }
 
         _ = request
-            .map { BetaTester.init($0.data, $0.included) }
+            .map { BetaTester($0.data, $0.included) }
             .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -81,7 +81,7 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
         }
 
         _ = request
-            .map { BetaTester.init($0.data, $0.include) }
+            .map { BetaTester.init($0.data, $0.included) }
             .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -84,7 +84,7 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
             .map(\.data)
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
+                receiveValue: { _ in }
             )
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -81,10 +81,7 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
         }
 
         _ = request
-            .map(\.data)
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: { _ in }
-            )
+            .map { BetaTester.init($0.data, $0.include) }
+            .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/DeleteBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/DeleteBetaTesterCommand.swift
@@ -76,7 +76,7 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
             // Remove a beta tester's ability to test all apps.
             case .all:
                 request = try api
-                    .betaTesterIdentifier(matching: email)
+                    .betaTesterResourceId(matching: email)
                     .flatMap {
                         api.request(APIEndpoint.delete(betaTesterWithId: $0)).eraseToAnyPublisher()
                     }
@@ -85,7 +85,7 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
             // Remove a specific beta tester's access to test any builds of one or more apps.
             case .removeFromApp(let bundleId):
                 request = try api
-                    .betaTesterIdentifier(matching: email)
+                    .betaTesterResourceId(matching: email)
                     .combineLatest(api.getAppResourceIdsFrom(bundleIds: [bundleId]))
                     .flatMap {
                         api.request(APIEndpoint.remove(accessOfBetaTesterWithId: $0, toAppsWithIds: $1))
@@ -95,7 +95,7 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
             // Remove a specific beta tester from one or more beta groups, revoking their access to test builds associated with those groups.
             case .removeFromGroup(let betaGroupName):
                 request = try api
-                    .betaTesterIdentifier(matching: email)
+                    .betaTesterResourceId(matching: email)
                     .combineLatest(try api.betaGroupIdentifier(matching: betaGroupName))
                     .flatMap {
                         api.request(APIEndpoint.remove(
@@ -108,7 +108,7 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
             // Remove access to test a specific build from one or more individually assigned testers.
             case .removeFromBuild(let buildId):
                 request = try api
-                    .betaTesterIdentifier(matching: email)
+                    .betaTesterResourceId(matching: email)
                     .flatMap {
                         api.request(APIEndpoint.remove(
                             individualTestersWithIds: [$0],

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/HTTPClient+BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/HTTPClient+BetaTester.swift
@@ -1,0 +1,39 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+extension HTTPClient {
+
+    private enum BetaTesterError: Error, CustomStringConvertible {
+        case couldntFindBetaTester
+
+        var description: String {
+            switch self {
+                case .couldntFindBetaTester:
+                    return "Couldn't find beta tester with input email or tester email not unique"
+            }
+        }
+    }
+
+    /// Find the opaque internal identifier for this tester; search by email adddress.
+    ///
+    /// This is an App Store Connect internal identifier
+    func betaTesterResourceId(matching email: String) throws -> AnyPublisher<String, Error> {
+        let endpoint = APIEndpoint.betaTesters(
+            filter: [ListBetaTesters.Filter.email([email])]
+        )
+
+        return self.request(endpoint)
+            .tryMap { response throws -> String in
+                guard response.data.count == 1, let id = response.data.first?.id else {
+                    throw BetaTesterError.couldntFindBetaTester
+                }
+
+                return id
+            }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/HTTPClient+BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/HTTPClient+BetaTester.swift
@@ -6,13 +6,13 @@ import Foundation
 
 extension HTTPClient {
 
-    private enum BetaTesterError: Error, CustomStringConvertible {
-        case couldntFindBetaTester
+    private enum BetaTesterError: Error, LocalizedError {
+        case couldntFindBetaTester(email: String)
 
         var description: String {
             switch self {
-                case .couldntFindBetaTester:
-                    return "Couldn't find beta tester with input email or tester email not unique"
+                case .couldntFindBetaTester(let email):
+                    return "Couldn't find beta tester with input email  \(email) or email not unique"
             }
         }
     }
@@ -28,7 +28,7 @@ extension HTTPClient {
         return self.request(endpoint)
             .tryMap { response throws -> String in
                 guard response.data.count == 1, let id = response.data.first?.id else {
-                    throw BetaTesterError.couldntFindBetaTester
+                    throw BetaTesterError.couldntFindBetaTester(email: email)
                 }
 
                 return id

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/HTTPClient+BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/HTTPClient+BetaTester.swift
@@ -6,10 +6,10 @@ import Foundation
 
 extension HTTPClient {
 
-    private enum BetaTesterError: Error, LocalizedError {
+    private enum BetaTesterError: LocalizedError {
         case couldntFindBetaTester(email: String)
 
-        var description: String {
+        var failureReason: String? {
             switch self {
                 case .couldntFindBetaTester(let email):
                     return "Couldn't find beta tester with input email  \(email) or email not unique"

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -29,14 +29,11 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
     )
     var versions: [String]
 
-    private enum CommandError: Error, LocalizedError {
-        case noAppsFound(bundleId: String)
+    private enum CommandError: LocalizedError {
         case noBuildsFound(preReleaseVersions: [String], versions: [String])
 
-        var errorDescription: String? {
+        var failureReason: String? {
             switch self {
-            case .noAppsFound(let bundleId):
-                return "No apps were found matching \(bundleId)"
             case .noBuildsFound(let preReleaseVersions, let versions):
                 return "No builds were found matching preReleaseVersions \(preReleaseVersions) and versions \(versions)"
             }
@@ -48,11 +45,7 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
 
         _  = api
             .getAppResourceIdsFrom(bundleIds: [bundleId])
-            .flatMap { [versions, preReleaseVersions, bundleId] appIds -> AnyPublisher<BuildsResponse, Error> in
-                guard !appIds.isEmpty else {
-                    let error = CommandError.noAppsFound(bundleId: bundleId)
-                    return Fail(error: error as Error).eraseToAnyPublisher()
-                }
+            .flatMap { [versions, preReleaseVersions] appIds -> AnyPublisher<BuildsResponse, Error> in
 
                 var filters: [ListBuilds.Filter] = [.app(appIds)]
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -42,7 +42,7 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
                 }
 
                 if !preReleaseVersions.isEmpty {
-                    filters.append(.version(preReleaseVersions))
+                    filters.append(.preReleaseVersionVersion(preReleaseVersions))
                 }
 
                 return api.request(APIEndpoint.builds(filter: filters))

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -72,7 +72,7 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
                 return api.request(endpoint).eraseToAnyPublisher()
             }
             .map { response in
-                response.data.map { BetaTester.init($0, response.included) }
+                response.data.map { BetaTester($0, response.included) }
             }
             .renderResult(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -1,0 +1,64 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "listByBuilds",
+        abstract: "List beta testers who were specifically assigned to one or more builds"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The bundle ID of an application. (eg. com.example.app)")
+    var bundleId: String
+
+    @Option(
+        parsing: .upToNextOption,
+        help: "The pre-release version number of this build. (eg. 1.0.0)"
+    )
+    var preReleaseVersions: [String]
+
+    @Option(
+        parsing: .upToNextOption,
+        help: "The version number of this build. (eg. 1)"
+    )
+    var versions: [String]
+
+    func run() throws {
+        let api = try makeClient()
+
+        _  = api
+            .getAppResourceIdsFrom(bundleIds: [bundleId])
+            .flatMap { [versions, preReleaseVersions] appIds -> AnyPublisher<BuildsResponse, Error> in
+                var filters: [ListBuilds.Filter] = [.app(appIds)]
+
+                if !versions.isEmpty {
+                    filters.append(.version(versions))
+                }
+
+                if !preReleaseVersions.isEmpty {
+                    filters.append(.version(preReleaseVersions))
+                }
+
+                return api.request(APIEndpoint.builds(filter: filters))
+                    .eraseToAnyPublisher()
+            }
+            .flatMap {
+                api.request(APIEndpoint.betaTesters(
+                        filter: [.builds($0.data.map(\.id))],
+                        include: [.apps, .betaGroups]
+                    )
+                )
+            }
+            .map { response in
+                response.data.map { BetaTester.init($0, response.included) }
+            }
+            .renderResult(format: common.outputFormat)
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -23,10 +23,10 @@ struct ListBetaTestersCommand: CommonParsableCommand {
             help: "Number of included related resources to return.")
     var relatedResourcesLimit: Int
 
-    private enum ListBetaTesterError: Error, CustomStringConvertible {
+    private enum ListBetaTesterError: LocalizedError {
         case multipleFilters
 
-        var description: String {
+        var failureReason: String? {
             switch self {
                 case .multipleFilters:
                     return "Only one relationship filter can be applied"

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -94,12 +94,13 @@ struct ListBetaTestersCommand: CommonParsableCommand {
                     }
                     .eraseToAnyPublisher()
             case .listByAppAndGroup:
-                throw ListBetaTesterError.multipleFilters
+                request = Fail(error: ListBetaTesterError.multipleFilters)
+                    .eraseToAnyPublisher()
         }
 
         _ = request
             .map { response in
-                response.data.map { BetaTester.init($0, response.included) }
+                response.data.map { BetaTester($0, response.included) }
             }
             .renderResult(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -15,15 +15,15 @@ struct ListBetaTestersCommand: CommonParsableCommand {
 
     @Option(default: "",
             help: "The bundle ID of an application. (eg. com.example.app)")
-    var bundleId: String
+    var bundleId: String?
 
     @Option(default: "",
             help: "The name of the beta group")
-    var betaGroupName: String
+    var betaGroupName: String?
 
     @Option(default: "",
             help: "The ID of one build of an application")
-    var buildId: String
+    var buildId: String?
 
     private enum ListStrategy {
         case all
@@ -31,15 +31,15 @@ struct ListBetaTestersCommand: CommonParsableCommand {
         case listByGroup(betaGroupName: String)
         case listByBuild(buildId: String)
 
-        typealias ListOptions = (bundleId: String, betaGroupName: String, buildId: String)
+        typealias ListOptions = (bundleId: String?, betaGroupName: String?, buildId: String?)
 
         init(options: ListOptions) {
             switch (options.bundleId, options.betaGroupName, options.buildId) {
-                case (let bundleId, _, _) where !bundleId.isEmpty:
+                case let(.some(bundleId), _, _) where !bundleId.isEmpty:
                     self = .listByApp(bundleId: bundleId)
-                case (_, let betaGroupName, _) where !betaGroupName.isEmpty:
+                case let(_, .some(betaGroupName), _) where !betaGroupName.isEmpty:
                     self = .listByGroup(betaGroupName: betaGroupName)
-                case (_, _, let buildId) where !buildId.isEmpty:
+                case let(_, _, .some(buildId)) where !buildId.isEmpty:
                     self = .listByBuild(buildId: buildId)
                 case (_, _, _):
                     self = .all
@@ -52,37 +52,46 @@ struct ListBetaTestersCommand: CommonParsableCommand {
 
         let request: AnyPublisher<BetaTestersResponse, Error>
 
+        let includes = [ListBetaTesters.Include.apps, ListBetaTesters.Include.betaGroups]
+
         switch ListStrategy(options: (bundleId, betaGroupName, buildId)) {
             case .all:
-                request = api.request(APIEndpoint.betaTesters()).eraseToAnyPublisher()
+                request = api
+                    .request(APIEndpoint.betaTesters(include: includes))
+                    .eraseToAnyPublisher()
 
             case .listByApp(let bundleId):
                 request = api
                     .getAppResourceIdsFrom(bundleIds: [bundleId])
                     .flatMap {
                         api.request(APIEndpoint.betaTesters(
-                            filter: [ListBetaTesters.Filter.apps($0)]
+                            filter: [ListBetaTesters.Filter.apps($0)],
+                            include: includes
                         ))
                     }
                     .eraseToAnyPublisher()
+
             case .listByGroup(let betaGroupName):
                 request = try api.betaGroupIdentifier(matching: betaGroupName)
                     .flatMap {
                         api.request(APIEndpoint.betaTesters(
-                            filter: [ListBetaTesters.Filter.betaGroups([$0])]
+                            filter: [ListBetaTesters.Filter.betaGroups([$0])],
+                            include: includes
                         ))
                     }
                     .eraseToAnyPublisher()
+            
             case .listByBuild(let buildId):
                 request = api.request(APIEndpoint.betaTesters(
-                        filter: [ListBetaTesters.Filter.builds([buildId])]
+                        filter: [ListBetaTesters.Filter.builds([buildId])],
+                        include: includes
                     ))
                     .eraseToAnyPublisher()
-
         }
 
         _ = request
             .map(\.data)
+            .flatMap { api.fromAPIBetaTesters(betaTesters: $0) }
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
                 receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -31,8 +31,10 @@ struct ListBetaTestersCommand: CommonParsableCommand {
         case listByGroup(betaGroupName: String)
         case listByBuild(buildId: String)
 
-        init(_ bundleId: String, _ betaGroupName: String, _ buildId: String) {
-            switch (bundleId, betaGroupName, buildId) {
+        typealias ListOptions = (bundleId: String, betaGroupName: String, buildId: String)
+
+        init(options: ListOptions) {
+            switch (options.bundleId, options.betaGroupName, options.buildId) {
                 case (let bundleId, _, _) where !bundleId.isEmpty:
                     self = .listByApp(bundleId: bundleId)
                 case (_, let betaGroupName, _) where !betaGroupName.isEmpty:
@@ -50,7 +52,7 @@ struct ListBetaTestersCommand: CommonParsableCommand {
 
         let request: AnyPublisher<BetaTestersResponse, Error>
 
-        switch ListStrategy(bundleId, betaGroupName, buildId) {
+        switch ListStrategy(options: (bundleId, betaGroupName, buildId)) {
             case .all:
                 request = api.request(APIEndpoint.betaTesters()).eraseToAnyPublisher()
 
@@ -67,13 +69,13 @@ struct ListBetaTestersCommand: CommonParsableCommand {
                 request = try api.betaGroupIdentifier(matching: betaGroupName)
                     .flatMap {
                         api.request(APIEndpoint.betaTesters(
-                            filter: [ListBetaTesters.Filter.betaGroups([$0])])
-                        )
+                            filter: [ListBetaTesters.Filter.betaGroups([$0])]
+                        ))
                     }
                     .eraseToAnyPublisher()
             case .listByBuild(let buildId):
                 request = api.request(APIEndpoint.betaTesters(
-                    filter: [ListBetaTesters.Filter.builds([buildId])]
+                        filter: [ListBetaTesters.Filter.builds([buildId])]
                     ))
                     .eraseToAnyPublisher()
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -88,11 +88,8 @@ struct ListBetaTestersCommand: CommonParsableCommand {
 
         _ = request
             .map { response in
-                response.data.map { BetaTester.init($0, response.include) }
+                response.data.map { BetaTester.init($0, response.included) }
             }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -14,13 +14,13 @@ struct ListBetaTestersCommand: CommonParsableCommand {
     var common: CommonOptions
 
     @Option(help: "The bundle ID of an application. (eg. com.example.app)")
-    var bundleId: String?
+    var filterBundleId: String?
 
     @Option(help: "The name of the beta group")
-    var betaGroupName: String?
+    var filterGroupName: String?
 
     @Option(help: "The ID of one build of an application")
-    var buildId: String?
+    var filterBuildId: String?
 
     private enum ListStrategy {
         case all
@@ -51,7 +51,7 @@ struct ListBetaTestersCommand: CommonParsableCommand {
 
         let includes = [ListBetaTesters.Include.apps, ListBetaTesters.Include.betaGroups]
 
-        switch ListStrategy(options: (bundleId, betaGroupName, buildId)) {
+        switch ListStrategy(options: (filterBundleId, filterGroupName, filterBuildId)) {
             case .all:
                 request = api
                     .request(APIEndpoint.betaTesters(include: includes))

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -87,8 +87,9 @@ struct ListBetaTestersCommand: CommonParsableCommand {
         }
 
         _ = request
-            .map(\.data)
-            .flatMap { api.fromAPIBetaTesters(betaTesters: $0) }
+            .map { response in
+                response.data.map { BetaTester.init($0, response.include) }
+            }
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
                 receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -19,26 +19,20 @@ struct ListBetaTestersCommand: CommonParsableCommand {
     @Option(help: "The name of the beta group")
     var filterGroupName: String?
 
-    @Option(help: "The ID of one build of an application")
-    var filterBuildId: String?
-
     private enum ListStrategy {
         case all
         case listByApp(bundleId: String)
         case listByGroup(betaGroupName: String)
-        case listByBuild(buildId: String)
 
-        typealias ListOptions = (bundleId: String?, betaGroupName: String?, buildId: String?)
+        typealias ListOptions = (bundleId: String?, betaGroupName: String?)
 
         init(options: ListOptions) {
-            switch (options.bundleId, options.betaGroupName, options.buildId) {
-                case let(.some(bundleId), _, _) where !bundleId.isEmpty:
+            switch (options.bundleId, options.betaGroupName) {
+                case let(.some(bundleId), _) where !bundleId.isEmpty:
                     self = .listByApp(bundleId: bundleId)
-                case let(_, .some(betaGroupName), _) where !betaGroupName.isEmpty:
+                case let(_, .some(betaGroupName)) where !betaGroupName.isEmpty:
                     self = .listByGroup(betaGroupName: betaGroupName)
-                case let(_, _, .some(buildId)) where !buildId.isEmpty:
-                    self = .listByBuild(buildId: buildId)
-                case (_, _, _):
+                case (_, _):
                     self = .all
             }
         }
@@ -51,7 +45,7 @@ struct ListBetaTestersCommand: CommonParsableCommand {
 
         let includes = [ListBetaTesters.Include.apps, ListBetaTesters.Include.betaGroups]
 
-        switch ListStrategy(options: (filterBundleId, filterGroupName, filterBuildId)) {
+        switch ListStrategy(options: (filterBundleId, filterGroupName)) {
             case .all:
                 request = api
                     .request(APIEndpoint.betaTesters(include: includes))
@@ -76,13 +70,6 @@ struct ListBetaTestersCommand: CommonParsableCommand {
                             include: includes
                         ))
                     }
-                    .eraseToAnyPublisher()
-            
-            case .listByBuild(let buildId):
-                request = api.request(APIEndpoint.betaTesters(
-                        filter: [ListBetaTesters.Filter.builds([buildId])],
-                        include: includes
-                    ))
                     .eraseToAnyPublisher()
         }
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -13,16 +13,13 @@ struct ListBetaTestersCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(default: "",
-            help: "The bundle ID of an application. (eg. com.example.app)")
+    @Option(help: "The bundle ID of an application. (eg. com.example.app)")
     var bundleId: String?
 
-    @Option(default: "",
-            help: "The name of the beta group")
+    @Option(help: "The name of the beta group")
     var betaGroupName: String?
 
-    @Option(default: "",
-            help: "The ID of one build of an application")
+    @Option(help: "The ID of one build of an application")
     var buildId: String?
 
     private enum ListStrategy {

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -1,0 +1,89 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ListBetaTestersCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List beta testers")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Option(default: "",
+            help: "The bundle ID of an application. (eg. com.example.app)")
+    var bundleId: String
+
+    @Option(default: "",
+            help: "The name of the beta group")
+    var betaGroupName: String
+
+    @Option(default: "",
+            help: "The ID of one build of an application")
+    var buildId: String
+
+    private enum ListStrategy {
+        case all
+        case listByApp(bundleId: String)
+        case listByGroup(betaGroupName: String)
+        case listByBuild(buildId: String)
+
+        init(_ bundleId: String, _ betaGroupName: String, _ buildId: String) {
+            switch (bundleId, betaGroupName, buildId) {
+                case (let bundleId, _, _) where !bundleId.isEmpty:
+                    self = .listByApp(bundleId: bundleId)
+                case (_, let betaGroupName, _) where !betaGroupName.isEmpty:
+                    self = .listByGroup(betaGroupName: betaGroupName)
+                case (_, _, let buildId) where !buildId.isEmpty:
+                    self = .listByBuild(buildId: buildId)
+                case (_, _, _):
+                    self = .all
+            }
+        }
+    }
+
+    func run() throws {
+        let api = try makeClient()
+
+        let request: AnyPublisher<BetaTestersResponse, Error>
+
+        switch ListStrategy(bundleId, betaGroupName, buildId) {
+            case .all:
+                request = api.request(APIEndpoint.betaTesters()).eraseToAnyPublisher()
+
+            case .listByApp(let bundleId):
+                request = api
+                    .getAppResourceIdsFrom(bundleIds: [bundleId])
+                    .flatMap {
+                        api.request(APIEndpoint.betaTesters(
+                            filter: [ListBetaTesters.Filter.apps($0)]
+                        ))
+                    }
+                    .eraseToAnyPublisher()
+            case .listByGroup(let betaGroupName):
+                request = try api.betaGroupIdentifier(matching: betaGroupName)
+                    .flatMap {
+                        api.request(APIEndpoint.betaTesters(
+                            filter: [ListBetaTesters.Filter.betaGroups([$0])])
+                        )
+                    }
+                    .eraseToAnyPublisher()
+            case .listByBuild(let buildId):
+                request = api.request(APIEndpoint.betaTesters(
+                    filter: [ListBetaTesters.Filter.builds([buildId])]
+                    ))
+                    .eraseToAnyPublisher()
+
+        }
+
+        _ = request
+            .map(\.data)
+            .sink(
+                receiveCompletion: Renderers.CompletionRenderer().render,
+                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
+            )
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
@@ -10,7 +10,8 @@ public struct TestFlightBetaTestersCommand: ParsableCommand {
         subcommands: [
              CreateBetaTesterCommand.self,
              DeleteBetaTesterCommand.self,
-             ListBetaTestersCommand.self
+             ListBetaTestersCommand.self,
+             ListBetaTesterByBuildsCommand.self
             // GetBetaTesterInfoCommand.self,
         ])
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
@@ -10,7 +10,7 @@ public struct TestFlightBetaTestersCommand: ParsableCommand {
         subcommands: [
              CreateBetaTesterCommand.self,
              DeleteBetaTesterCommand.self,
-            // ListBetaTestersCommand.self,
+             ListBetaTestersCommand.self
             // GetBetaTesterInfoCommand.self,
         ])
 

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -5,10 +5,10 @@ import Combine
 import Foundation
 
 extension HTTPClient {
-    private enum BetaGroupError: Error, CustomStringConvertible {
+    private enum BetaGroupError: LocalizedError {
         case couldntFindBetaGroup
 
-        var description: String {
+        var failureReason: String? {
             switch self {
                 case .couldntFindBetaGroup:
                     return "Couldn't find beta group with input name or group name not unique"

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -5,7 +5,28 @@ import Combine
 import Foundation
 import SwiftyTextTable
 
-extension BetaTester: ResultRenderable { }
+struct BetaTester: ResultRenderable {
+    let email: String
+    let firstName: String
+    let lastName: String
+    let inviteType: String
+    let betaGroups: [BetaGroup]
+    let apps: [App]
+
+    init(email: String?,
+         firstName: String?,
+         lastName: String?,
+         inviteType: BetaInviteType?,
+         betaGroups: [BetaGroup]?,
+         apps: [App]?) {
+        self.email = email ?? ""
+        self.firstName = firstName ?? ""
+        self.lastName = lastName ?? ""
+        self.inviteType = inviteType?.rawValue ?? ""
+        self.betaGroups = betaGroups ?? []
+        self.apps = apps ?? []
+    }
+}
 
 extension BetaTester: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
@@ -13,33 +34,21 @@ extension BetaTester: TableInfoProvider {
             TextTableColumn(header: "Email"),
             TextTableColumn(header: "First Name"),
             TextTableColumn(header: "Last Name"),
-            TextTableColumn(header: "Invite Type")
+            TextTableColumn(header: "Invite Type"),
+            TextTableColumn(header: "Beta Groups"),
+            TextTableColumn(header: "Apps")
         ]
     }
 
     var tableRow: [CustomStringConvertible] {
         return [
-            attributes?.email ?? "",
-            attributes?.firstName ?? "",
-            attributes?.lastName ?? "",
-            betaInviteType
+            email,
+            firstName,
+            lastName,
+            inviteType,
+            betaGroups.compactMap { $0.attributes?.name }.joined(separator: ", ") ,
+            apps.compactMap { $0.name }.joined(separator: ", ")
         ]
-    }
-
-    var betaInviteType: String {
-        return attributes?.inviteType?.rawValue ?? ""
-    }
-
-    var appsId: [String] {
-        return relationships?.apps?.data?.compactMap { $0.id } ?? []
-    }
-
-    var betaGroupsIds: [String] {
-        return relationships?.betaGroups?.data?.compactMap { $0.id } ?? []
-    }
-
-    var buildsIds: [String] {
-        return relationships?.builds?.data?.compactMap { $0.id } ?? []
     }
 }
 
@@ -74,5 +83,118 @@ extension HTTPClient {
             }
             .eraseToAnyPublisher()
     }
-    
+
+    private enum TransformStrategy {
+        case hasApps(appIds: [String])
+        case hasGroups(groupIds: [String])
+        case hasBoth(appIds: [String], groupIds: [String])
+        case none
+
+        init(groupIds: [String]?, appIds: [String]?) {
+            switch (groupIds, appIds) {
+                case let(.some(groupIds), _) where !groupIds.isEmpty:
+                    self = .hasGroups(groupIds:groupIds)
+                case let(_, .some(appIds)) where !appIds.isEmpty:
+                    self = .hasApps(appIds: appIds)
+                case let(.some(groupIds), .some(appIds)) where !groupIds.isEmpty && !appIds.isEmpty:
+                    self = .hasBoth(appIds: appIds, groupIds: groupIds)
+                case (_, _):
+                    self = .none
+            }
+        }
+    }
+
+    func fromAPIBetaTesters(betaTesters: [AppStoreConnect_Swift_SDK.BetaTester]) -> AnyPublisher<[BetaTester], Error> {
+        let betaTesters = betaTesters.map { (tester: AppStoreConnect_Swift_SDK.BetaTester) -> AnyPublisher<BetaTester, Error> in
+            let groupIds = tester.relationships?.betaGroups?.data?.compactMap { $0.id }
+            let appIds = tester.relationships?.apps?.data?.compactMap { $0.id }
+
+            switch TransformStrategy(groupIds: groupIds, appIds: appIds) {
+                case .hasApps(let appIds):
+                    let endpoint = APIEndpoint.apps(
+                        filters: [ListApps.Filter.id(appIds)]
+                    )
+
+                    return self.request(endpoint)
+                        .map(\.data)
+                        .map { (apps: [AppStoreConnect_Swift_SDK.App]) in
+                            let apps = apps.map { App(bundleId: $0.attributes?.bundleId,
+                                                      name: $0.attributes?.name,
+                                                      primaryLocale: $0.attributes?.primaryLocale,
+                                                      sku: $0.attributes?.sku) }
+
+                            return BetaTester(
+                                email: tester.attributes?.email,
+                                firstName: tester.attributes?.firstName,
+                                lastName: tester.attributes?.lastName,
+                                inviteType: tester.attributes?.inviteType,
+                                betaGroups: nil,
+                                apps: apps
+                            )
+                        }
+                        .eraseToAnyPublisher()
+
+                case .hasGroups(let groupIds):
+                    let endpoint = APIEndpoint.betaGroups(
+                        filter: [ListBetaGroups.Filter.id(groupIds)]
+                    )
+
+                    return self.request(endpoint)
+                        .map(\.data)
+                        .map { (groups: [BetaGroup]) in
+                            return BetaTester(
+                                email: tester.attributes?.email,
+                                firstName: tester.attributes?.firstName,
+                                lastName: tester.attributes?.lastName,
+                                inviteType: tester.attributes?.inviteType,
+                                betaGroups: groups,
+                                apps: nil)
+                        }
+                        .eraseToAnyPublisher()
+
+                case .hasBoth(let appIds, let groupIds):
+                    let betaGroupEndpoint = APIEndpoint.betaGroups(
+                        filter: [ListBetaGroups.Filter.id(groupIds)]
+                    )
+
+                    let appsEndpoint = APIEndpoint.apps(
+                        filters: [ListApps.Filter.id(appIds)]
+                    )
+
+                    return self.request(betaGroupEndpoint)
+                        .combineLatest(self.request(appsEndpoint))
+                        .map { ($0.0.data, $0.1.data) }
+                        .map {
+                            return BetaTester(
+                                email: tester.attributes?.email,
+                                firstName: tester.attributes?.firstName,
+                                lastName: tester.attributes?.lastName,
+                                inviteType: tester.attributes?.inviteType,
+                                betaGroups: $0,
+                                apps: $1.map { App(bundleId: $0.attributes?.bundleId,
+                                                   name: $0.attributes?.name,
+                                                   primaryLocale: $0.attributes?.primaryLocale,
+                                                   sku: $0.attributes?.sku) }
+                            )
+                        }
+                        .eraseToAnyPublisher()
+
+                case .none:
+                    let tester = BetaTester(
+                        email: tester.attributes?.email,
+                        firstName: tester.attributes?.firstName,
+                        lastName: tester.attributes?.lastName,
+                        inviteType: tester.attributes?.inviteType,
+                        betaGroups: nil,
+                        apps: nil
+                    )
+
+                    return Empty<BetaTester, Error>()
+                        .append(tester)
+                        .eraseToAnyPublisher()
+            }
+        }
+
+        return Publishers.MergeMany(betaTesters).reduce([], { $0 + [$1] }).eraseToAnyPublisher()
+    }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -98,7 +98,7 @@ extension HTTPClient {
     /// Find the opaque internal identifier for this tester; search by email adddress.
     ///
     /// This is an App Store Connect internal identifier
-    func betaTesterIdentifier(matching email: String) throws -> AnyPublisher<String, Error> {
+    func betaTesterResourceId(matching email: String) throws -> AnyPublisher<String, Error> {
         let endpoint = APIEndpoint.betaTesters(
             filter: [ListBetaTesters.Filter.email([email])]
         )
@@ -114,117 +114,4 @@ extension HTTPClient {
             .eraseToAnyPublisher()
     }
 
-    private enum TransformStrategy {
-        case hasApps(appIds: [String])
-        case hasGroups(groupIds: [String])
-        case hasBoth(appIds: [String], groupIds: [String])
-        case none
-
-        init(groupIds: [String]?, appIds: [String]?) {
-            switch (groupIds, appIds) {
-                case let(.some(groupIds), _) where !groupIds.isEmpty:
-                    self = .hasGroups(groupIds:groupIds)
-                case let(_, .some(appIds)) where !appIds.isEmpty:
-                    self = .hasApps(appIds: appIds)
-                case let(.some(groupIds), .some(appIds)) where !groupIds.isEmpty && !appIds.isEmpty:
-                    self = .hasBoth(appIds: appIds, groupIds: groupIds)
-                case (_, _):
-                    self = .none
-            }
-        }
-    }
-
-    func fromAPIBetaTesters(betaTesters: [AppStoreConnect_Swift_SDK.BetaTester]) -> AnyPublisher<[BetaTester], Error> {
-        let betaTesters = betaTesters.map { (tester: AppStoreConnect_Swift_SDK.BetaTester) -> AnyPublisher<BetaTester, Error> in
-            let groupIds = tester.relationships?.betaGroups?.data?.compactMap { $0.id }
-            let appIds = tester.relationships?.apps?.data?.compactMap { $0.id }
-
-            switch TransformStrategy(groupIds: groupIds, appIds: appIds) {
-                case .hasApps(let appIds):
-                    let endpoint = APIEndpoint.apps(
-                        filters: [ListApps.Filter.id(appIds)]
-                    )
-
-                    return self.request(endpoint)
-                        .map(\.data)
-                        .map { (apps: [AppStoreConnect_Swift_SDK.App]) in
-                            let apps = apps.map { App(bundleId: $0.attributes?.bundleId,
-                                                      name: $0.attributes?.name,
-                                                      primaryLocale: $0.attributes?.primaryLocale,
-                                                      sku: $0.attributes?.sku) }
-
-                            return BetaTester(
-                                email: tester.attributes?.email,
-                                firstName: tester.attributes?.firstName,
-                                lastName: tester.attributes?.lastName,
-                                inviteType: tester.attributes?.inviteType,
-                                betaGroups: nil,
-                                apps: apps
-                            )
-                        }
-                        .eraseToAnyPublisher()
-
-                case .hasGroups(let groupIds):
-                    let endpoint = APIEndpoint.betaGroups(
-                        filter: [ListBetaGroups.Filter.id(groupIds)]
-                    )
-
-                    return self.request(endpoint)
-                        .map(\.data)
-                        .map { (groups: [BetaGroup]) in
-                            return BetaTester(
-                                email: tester.attributes?.email,
-                                firstName: tester.attributes?.firstName,
-                                lastName: tester.attributes?.lastName,
-                                inviteType: tester.attributes?.inviteType,
-                                betaGroups: groups,
-                                apps: nil)
-                        }
-                        .eraseToAnyPublisher()
-
-                case .hasBoth(let appIds, let groupIds):
-                    let betaGroupEndpoint = APIEndpoint.betaGroups(
-                        filter: [ListBetaGroups.Filter.id(groupIds)]
-                    )
-
-                    let appsEndpoint = APIEndpoint.apps(
-                        filters: [ListApps.Filter.id(appIds)]
-                    )
-
-                    return self.request(betaGroupEndpoint)
-                        .combineLatest(self.request(appsEndpoint))
-                        .map { ($0.0.data, $0.1.data) }
-                        .map {
-                            return BetaTester(
-                                email: tester.attributes?.email,
-                                firstName: tester.attributes?.firstName,
-                                lastName: tester.attributes?.lastName,
-                                inviteType: tester.attributes?.inviteType,
-                                betaGroups: $0,
-                                apps: $1.map { App(bundleId: $0.attributes?.bundleId,
-                                                   name: $0.attributes?.name,
-                                                   primaryLocale: $0.attributes?.primaryLocale,
-                                                   sku: $0.attributes?.sku) }
-                            )
-                        }
-                        .eraseToAnyPublisher()
-
-                case .none:
-                    let tester = BetaTester(
-                        email: tester.attributes?.email,
-                        firstName: tester.attributes?.firstName,
-                        lastName: tester.attributes?.lastName,
-                        inviteType: tester.attributes?.inviteType,
-                        betaGroups: nil,
-                        apps: nil
-                    )
-
-                    return Empty<BetaTester, Error>()
-                        .append(tester)
-                        .eraseToAnyPublisher()
-            }
-        }
-
-        return Publishers.MergeMany(betaTesters).reduce([], { $0 + [$1] }).eraseToAnyPublisher()
-    }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -6,12 +6,12 @@ import Foundation
 import SwiftyTextTable
 
 struct BetaTester: ResultRenderable {
-    let email: String
-    let firstName: String
-    let lastName: String
-    let inviteType: String
-    let betaGroups: [BetaGroup]
-    let apps: [App]
+    let email: String?
+    let firstName: String?
+    let lastName: String?
+    let inviteType: String?
+    let betaGroups: [BetaGroup]?
+    let apps: [App]?
 
     init(email: String?,
          firstName: String?,
@@ -19,12 +19,42 @@ struct BetaTester: ResultRenderable {
          inviteType: BetaInviteType?,
          betaGroups: [BetaGroup]?,
          apps: [App]?) {
-        self.email = email ?? ""
-        self.firstName = firstName ?? ""
-        self.lastName = lastName ?? ""
-        self.inviteType = inviteType?.rawValue ?? ""
-        self.betaGroups = betaGroups ?? []
-        self.apps = apps ?? []
+        self.email = email
+        self.firstName = firstName
+        self.lastName = lastName
+        self.inviteType = inviteType?.rawValue
+        self.betaGroups = betaGroups
+        self.apps = apps
+    }
+
+    init(_ betaTester: AppStoreConnect_Swift_SDK.BetaTester, _ includes: [AppStoreConnect_Swift_SDK.BetaTesterRelationship]?) {
+        let attributes = betaTester.attributes
+
+        let apps = includes?.compactMap { relationship -> App? in
+            if case let .app(app) = relationship {
+                return App(bundleId: app.attributes?.bundleId,
+                           name: app.attributes?.name,
+                           primaryLocale: app.attributes?.primaryLocale,
+                           sku: app.attributes?.sku)
+            }
+
+            return nil
+        }
+
+        let betaGroups = includes?.compactMap { relationship -> BetaGroup? in
+            if case let .betaGroup(betaGroup) = relationship {
+                return betaGroup
+            }
+
+            return nil
+        }
+
+        self.init(email: attributes?.email,
+                  firstName: attributes?.firstName,
+                  lastName: attributes?.lastName,
+                  inviteType: attributes?.inviteType,
+                  betaGroups: betaGroups,
+                  apps: apps)
     }
 }
 
@@ -42,12 +72,12 @@ extension BetaTester: TableInfoProvider {
 
     var tableRow: [CustomStringConvertible] {
         return [
-            email,
-            firstName,
-            lastName,
-            inviteType,
-            betaGroups.compactMap { $0.attributes?.name }.joined(separator: ", ") ,
-            apps.compactMap { $0.bundleId }.joined(separator: ", ")
+            email ?? "",
+            firstName ?? "",
+            lastName ?? "",
+            inviteType ?? "",
+            betaGroups?.compactMap { $0.attributes?.name }.joined(separator: ", ") ?? "",
+            apps?.compactMap { $0.bundleId }.joined(separator: ", ") ?? ""
         ]
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -47,7 +47,7 @@ extension BetaTester: TableInfoProvider {
             lastName,
             inviteType,
             betaGroups.compactMap { $0.attributes?.name }.joined(separator: ", ") ,
-            apps.compactMap { $0.name }.joined(separator: ", ")
+            apps.compactMap { $0.bundleId }.joined(separator: ", ")
         ]
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -13,12 +13,14 @@ struct BetaTester: ResultRenderable {
     let betaGroups: [String]?
     let apps: [String]?
 
-    init(email: String?,
+    init(
+        email: String?,
          firstName: String?,
          lastName: String?,
          inviteType: BetaInviteType?,
          betaGroups: [String]?,
-         apps: [String]?) {
+         apps: [String]?
+    ) {
         self.email = email
         self.firstName = firstName
         self.lastName = lastName
@@ -46,12 +48,14 @@ struct BetaTester: ResultRenderable {
         }
 
         // Find tester related beta groups and apps in included data
-        let betaGroupsNames = relationships?.betaGroups?.data?.compactMap { group -> [BetaGroup]? in
+        let betaGroupsNames = relationships?.betaGroups?.data?
+            .compactMap { group -> [BetaGroup]? in
                 includedBetaGroups?.filter { $0.id == group.id }
             }
             .flatMap { $0.compactMap { $0.attributes?.name } }
 
-        let appsBundleIds = relationships?.apps?.data?.compactMap { app -> [AppStoreConnect_Swift_SDK.App]? in
+        let appsBundleIds = relationships?.apps?.data?
+            .compactMap { app -> [AppStoreConnect_Swift_SDK.App]? in
                 includedApps?.filter { app.id == $0.id }
             }
             .flatMap { $0.compactMap { $0.attributes?.bundleId } }

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -81,37 +81,3 @@ extension BetaTester: TableInfoProvider {
         ]
     }
 }
-
-extension HTTPClient {
-
-    private enum BetaTesterError: Error, CustomStringConvertible {
-        case couldntFindBetaTester
-
-        var description: String {
-            switch self {
-                case .couldntFindBetaTester:
-                    return "Couldn't find beta tester with input email or tester email not unique"
-            }
-        }
-    }
-
-    /// Find the opaque internal identifier for this tester; search by email adddress.
-    ///
-    /// This is an App Store Connect internal identifier
-    func betaTesterResourceId(matching email: String) throws -> AnyPublisher<String, Error> {
-        let endpoint = APIEndpoint.betaTesters(
-            filter: [ListBetaTesters.Filter.email([email])]
-        )
-
-        return self.request(endpoint)
-            .tryMap { response throws -> String in
-                guard response.data.count == 1, let id = response.data.first?.id else {
-                    throw BetaTesterError.couldntFindBetaTester
-                }
-
-                return id
-            }
-            .eraseToAnyPublisher()
-    }
-
-}

--- a/Sources/AppStoreConnectCLI/Model/User.swift
+++ b/Sources/AppStoreConnectCLI/Model/User.swift
@@ -41,7 +41,7 @@ extension User {
 
         return users.compactMap { (user: AppStoreConnect_Swift_SDK.User) -> User in
             let userVisibleAppIds = user.relationships?.visibleApps?.data?.compactMap { $0.id }
-            let userVisibleApps = response.include?.filter {
+            let userVisibleApps = response.included?.filter {
                 userVisibleAppIds?.contains($0.id) ?? false
             }
 


### PR DESCRIPTION
Implement List Beta Tester Command, four ways of listing are supported, this PR is related to #45 

# 📝 Summary of Changes

Changes proposed in this pull request:
- Update `appstoreconnect-swift-sdk` to 1.0.3
- Create `ListBetaTestersCommand`, user can list beta testers who are related to 
1. an app,
3. a beta group
4. all, if there is no input
- Create `ListBetaTestersByBuilds`, user can list beta testers who were assigned to one or more specific builds

# Notes
1. Can't input both group name and bundle, API will return `PARAMETER_ERROR.INVALID` and `Only one relationship filter can be applied`, and an error will be thrown
2. For listing the by beta group name, there will be no `include` with `relationship` data in response. I already filed feedback to Apple, haven't got something back now.

# 🧐🗒 Reviewer Notes

## 💁 Example

`testflight betatesters list [--bundle-id <bundle-id>] [--beta-group-name <beta-group-name>] [--build-id <build-id>] [--related-resources-limit <related-resources-limit>]`

`testflight betatesters listByBuilds <bundle-id> [--pre-release-versions <pre-release-versions> ...] [--versions <versions> ...]`

## 🔨 How To Test

`swift run asc testflight betatesters list --group-name yourGroupName`

`swift run asc testflight betatesters listByBuilds com.example.roadrunner --pre-release-versions 1.0.0 --versions 1 `
