### PR TITLE
Correctly implement limit visible apps for list user commands

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -13,7 +13,7 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(help: "Limit the number visible apps to return (maximum 200).")
+    @Option(help: "Limit the number visible apps to return (maximum 50).")
     var limit: Int?
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified username")

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -43,7 +43,7 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
         let api = try makeClient()
 
         let endpoint = APIEndpoint.invitedUsers(
-            limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] } ?? [],
+            limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] } ,
             filter: filters
         )
 

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -14,7 +14,7 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
     var common: CommonOptions
 
     @Option(help: "Limit the number visible apps to return (maximum 50).")
-    var limit: Int?
+    var limitVisibleApps: Int?
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified username")
     var filterEmail: [String]
@@ -43,7 +43,7 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
         let api = try makeClient()
 
         let endpoint = APIEndpoint.invitedUsers(
-            limit: limit.map { [ListInvitedUsers.Limit.visibleApps($0)] } ?? [],
+            limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] } ?? [],
             filter: filters
         )
 

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -13,7 +13,7 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(help: "Limit the number of users to return (maximum 200).")
+    @Option(help: "Limit the number visible apps to return (maximum 200).")
     var limit: Int?
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified username")

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -43,7 +43,7 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
         let api = try makeClient()
 
         let endpoint = APIEndpoint.invitedUsers(
-            limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] } ,
+            limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] },
             filter: filters
         )
 

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -74,7 +74,6 @@ public struct ListUsersCommand: CommonParsableCommand {
             filter: filters,
             next: nil)
 
-
         _ = api.request(request)
             .map(User.fromAPIResponse)
             .sink(

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -69,7 +69,7 @@ public struct ListUsersCommand: CommonParsableCommand {
             include: includeVisibleApps
                 ? [ListUsers.Include.visibleApps]
                 : nil,
-            limit: limitVisibleApps.map { [ListUsers.Limit.visibleApps($0)] } ?? [],
+            limit: limitVisibleApps.map { [ListUsers.Limit.visibleApps($0)] },
             sort: [sort].compactMap { $0 },
             filter: filters,
             next: nil)

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -15,7 +15,7 @@ public struct ListUsersCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(help: "Limit the number of users to return (maximum 200).")
+    @Option(help: "Limit the number visible apps to return (maximum 50).")
     var limit: Int?
 
     @Option(
@@ -69,10 +69,11 @@ public struct ListUsersCommand: CommonParsableCommand {
             include: includeVisibleApps
                 ? [ListUsers.Include.visibleApps]
                 : nil,
-            limit: nil, // Limit of visibleApps if included, not limit of users
+            limit: limit.map { [ListUsers.Limit.visibleApps($0)] } ?? [], // Limit of visibleApps if included, not limit of users
             sort: [sort].compactMap { $0 },
             filter: filters,
             next: nil)
+
 
         _ = api.request(request)
             .map(User.fromAPIResponse)

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -16,7 +16,7 @@ public struct ListUsersCommand: CommonParsableCommand {
     var common: CommonOptions
 
     @Option(help: "Limit the number visible apps to return (maximum 50).")
-    var limit: Int?
+    var limitVisibleApps: Int?
 
     @Option(
         parsing: SingleValueParsingStrategy.unconditional,
@@ -69,7 +69,7 @@ public struct ListUsersCommand: CommonParsableCommand {
             include: includeVisibleApps
                 ? [ListUsers.Include.visibleApps]
                 : nil,
-            limit: limit.map { [ListUsers.Limit.visibleApps($0)] } ?? [], // Limit of visibleApps if included, not limit of users
+            limit: limitVisibleApps.map { [ListUsers.Limit.visibleApps($0)] } ?? [],
             sort: [sort].compactMap { $0 },
             filter: filters,
             next: nil)


### PR DESCRIPTION

# 📝 Summary of Changes

Changes proposed in this pull request:

Right now the sdk is only supporting limit for visible apps. So for the time being 
- Renamed limit optional argument to limitVisibleApps
- Passed the value of the limitVisibleApps  to the limit parameter of the request for ListUsersCommand
- Changed the wordings of the option help text for ListUsersCommand and ListUserInvitationsCommand

More changes can be added when the sdk supports limit for users

# 🔨 How to test
swift run asc users list --limit-visible-apps 2
