### PR TITLE
Improve bundle-ids commands

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
@@ -22,7 +22,7 @@ struct DeleteBundleIdCommand: CommonParsableCommand {
         let api = try makeClient()
 
         _ = try api
-            .internalId(matching: identifier)
+            .bundleIdResourceId(matching: identifier)
             .flatMap { internalId in
                 api.request(APIEndpoint.delete(bundleWithId: internalId)).eraseToAnyPublisher()
             }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
@@ -24,11 +24,8 @@ struct DeleteBundleIdCommand: CommonParsableCommand {
         _ = try api
             .bundleIdResourceId(matching: identifier)
             .flatMap { internalId in
-                api.request(APIEndpoint.delete(bundleWithId: internalId)).eraseToAnyPublisher()
+                api.request(APIEndpoint.delete(bundleWithId: internalId))
             }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: { _ in }
-            )
+            .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/HTTPClient+BundleId.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/HTTPClient+BundleId.swift
@@ -1,0 +1,43 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+extension HTTPClient {
+
+    enum BundleIDError: Error, LocalizedError {
+        case notUnique(String)
+
+        var failureReason: String? {
+            switch self {
+            case .notUnique(let identifier):
+                return "'\(identifier)' is not a unique Bundle Identifier."
+            }
+        }
+    }
+
+    /// Find the opaque internal identifier for a bundle ID matching `identifier`.
+    ///
+    ///  not the reverse-DNS bundleId identifier. Use this for reading, modifying and deleting bundleId resources.
+    /// - parameter identifier: The  reverse-DNS style Bundle Identifier.
+    /// - returns: The App Store Connect API resource identifier for the Bundle Identifier.
+    func bundleIdResourceId(matching identifier: String) throws -> AnyPublisher<String, Error> {
+        let request = APIEndpoint.listBundleIds(
+            filter: [
+                BundleIds.Filter.identifier([identifier])
+            ]
+        )
+
+        return self.request(request)
+            .map { $0.data.filter { $0.attributes?.identifier == identifier } }
+            .tryMap { response -> String in
+                guard response.count == 1 else {
+                    throw BundleIDError.notUnique(identifier)
+                }
+                return response.first!.id
+            }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
@@ -29,10 +29,7 @@ struct ListBundleIdsCommand: CommonParsableCommand {
 
         _ = api.request(request)
             .map { $0.data.map(BundleId.init) }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .renderResult(format: common.outputFormat)            
     }
 }
 

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
@@ -25,7 +25,7 @@ struct ModifyBundleIdCommand: CommonParsableCommand {
         let api = try makeClient()
 
         _ = try api
-            .internalId(matching: identifier)
+            .bundleIdResourceId(matching: identifier)
             .flatMap { internalId in
                 api.request(APIEndpoint.modifyBundleId(id: internalId, name: self.name)).eraseToAnyPublisher()
             }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
@@ -15,10 +15,10 @@ struct ModifyBundleIdCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(help: "The reverse-DNS bundle ID identifier. (eg. com.example.app)")
+    @Argument(help: "The reverse-DNS bundle ID identifier. (eg. com.example.app)")
     var identifier: String
 
-    @Option(help: "The new name for the bundle identifier.")
+    @Argument(help: "The new name for the bundle identifier.")
     var name: String
 
     func run() throws {

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
@@ -30,9 +30,6 @@ struct ModifyBundleIdCommand: CommonParsableCommand {
                 api.request(APIEndpoint.modifyBundleId(id: internalId, name: self.name)).eraseToAnyPublisher()
             }
             .map(BundleId.init)
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .renderResult(format: common.outputFormat)            
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
@@ -25,10 +25,7 @@ struct ReadBundleIdCommand: CommonParsableCommand {
             .flatMap { internalId in
                 api.request(APIEndpoint.readBundleIdInformation(id: internalId)).eraseToAnyPublisher()
             }
-            .map(BundleId.init)
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+        .map(BundleId.init)
+        .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
@@ -21,7 +21,7 @@ struct ReadBundleIdCommand: CommonParsableCommand {
         let api = try makeClient()
 
         _ = try api
-            .internalId(matching: identifier)
+            .bundleIdResourceId(matching: identifier)
             .flatMap { internalId in
                 api.request(APIEndpoint.readBundleIdInformation(id: internalId)).eraseToAnyPublisher()
             }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -20,7 +20,8 @@ struct RegisterBundleIdCommand: CommonParsableCommand {
     var name: String
 
     @Option(
-        help: "The platform of the bundle identifier (\(BundleIdPlatform.allCases.map { $0.rawValue.lowercased() }.joined(separator: ", ")))."
+        default: .universal,
+        help: "The platform of the bundle identifier \(BundleIdPlatform.allCases)."
     )
     var platform: BundleIdPlatform
 

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -31,10 +31,7 @@ struct RegisterBundleIdCommand: CommonParsableCommand {
         let request = APIEndpoint.registerNewBundleId(id: identifier, name: name, platform: platform)
 
         _ = api.request(request)
-            .map(BundleId.init(response:))
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .map(BundleId.init)
+            .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -13,10 +13,10 @@ struct RegisterBundleIdCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(help: "The reverse-DNS bundle ID identifier. Must be unique. (eg. com.example.app)")
+    @Argument(help: "The reverse-DNS bundle ID identifier. Must be unique. (eg. com.example.app)")
     var identifier: String
 
-    @Option(help: "The new name for the bundle identifier.")
+    @Argument(help: "The new name for the bundle identifier.")
     var name: String
 
     @Option(

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -1,0 +1,22 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Combine
+import Foundation
+
+extension Publisher where Output: ResultRenderable, Failure == Error {
+    func renderResult(format: OutputFormat) -> AnyCancellable {
+        self.sink(
+            receiveCompletion: Renderers.CompletionRenderer().render,
+            receiveValue: Renderers.ResultRenderer<Output>(format: format).render
+        )
+    }
+}
+
+extension Publisher where Output == Void, Failure == Error {
+    func renderResult(format: OutputFormat) -> AnyCancellable {
+        self.sink(
+            receiveCompletion: Renderers.CompletionRenderer().render,
+            receiveValue: Renderers.null
+        )
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/API/BundleIdPlatform+Init.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/BundleIdPlatform+Init.swift
@@ -4,13 +4,17 @@ import ArgumentParser
 import AppStoreConnect_Swift_SDK
 import Foundation
 
-extension BundleIdPlatform: CaseIterable, ExpressibleByArgument {
+extension BundleIdPlatform: CaseIterable, ExpressibleByArgument, CustomStringConvertible {
     public typealias AllCases = [BundleIdPlatform]
-    public static var allCases: BundleIdPlatform.AllCases {
-        return [.iOS, .macOS]
+    public static var allCases: AllCases {
+        return [.iOS, .macOS, .universal]
     }
 
     public init?(argument: String) {
         self.init(rawValue: argument.uppercased())
+    }
+
+    public var description: String {
+        return self.rawValue.lowercased()
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/BundleId.swift
+++ b/Sources/AppStoreConnectCLI/Model/BundleId.swift
@@ -57,28 +57,3 @@ extension BundleId: TableInfoProvider {
         ]
     }
 }
-
-extension HTTPClient {
-
-    /// Find the opaque internal identifier for this bundle ID.
-    ///
-    /// This is an App Store Connect internal identifier; not the reverse-DNS bundleId identifier. Use this for reading, modifying and deleting bundleId resources.
-    func internalId(matching identifier: String) throws -> AnyPublisher<String, Error> {
-        let request = APIEndpoint.listBundleIds(
-            filter: [
-                BundleIds.Filter.identifier([identifier])
-            ]
-        )
-
-        return self.request(request)
-            .map { $0.data.filter { $0.attributes?.identifier == identifier } }
-            .compactMap { response -> String? in
-                if response.count == 1 {
-                    return response.first?.id
-                }
-                fatalError("Bundle ID identifier '\(identifier)' not unique or not found")
-            }
-            .eraseToAnyPublisher()
-    }
-
-}

--- a/Sources/AppStoreConnectCLI/Model/BundleId.swift
+++ b/Sources/AppStoreConnectCLI/Model/BundleId.swift
@@ -15,24 +15,21 @@ struct BundleId: ResultRenderable {
 // MARK: - API conveniences
 
 extension BundleId {
-    init(_ apiBundleId: AppStoreConnect_Swift_SDK.BundleId) {
-        let attributes = apiBundleId.attributes
+    init(_ attributes: AppStoreConnect_Swift_SDK.BundleId.Attributes) {
         self.init(
-            identifier: attributes?.identifier,
-            name: attributes?.name,
-            platform: attributes?.platform,
-            seedId: attributes?.seedId
+            identifier: attributes.identifier,
+            name: attributes.name,
+            platform: attributes.platform,
+            seedId: attributes.seedId
         )
     }
 
-    init(response: AppStoreConnect_Swift_SDK.BundleIdResponse) {
-        let attributes = response.data.attributes
-        self.init(
-            identifier: attributes?.identifier,
-            name: attributes?.name,
-            platform: attributes?.platform,
-            seedId: attributes?.seedId
-        )
+    init(_ apiBundleId: AppStoreConnect_Swift_SDK.BundleId) {
+        self.init(apiBundleId.attributes!)
+    }
+
+    init(_ response: AppStoreConnect_Swift_SDK.BundleIdResponse) {
+        self.init(response.data)
     }
 }
 

--- a/Sources/AppStoreConnectCLI/Model/BundleId.swift
+++ b/Sources/AppStoreConnectCLI/Model/BundleId.swift
@@ -41,10 +41,10 @@ extension BundleId {
 extension BundleId: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
-            TextTableColumn(header: "identifier"),
-            TextTableColumn(header: "name"),
-            TextTableColumn(header: "platform"),
-            TextTableColumn(header: "seedId")
+            TextTableColumn(header: "Identifier"),
+            TextTableColumn(header: "Name"),
+            TextTableColumn(header: "Platform"),
+            TextTableColumn(header: "Seed ID")
         ]
     }
 

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -1,11 +1,11 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
-import Foundation
+import AppStoreConnect_Swift_SDK
 import CodableCSV
 import Combine
+import Foundation
 import SwiftyTextTable
 import Yams
-import AppStoreConnect_Swift_SDK
 
 protocol Renderer {
     associatedtype Input
@@ -13,14 +13,25 @@ protocol Renderer {
     func render(_ input: Input)
 }
 
+private final class StandardErrorOutputStream: TextOutputStream {
+    func write(_ string: String) {
+        FileHandle.standardError.write(Data(string.utf8))
+    }
+}
+
 enum Renderers {
+
+    static func null(_ input: Void) {}
+
+    private static var errorOutput = StandardErrorOutputStream()
+
     struct CompletionRenderer: Renderer {
         func render(_ input: Subscribers.Completion<Error>) {
             switch input {
                 case .finished:
                     break
                 case .failure(let error):
-                    print("Completed with error: \(error)")
+                    print("Error: \(error.localizedDescription)", to: &errorOutput)
             }
         }
     }


### PR DESCRIPTION
This PR improves the implementation of the `bundle-ids` commands.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds a `renderResult` convenience.
- Makes arguments more consistent.
- Improves the output rendering.

# 🧐🗒 Reviewer Notes

## 💁 Example

```sh
$ swift run asc bundle-ids read com.anz
Error: The operation couldn’t be completed. 'com.anz' is not a unique Bundle Identifier.
```

```sh
$ swift run asc bundle-ids list
+---------------------------------+-------------------------------------+-----------+------------+
| Identifier                      | Name                                | Platform  | Seed ID    |
+---------------------------------+-------------------------------------+-----------+------------+
...
```

```sh
$ swift run asc bundle-ids register -h
OVERVIEW: Register a new bundle ID for app development.

USAGE: asc bundle-ids register [--api-issuer <uuid>] [--api-key-id <keyid>] [--csv] [--json] [--table] [--yaml] <identifier> <name> [--platform <platform>]

ARGUMENTS:
  <identifier>            The reverse-DNS bundle ID identifier. Must be unique. (eg. com.example.app) 
  <name>                  The new name for the bundle identifier. 
...
  --platform <platform>   The platform of the bundle identifier [ios, mac_os, universal]. (default: universal)
...
```
