### PR TITLE
Testflight/Implement invite beta tester command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -34,8 +34,8 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
 
         var failureReason: String? {
             switch self {
-                case .noGroupsExist(let groupNames, let bundleId):
-                    return "One or more of beta groups \"\(groupNames)\" don't exist or don't belongs to application with bundle Id \"\(bundleId)\"."
+            case .noGroupsExist(let groupNames, let bundleId):
+                return "One or more of beta groups \"\(groupNames)\" don't exist or don't belong to application with bundle ID \"\(bundleId)\"."
             }
         }
     }
@@ -44,13 +44,13 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
         let service = try makeService()
 
         _ = api
-            // Find app resource id matching bundleId
+            // Find app resource id matching bundle Id
             .appResourceId(matching: bundleId)
             // Find beta groups matching app resource Id
             .flatMap {
                 api.request(APIEndpoint.betaGroups(forAppWithId: $0)).eraseToAnyPublisher()
             }
-            // Check if input group names are belong to the app, else throw Error
+            // Check if input group names are belong to the app, else throws error
             .tryMap { [groups, bundleId] (response: BetaGroupsResponse) -> AnyPublisher<[String], Error> in
                 let groupNamesInApp = Set(response.data.compactMap { $0.attributes?.name })
                 let inputGroupNames = Set(groups)

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -29,13 +29,13 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
             help: "Names of TestFlight beta tester group that the tester will be assigned to")
     var groups: [String]
 
-    enum CommandError: LocalizedError {
+    private enum CommandError: LocalizedError {
         case noGroupsExist(groupNames: [String], bundleId: String)
 
         var failureReason: String? {
             switch self {
                 case .noGroupsExist(let groupNames, let bundleId):
-                    return "One or more of beta groups \"\(groupNames)\" don't exist or don't belongs to application with Bundle ID \"\(bundleId)\"."
+                    return "One or more of beta groups \"\(groupNames)\" don't exist or don't belongs to application with bundle Id \"\(bundleId)\"."
             }
         }
     }
@@ -73,17 +73,20 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
                     return api.request(endpoint).eraseToAnyPublisher()
                 }
 
-                return Publishers.ConcatenateMany(requests).last().eraseToAnyPublisher()
+                return Publishers.ConcatenateMany(requests)
+                    .last()
+                    .eraseToAnyPublisher()
             }
             // Get invited tester info
             .flatMap {
                 api.request(APIEndpoint.betaTester(
                         withId: $0.data.id,
-                        include: [GetBetaTester.Include.betaGroups, GetBetaTester.Include.apps]
+                        include: [GetBetaTester.Include.betaGroups,
+                                  GetBetaTester.Include.apps]
                     ))
                     .eraseToAnyPublisher()
             }
-            .map { BetaTester.init($0.data, $0.included) }
+            .map { BetaTester($0.data, $0.included) }
             .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -8,7 +8,7 @@ import Foundation
 struct CreateBetaTesterCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "invite",
-        abstract: "Create a beta tester and assign to a group")
+        abstract: "Create a beta tester and assign to one or more groups")
 
     @OptionGroup()
     var common: CommonOptions

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -7,8 +7,8 @@ import Foundation
 
 struct CreateBetaTesterCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
-        commandName: "create",
-        abstract: "Create a beta tester")
+        commandName: "invite",
+        abstract: "Create a beta tester and assign to a group")
 
     @OptionGroup()
     var common: CommonOptions
@@ -16,28 +16,26 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
     @Argument(help: "The beta tester's email address, used for sending beta testing invitations.")
     var email: String
 
-    @Option(help: "The beta tester's first name.")
+    @Argument(help: "The beta tester's first name.")
     var firstName: String?
 
-    @Option(help: "The beta tester's last name.")
+    @Argument(help: "The beta tester's last name.")
     var lastName: String?
 
-    @Option(help: "Array of opaque resource ID that uniquely identifies the builds for an application.")
-    var buildIds: [String]
+    @Argument(help: "The bundle ID of an application. (eg. com.example.app)")
+    var bundleId: String
 
-    @Option(help: "Names of TestFlight beta tester group that the tester will be assigned to")
-    var groupNames: [String]
+    @Option(parsing: .upToNextOption,
+            help: "Names of TestFlight beta tester group that the tester will be assigned to")
+    var groups: [String]
 
-    private enum CommandError: Error, CustomStringConvertible {
-        case invalidInput, couldntFindBetaGroup
+    enum CommandError: LocalizedError {
+        case noGroupsExist(groupNames: [String], bundleId: String)
 
-        var description: String {
+        var failureReason: String? {
             switch self {
-            case .invalidInput:
-                return "Invalid input, one or more build Id or beta group name is required when creating a tester"
-
-            case .couldntFindBetaGroup:
-                return "Couldn't find any beta group with input names."
+                case .noGroupsExist(let groupNames, let bundleId):
+                    return "No Beta Group \"\(groupNames)\" exists for application with Bundle ID \"\(bundleId)\"."
             }
         }
     }
@@ -45,45 +43,43 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
     func run() throws {
         let service = try makeService()
 
-        let request: AnyPublisher<BetaTesterResponse, Error>
+        _ = api
+            // Find app resource id matching bundleId
+            .appResourceId(matching: bundleId)
+            // Find beta groups matching app resource Id
+            .flatMap {
+                api.request(APIEndpoint.betaGroups(forAppWithId: $0)).eraseToAnyPublisher()
+            }
+            // Check if input group names are belong to the app, else throw Error
+            .tryMap { [groups, bundleId] (response: BetaGroupsResponse) -> AnyPublisher<[String], Error> in
+                let groupNamesInApp = Set(response.data.compactMap { $0.attributes?.name })
+                let inputGroupNames = Set(groups)
 
-        let createWithBuildIds = { ids -> APIEndpoint<BetaTesterResponse> in
-            .create(betaTesterWithEmail: self.email, firstName: self.firstName, lastName: self.lastName, buildIds: ids)
-        }
+                guard inputGroupNames.isSubset(of: groupNamesInApp) else {
+                    throw CommandError.noGroupsExist(groupNames: groups, bundleId: bundleId)
+                }
 
-        let createWithGroupIds = { ids -> APIEndpoint<BetaTesterResponse> in
-            .create(betaTesterWithEmail: self.email, firstName: self.firstName, lastName: self.lastName, betaGroupIds: ids)
-        }
+                return try api.betaGroupIdentifiers(matching: groups)
+            }
+            .flatMap { $0 }
+            // Invite tester to the input groups
+            .flatMap { [email, firstName, lastName] (groupIds: [String]) -> AnyPublisher<BetaTesterResponse, Error> in
+                let endpoint = APIEndpoint.create(betaTesterWithEmail: email,
+                                                  firstName: firstName,
+                                                  lastName: lastName,
+                                                  betaGroupIds: groupIds)
 
-        switch (buildIds, groupNames) {
-            case (let buildIds, _) where !buildIds.isEmpty:
-                let endpoint = createWithBuildIds(buildIds)
-                request = service.request(endpoint).eraseToAnyPublisher()
-
-            case (_, let groupNames) where !groupNames.isEmpty:
-                let endpoint = APIEndpoint.betaGroups(filter: [ListBetaGroups.Filter.name(groupNames)])
-
-                let groupIds = service.request(endpoint).map { $0.data.map(\.id) }
-
-                request = groupIds
-                    .flatMap { (groupIds: [String]) -> AnyPublisher<BetaTesterResponse, Error> in
-                        guard !groupIds.isEmpty else {
-                            return Fail(error: CommandError.couldntFindBetaGroup).eraseToAnyPublisher()
-                        }
-
-                        let endpoint = createWithGroupIds(groupIds)
-
-                        return service.request(endpoint).eraseToAnyPublisher()
-                    }
+                return api.request(endpoint).eraseToAnyPublisher()
+            }
+            // Get invited tester info
+            .flatMap {
+                api.request(APIEndpoint.betaTester(
+                        withId: $0.data.id,
+                        include: [GetBetaTester.Include.betaGroups, GetBetaTester.Include.apps]
+                    ))
                     .eraseToAnyPublisher()
-            case (_, _):
-                request = Fail(error: CommandError.invalidInput as Error).eraseToAnyPublisher()
-        }
-
-        let betaTester = try request
-            .map { BetaTester($0.data, $0.included) }
-            .await()
-
-        betaTester.render(format: common.outputFormat)
+            }
+            .map { BetaTester.init($0.data, $0.included) }
+            .renderResult(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/DeleteBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/DeleteBetaTesterCommand.swift
@@ -96,7 +96,7 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
             case .removeFromGroup(let betaGroupName):
                 request = try service
                     .betaTesterResourceId(matching: email)
-                    .combineLatest(try service.betaGroupIdentifier(matching: betaGroupName))
+                    .combineLatest(service.betaGroupIdentifier(matching: betaGroupName))
                     .flatMap {
                         service.request(APIEndpoint.remove(
                             betaTestersWithIds: [$0],

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
@@ -53,13 +53,13 @@ struct InviteBetaTesterCommand: CommonParsableCommand {
                 let groupNamesInApp = Set(response.data.compactMap { $0.attributes?.name })
                 let inputGroupNames = Set(groups)
 
-//                guard inputGroupNames.isSubset(of: groupNamesInApp) else {
-//                    throw CommandError.noGroupsExist(groupNames: groups, bundleId: bundleId)
-//                }
+                guard inputGroupNames.isSubset(of: groupNamesInApp) else {
+                    let error = CommandError.noGroupsExist(groupNames: groups, bundleId: bundleId)
+                    return Fail(error: error).eraseToAnyPublisher()
+                }
 
-                return try! api.betaGroupIdentifiers(matching: groups)
+                return api.betaGroupIdentifiers(matching: groups)
             }
-//            .flatMap { $0 }
             // Invite tester to the input groups
             .flatMap { [email, firstName, lastName] (groupIds: [String]) -> AnyPublisher<BetaTesterResponse, Error> in
                 // A tester can only be invite to one group at a time

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
@@ -29,40 +29,15 @@ struct InviteBetaTesterCommand: CommonParsableCommand {
             help: "Names of TestFlight beta tester group that the tester will be assigned to")
     var groups: [String]
 
-    private enum CommandError: LocalizedError {
-        case noGroupsExist(groupNames: [String], bundleId: String)
-
-        var errorDescription: String? {
-            switch self {
-            case .noGroupsExist(let groupNames, let bundleId):
-                return "One or more of beta groups \"\(groupNames)\" don't exist or don't belong to application with bundle ID \"\(bundleId)\"."
-            }
-        }
-    }
-
     func run() throws {
         let service = try makeService()
-
-        let appId = try service.appResourceId(matching: bundleId).await()
-
-        let betaGroups = try service.request(APIEndpoint.betaGroups(forAppWithId: appId)).map { $0.data }.await()
-
-        let groupNamesInApp = Set(betaGroups.compactMap { $0.attributes?.name })
-        let inputGroupNames = Set(groups)
-
-        guard inputGroupNames.isSubset(of: groupNamesInApp) else {
-            throw CommandError.noGroupsExist(groupNames: groups, bundleId: bundleId)
-        }
-
-        let groupIds = try service
-            .betaGroupIdentifiers(matching: groups)
-            .await()
 
         let options = InviteBetaTesterOptions(
             firstName: firstName,
             lastName: lastName,
             email: email,
-            betaGroupIds: groupIds
+            bundleId: bundleId,
+            groupNames: groups
         )
 
         let betaTester = try service

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
@@ -26,7 +26,7 @@ struct InviteBetaTesterCommand: CommonParsableCommand {
     var bundleId: String
 
     @Option(parsing: .upToNextOption,
-            help: "Names of TestFlight beta tester group that the tester will be assigned to")
+            help: "Names of TestFlight beta tester group that the tester will be assigned to.")
     var groups: [String]
 
     func run() throws {

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -70,7 +70,6 @@ struct ListBetaTestersCommand: CommonParsableCommand {
                 request = api
                     .request(APIEndpoint.betaTesters(include: includes, limit: limits))
                     .eraseToAnyPublisher()
-
             case .listByApp(let bundleId):
                 request = api
                     .getAppResourceIdsFrom(bundleIds: [bundleId])
@@ -82,9 +81,8 @@ struct ListBetaTestersCommand: CommonParsableCommand {
                         ))
                     }
                     .eraseToAnyPublisher()
-
             case .listByGroup(let betaGroupName):
-                request = try api.betaGroupIdentifier(matching: betaGroupName)
+                request = api.betaGroupIdentifier(matching: betaGroupName)
                     .flatMap {
                         api.request(APIEndpoint.betaTesters(
                             filter: [.betaGroups([$0])],

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
@@ -8,7 +8,7 @@ public struct TestFlightBetaTestersCommand: ParsableCommand {
         commandName: "betatesters",
         abstract: "People who can install and test prerelease builds.",
         subcommands: [
-             CreateBetaTesterCommand.self,
+             InviteBetaTesterCommand.self,
              DeleteBetaTesterCommand.self,
              ListBetaTestersCommand.self,
              ListBetaTesterByBuildsCommand.self

--- a/Sources/AppStoreConnectCLI/Helpers/Array+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Array+Helpers.swift
@@ -1,0 +1,9 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+extension Array where Element == String {
+    func isSubarray(of array: [String]) -> Bool {
+        Set(self).isSubset(of: Set(array))
+    }
+}

--- a/Sources/AppStoreConnectCLI/Helpers/Array+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Array+Helpers.swift
@@ -1,9 +1,0 @@
-// Copyright 2020 Itty Bitty Apps Pty Ltd
-
-import Foundation
-
-extension Array where Element == String {
-    func isSubarray(of array: [String]) -> Bool {
-        Set(self).isSubset(of: Set(array))
-    }
-}

--- a/Sources/AppStoreConnectCLI/Model/App.swift
+++ b/Sources/AppStoreConnectCLI/Model/App.swift
@@ -54,12 +54,12 @@ extension AppStoreConnectService {
         case couldntFindApp(bundleId: [String])
         case bundleIdNotUnique(bundleId: String)
 
-        var failureReason: String? {
+        var errorDescription: String? {
             switch self {
-                case .couldntFindApp(let bundleIds):
-                    return "No apps were found matching \(bundleIds)"
-                case .bundleIdNotUnique(let bundleId):
-                    return "BundleId \(bundleId) is not unique"
+            case .couldntFindApp(let bundleIds):
+                return "No apps were found matching \(bundleIds)"
+            case .bundleIdNotUnique(let bundleId):
+                return "BundleId \(bundleId) is not unique"
             }
         }
     }

--- a/Sources/AppStoreConnectCLI/Model/App.swift
+++ b/Sources/AppStoreConnectCLI/Model/App.swift
@@ -56,7 +56,7 @@ extension AppStoreConnectService {
         var errorDescription: String? {
             switch self {
             case .couldntFindApp(let bundleIds):
-                return "No apps were found matching \(bundleIds)"
+                return "No apps were found matching \(bundleIds)."
             }
         }
     }

--- a/Sources/AppStoreConnectCLI/Model/App.swift
+++ b/Sources/AppStoreConnectCLI/Model/App.swift
@@ -52,14 +52,11 @@ extension AppStoreConnectService {
 
     private enum AppError: LocalizedError {
         case couldntFindApp(bundleId: [String])
-        case bundleIdNotUnique(bundleId: String)
 
         var errorDescription: String? {
             switch self {
             case .couldntFindApp(let bundleIds):
                 return "No apps were found matching \(bundleIds)"
-            case .bundleIdNotUnique(let bundleId):
-                return "BundleId \(bundleId) is not unique"
             }
         }
     }
@@ -79,27 +76,6 @@ extension AppStoreConnectService {
                 return response.data
             }
             .compactMap { $0.map { $0.id } }
-            .eraseToAnyPublisher()
-    }
-
-    /// Find a opaque internal identifier for an application that related to this bundle ID.
-    func appResourceId(matching bundleId: String) -> AnyPublisher<String, Error> {
-        let getAppResourceIdRequest = APIEndpoint.apps(
-            filters: [ListApps.Filter.bundleId([bundleId])]
-        )
-
-        return self.request(getAppResourceIdRequest)
-            .tryMap { (response: AppsResponse) throws -> String in
-                guard !response.data.isEmpty else {
-                    throw AppError.couldntFindApp(bundleId: [bundleId])
-                }
-
-                guard response.data.count == 1, let app = response.data.first else {
-                    throw AppError.bundleIdNotUnique(bundleId: bundleId)
-                }
-
-                return app.id
-            }
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -84,7 +84,6 @@ extension AppStoreConnectService {
     }
 
     func betaGroupIdentifiers(matching names: [String]) throws -> AnyPublisher<[String], Error> {
-
         // Find group by name sequentially
         let requests = try names.map { (name: String) throws in
             return try self.betaGroupIdentifier(matching: name)

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -84,12 +84,4 @@ extension AppStoreConnectService {
             }
             .eraseToAnyPublisher()
     }
-
-    func betaGroupIdentifiers(matching names: [String]) -> AnyPublisher<[String], Error> {
-        let requests = names.map { self.betaGroupIdentifier(matching: $0) }
-
-        return Publishers.MergeMany(requests)
-            .reduce([]) { $0 + [$1] }
-            .eraseToAnyPublisher()
-    }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -50,12 +50,12 @@ extension AppStoreConnectService {
         case couldntFindBetaGroup(groupNames: [String])
         case betaGroupNotUnique(groupNames: [String])
 
-        var failureReason: String? {
+        var errorDescription: String? {
             switch self {
-                case .couldntFindBetaGroup(let groupNames):
-                    return "Couldn't find beta group with input names \(groupNames)"
-                case .betaGroupNotUnique(let groupNames):
-                    return "The group name you input \(groupNames) are not unique"
+            case .couldntFindBetaGroup(let groupNames):
+                return "Couldn't find beta group with input names \(groupNames)"
+            case .betaGroupNotUnique(let groupNames):
+                return "The group name you input \(groupNames) are not unique"
             }
         }
     }

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -47,12 +47,15 @@ struct BetaGroup: TableInfoProvider, ResultRenderable, Equatable {
 
 extension AppStoreConnectService {
     private enum BetaGroupError: LocalizedError {
-        case couldntFindBetaGroup
+        case couldntFindBetaGroup(groupNames: [String])
+        case betaGroupNotUnique(groupNames: [String])
 
         var failureReason: String? {
             switch self {
-                case .couldntFindBetaGroup:
-                    return "Couldn't find beta group with input name or group name not unique"
+                case .couldntFindBetaGroup(let groupNames):
+                    return "Couldn't find beta group with input names \(groupNames)"
+                case .betaGroupNotUnique(let groupNames):
+                    return "The group name you input \(groupNames) are not unique"
             }
         }
     }
@@ -67,11 +70,31 @@ extension AppStoreConnectService {
 
         return self.request(endpoint)
             .tryMap { response throws -> String in
+                guard !response.data.isEmpty else {
+                    throw BetaGroupError.couldntFindBetaGroup(groupNames: [name])
+                }
+
                 guard response.data.count == 1, let id = response.data.first?.id else {
-                    throw BetaGroupError.couldntFindBetaGroup
+                    throw BetaGroupError.betaGroupNotUnique(groupNames: [name])
                 }
 
                 return id
+            }
+            .eraseToAnyPublisher()
+    }
+
+    func betaGroupIdentifiers(matching names: [String]) throws -> AnyPublisher<[String], Error> {
+        let endpoint = APIEndpoint.betaGroups(
+            filter: [ListBetaGroups.Filter.name(names)]
+        )
+
+        return self.request(endpoint)
+            .tryMap { response throws -> [String] in
+                guard !response.data.isEmpty else {
+                    throw BetaGroupError.couldntFindBetaGroup(groupNames: names)
+                }
+
+                return response.data.map { $0.id }
             }
             .eraseToAnyPublisher()
     }

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -47,15 +47,15 @@ struct BetaGroup: TableInfoProvider, ResultRenderable, Equatable {
 
 extension AppStoreConnectService {
     private enum BetaGroupError: LocalizedError {
-        case couldntFindBetaGroup(groupNames: [String])
+        case betaGroupNotFound(groupNames: [String])
         case betaGroupNotUnique(groupNames: [String])
 
         var errorDescription: String? {
             switch self {
-            case .couldntFindBetaGroup(let groupNames):
-                return "Couldn't find beta group with input names \(groupNames)"
+            case .betaGroupNotFound(let groupNames):
+                return "Couldn't find beta group with input names \(groupNames)."
             case .betaGroupNotUnique(let groupNames):
-                return "The group name you input \(groupNames) are not unique"
+                return "The group name you input \(groupNames) are not unique."
             }
         }
     }
@@ -71,7 +71,7 @@ extension AppStoreConnectService {
         return self.request(endpoint)
             .flatMap { response -> AnyPublisher<String, Error> in
                 guard !response.data.isEmpty else {
-                    let error = BetaGroupError.couldntFindBetaGroup(groupNames: [name])
+                    let error = BetaGroupError.betaGroupNotFound(groupNames: [name])
                     return Fail(error: error).eraseToAnyPublisher()
                 }
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -41,7 +41,7 @@ class AppStoreConnectService {
 
     func inviteBetaTesterToGroups(with options: InviteBetaTesterOptions) throws -> AnyPublisher<BetaTester, Error> {
         let dependencies = InviteTesterOperation.Dependencies(
-            apps: request,
+            appsResponse: request,
             betaGroupsResponse: request,
             betaTesterResponse: request
         )

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -40,11 +40,15 @@ class AppStoreConnectService {
     }
 
     func inviteBetaTesterToGroups(with options: InviteBetaTesterOptions) throws -> AnyPublisher<BetaTester, Error> {
-        let dependencies = InviteTesterOperation.Dependencies(betaTesterResponse: request)
+        let dependencies = InviteTesterOperation.Dependencies(
+            apps: request,
+            betaGroupsResponse: request,
+            betaTesterResponse: request
+        )
 
         let operation = InviteTesterOperation(options: options)
 
-        return operation.execute(with: dependencies)
+        return try operation.execute(with: dependencies)
     }
 
     func createBetaGroup(with options: CreateBetaGroupOptions) -> AnyPublisher<BetaGroup, Error> {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -39,6 +39,14 @@ class AppStoreConnectService {
         return operation.execute(with: dependencies)
     }
 
+    func inviteBetaTesterToGroups(with options: InviteBetaTesterOptions) throws -> AnyPublisher<BetaTester, Error> {
+        let dependencies = InviteTesterOperation.Dependencies(betaTesterResponse: request)
+
+        let operation = InviteTesterOperation(options: options)
+
+        return operation.execute(with: dependencies)
+    }
+
     func createBetaGroup(with options: CreateBetaGroupOptions) -> AnyPublisher<BetaGroup, Error> {
         let dependencies = CreateBetaGroupOperation.Dependencies(
             apps: request,

--- a/Sources/AppStoreConnectCLI/Services/Operations/APIOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/APIOperation.swift
@@ -10,5 +10,5 @@ protocol APIOperation {
 
     init(options: Options)
 
-    func execute(with dependencies: Dependencies) -> AnyPublisher<Output, Error>
+    func execute(with dependencies: Dependencies) throws -> AnyPublisher<Output, Error>
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateBetaGroupOperation.swift
@@ -11,11 +11,9 @@ struct CreateBetaGroupOperation: APIOperation {
     }
 
     private let options: CreateBetaGroupOptions
-    private let getAppsOperation: GetAppsOperation
 
     init(options: CreateBetaGroupOptions) {
         self.options = options
-        self.getAppsOperation = GetAppsOperation(options: .init(bundleIds: [options.appBundleId]))
     }
 
     private typealias AppAttributes = AppStoreConnect_Swift_SDK.App.Attributes
@@ -24,7 +22,9 @@ struct CreateBetaGroupOperation: APIOperation {
     func execute(with dependencies: CreateBetaGroupDependencies) -> AnyPublisher<BetaGroup, Error> {
         let options = self.options
 
-        let app = getAppsOperation
+        let app = GetAppsOperation(
+                options: .init(bundleIds: [options.appBundleId])
+            )
             .execute(with: .init(apps: dependencies.apps))
             .compactMap(\.first)
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetAppsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetAppsOperation.swift
@@ -16,9 +16,9 @@ struct GetAppsOperation: APIOperation {
         var errorDescription: String? {
             switch self {
             case .couldntFindAnyAppsMatching(let bundleIds):
-                return "No apps were found matching \(bundleIds)"
+                return "No apps were found matching \(bundleIds)."
             case .appsDoNotExist(let bundleIds):
-                return "Specified apps were non found / do not exist: \(bundleIds)"
+                return "Specified apps were non found / do not exist: \(bundleIds)."
             }
         }
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaTesterInfoOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaTesterInfoOperation.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct GetBetaTesterInfoOperation: APIOperation {
+
+    struct GetBetaTesterInfoDependencies {
+        let betaTesterResponse: (APIEndpoint<BetaTesterResponse>) -> Future<BetaTesterResponse, Error>
+    }
+
+    private let endpoint: APIEndpoint<BetaTesterResponse>
+
+    init(options: GetBetaTesterInfoOptions) {
+        endpoint = APIEndpoint.betaTester(
+            withId: options.id,
+            include: [GetBetaTester.Include.betaGroups,
+                      GetBetaTester.Include.apps])
+    }
+
+    func execute(with dependencies: GetBetaTesterInfoDependencies) -> AnyPublisher<BetaTester, Error> {
+        dependencies.betaTesterResponse(endpoint)
+            .map { BetaTester($0.data, $0.included) }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaTesterInfoOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaTesterInfoOperation.swift
@@ -15,8 +15,7 @@ struct GetBetaTesterInfoOperation: APIOperation {
     init(options: GetBetaTesterInfoOptions) {
         endpoint = APIEndpoint.betaTester(
             withId: options.id,
-            include: [GetBetaTester.Include.betaGroups,
-                      GetBetaTester.Include.apps])
+            include: [.betaGroups, .apps])
     }
 
     func execute(with dependencies: GetBetaTesterInfoDependencies) -> AnyPublisher<BetaTester, Error> {

--- a/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
@@ -7,18 +7,55 @@ import Foundation
 struct InviteTesterOperation: APIOperation {
 
     struct InviteBetaTesterDependencies {
+        let apps: (APIEndpoint<AppsResponse>) -> Future<AppsResponse, Error>
+        let betaGroupsResponse: (APIEndpoint<BetaGroupsResponse>) -> Future<BetaGroupsResponse, Error>
         let betaTesterResponse: (APIEndpoint<BetaTesterResponse>) -> Future<BetaTesterResponse, Error>
+    }
+
+    private enum InviteTesterError: LocalizedError {
+        case noGroupsExist(groupNames: [String], bundleId: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .noGroupsExist(let groupNames, let bundleId):
+                return "One or more of beta groups \"\(groupNames)\" don't exist or don't belong to application with bundle ID \"\(bundleId)\"."
+            }
+        }
     }
 
     private let options: InviteBetaTesterOptions
 
+    private let getAppsOperation: GetAppsOperation
+
     init(options: InviteBetaTesterOptions) {
         self.options = options
+
+        self.getAppsOperation = GetAppsOperation(options: .init(bundleIds: [options.bundleId]))
     }
 
-    func execute(with dependencies: InviteBetaTesterDependencies) -> AnyPublisher<BetaTester, Error> {
+    func execute(with dependencies: InviteBetaTesterDependencies) throws -> AnyPublisher<BetaTester, Error> {
+        let appId = try getAppsOperation
+            .execute(with: .init(apps: dependencies.apps))
+            .await()
+            .map { $0.id }
+            .first!
 
-        let requests = options.betaGroupIds.map { (id: String) -> AnyPublisher<BetaTesterResponse, Error> in
+        let betaGroups = try dependencies
+            .betaGroupsResponse(APIEndpoint.betaGroups(forAppWithId: appId))
+            .await()
+            .data
+
+        guard options.groupNames.isSubarray(of:
+            betaGroups.compactMap { $0.attributes?.name }) else {
+                throw InviteTesterError.noGroupsExist(
+                    groupNames: options.groupNames,
+                    bundleId: options.bundleId
+                )
+            }
+
+        let groupIds = getGroupIds(in: betaGroups, matching: options.groupNames)
+
+        let requests = groupIds.map { (id: String) -> AnyPublisher<BetaTesterResponse, Error> in
             let endpoint = APIEndpoint.create(
                 betaTesterWithEmail: options.email,
                 firstName: options.firstName,
@@ -44,6 +81,20 @@ struct InviteTesterOperation: APIOperation {
                 with: .init(betaTesterResponse: dependencies.betaTesterResponse)
             )
             .eraseToAnyPublisher()
+    }
+
+    func getGroupIds(
+        in betaGroups: [AppStoreConnect_Swift_SDK.BetaGroup],
+        matching names: [String]
+    ) -> [String] {
+        betaGroups.filter { (betaGroup: AppStoreConnect_Swift_SDK.BetaGroup) in
+            guard let name = betaGroup.attributes?.name else {
+                return false
+            }
+
+            return options.groupNames.contains(name)
+        }
+        .map { $0.id }
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
@@ -68,7 +68,7 @@ struct InviteTesterOperation: APIOperation {
                 .eraseToAnyPublisher()
         }
 
-        let testerId = try! Publishers.ConcatenateMany(requests)
+        let testerId = try Publishers.ConcatenateMany(requests)
             .last()
             .await()
             .data

--- a/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
@@ -44,9 +44,9 @@ struct InviteTesterOperation: APIOperation {
             .betaGroupsResponse(APIEndpoint.betaGroups(forAppWithId: appId))
             .await()
             .data
-
-        guard options.groupNames.isSubarray(of:
-            betaGroups.compactMap { $0.attributes?.name }) else {
+        
+        guard Set(options.groupNames).isSubset(of:
+            Set(betaGroups.compactMap { $0.attributes?.name })) else {
                 throw InviteTesterError.noGroupsExist(
                     groupNames: options.groupNames,
                     bundleId: options.bundleId

--- a/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/InviteTesterOperation.swift
@@ -1,0 +1,49 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct InviteTesterOperation: APIOperation {
+
+    struct InviteBetaTesterDependencies {
+        let betaTesterResponse: (APIEndpoint<BetaTesterResponse>) -> Future<BetaTesterResponse, Error>
+    }
+
+    private let options: InviteBetaTesterOptions
+
+    init(options: InviteBetaTesterOptions) {
+        self.options = options
+    }
+
+    func execute(with dependencies: InviteBetaTesterDependencies) -> AnyPublisher<BetaTester, Error> {
+
+        let requests = options.betaGroupIds.map { (id: String) -> AnyPublisher<BetaTesterResponse, Error> in
+            let endpoint = APIEndpoint.create(
+                betaTesterWithEmail: options.email,
+                firstName: options.firstName,
+                lastName: options.lastName,
+                betaGroupIds: [id]
+            )
+
+            return dependencies
+                .betaTesterResponse(endpoint)
+                .eraseToAnyPublisher()
+        }
+
+        let testerId = try! Publishers.ConcatenateMany(requests)
+            .last()
+            .await()
+            .data
+            .id
+
+        return GetBetaTesterInfoOperation(
+                options: GetBetaTesterInfoOptions(id: testerId)
+            )
+            .execute(
+                with: .init(betaTesterResponse: dependencies.betaTesterResponse)
+            )
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/Options/GetBetaTesterInfoOptions.swift
+++ b/Sources/AppStoreConnectCLI/Services/Options/GetBetaTesterInfoOptions.swift
@@ -1,0 +1,7 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+struct GetBetaTesterInfoOptions {
+    let id: String
+}

--- a/Sources/AppStoreConnectCLI/Services/Options/InviteBetaTesterOptions.swift
+++ b/Sources/AppStoreConnectCLI/Services/Options/InviteBetaTesterOptions.swift
@@ -1,0 +1,11 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+struct InviteBetaTesterOptions {
+    let firstName: String?
+    let lastName: String?
+    let email: String
+    let betaGroupIds: [String]
+}
+

--- a/Sources/AppStoreConnectCLI/Services/Options/InviteBetaTesterOptions.swift
+++ b/Sources/AppStoreConnectCLI/Services/Options/InviteBetaTesterOptions.swift
@@ -6,6 +6,7 @@ struct InviteBetaTesterOptions {
     let firstName: String?
     let lastName: String?
     let email: String
-    let betaGroupIds: [String]
+    let bundleId: String
+    let groupNames: [String]
 }
 

--- a/Tests/appstoreconnect-cliTests/Operations/GetBetaTesterInfoOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetBetaTesterInfoOperationTests.swift
@@ -1,0 +1,162 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+@testable import AppStoreConnectCLI
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+import XCTest
+
+final class GetBetaTesterInfoOperationTests: XCTestCase {
+    typealias Dependencies = GetBetaTesterInfoOperation.Dependencies
+
+    let options = GetBetaTesterInfoOptions(id: "abc")
+
+    func testExecute_success() {
+        let dependencies: Dependencies = .createdSuccess
+
+        let operation = GetBetaTesterInfoOperation(options: options)
+
+        let result = Result {
+            try operation.execute(with: dependencies).await()
+        }
+
+        switch result {
+            case .success(let betaTester):
+                XCTAssertEqual(betaTester.betaGroups?[0], "FooGroup")
+                XCTAssertEqual(betaTester.apps?[0], "com.example.fooapp")
+                XCTAssertEqual(betaTester.apps?[1], "com.example.fooapp")
+                XCTAssertEqual(betaTester.firstName, "Foo")
+            default:
+                XCTFail("Error happened when parsing get beta tester response")
+        }
+    }
+
+    func testExecute_propagatesUpstreamErrors() {
+        let dependencies: Dependencies = .createdFailed
+
+        let operation = GetBetaTesterInfoOperation(options: options)
+
+        let result = Result {
+            try operation.execute(with: dependencies).await()
+        }
+
+        let expectedError = TestError.somethingBadHappened
+
+        switch result {
+            case .failure(let error as TestError):
+                XCTAssertEqual(expectedError, error)
+            default:
+                XCTFail("Expected failure with: \(expectedError), got: \(result)")
+        }
+    }
+}
+
+private extension GetBetaTesterInfoOperationTests.Dependencies {
+
+    static let createdSuccessResponse = """
+    {
+      "data": {
+        "type": "betaTesters",
+        "id": "123456-12345-4276-a6bb-28a5b8f46e32",
+        "attributes": {
+          "firstName": "Foo",
+          "lastName": "Bar",
+          "email": "Foo@gmail.com",
+          "inviteType": "EMAIL"
+        },
+        "relationships": {
+          "apps": {
+            "meta": {
+              "paging": {
+                "total": 1,
+                "limit": 10
+              }
+            },
+            "data": [
+              {
+                "type": "apps",
+                "id": "12345678"
+              },
+              {
+                "type": "apps",
+                "id": "12345678"
+              }
+            ],
+          },
+          "betaGroups": {
+            "meta": {
+              "paging": {
+                "total": 1,
+                "limit": 10
+              }
+            },
+            "data": [
+              {
+                "type": "betaGroups",
+                 "id": "0987654321-0987654321-47c7-9bf8-2f09cd834d73"
+              }
+            ]
+          }
+        },
+        "links": {
+          "self": "https://api.appstoreconnect.apple.com/v1/betaTesters/1234567-b311-4276-a6bb-28a5b8f46e32"
+        }
+      },
+      "included": [
+        {
+          "type": "apps",
+          "id": "12345678",
+          "attributes": {
+            "name": "FooApp",
+            "bundleId": "com.example.fooapp",
+            "sku": "com.example.fooapp",
+            "primaryLocale": "zh-Hans"
+          },
+          "links": {
+            "self": "https://api.appstoreconnect.apple.com/v1/apps/12345678"
+          }
+        },
+        {
+          "type": "betaGroups",
+          "id": "0987654321-0987654321-47c7-9bf8-2f09cd834d73",
+          "attributes": {
+            "name": "FooGroup",
+            "createdDate": "2020-03-28T07:53:43.812Z",
+            "isInternalGroup": false,
+            "publicLinkEnabled": false,
+            "publicLinkId": null,
+            "publicLinkLimitEnabled": false,
+            "publicLinkLimit": null,
+            "publicLink": null,
+            "feedbackEnabled": true
+          },
+          "links": {
+            "self": "https://api.appstoreconnect.apple.com/v1/betaGroups/0987654321-0987654321-47c7-9bf8-2f09cd834d73"
+          }
+        }
+      ],
+      "links": {
+        "self": "https://api.appstoreconnect.apple.com/v1/betaTesters/123455678-b311-4276-a6bb-28a5b8f46e32?include=betaGroups%2Capps"
+      }
+    }
+    """.data(using: .utf8)!
+
+    static let createdSuccess = Self(
+        betaTesterResponse: { _ in
+            Future<BetaTesterResponse, Error> { promise in
+                let certificateResponse = try! jsonDecoder
+                    .decode(BetaTesterResponse.self, from: createdSuccessResponse)
+                promise(.success(certificateResponse))
+            }
+        }
+    )
+
+    static let createdFailed = Self(
+        betaTesterResponse: { _ in
+            Future<BetaTesterResponse, Error> { promise in
+                promise(.failure(TestError.somethingBadHappened))
+            }
+        }
+    )
+}
+


### PR DESCRIPTION
Some tweaks to get the inviting beta tester feature matching the issue #72 

# 📝 Summary of Changes

Changes proposed in this pull request:
Resolves issue #72 by changing the follows
- commandName: `betatesters create` -> `betatesters invite`
- Can invite tester to multiple groups at once
- Get tester info after invitation, show the result to the user with `Apps` and `BetaGroups`
- Show more clear error message when error occured

# ⚠️ Items of Note

This branch is based on #58 so it's better to merge #58 first 

# 🧐🗒 Reviewer Notes

## 💁 Example
Usage: 
`asc testflight betatesters invite <email> [<first-name>] [<last-name>] <bundle-id> [--groups <groups> ...]`

Exaple output: 
| Email | First Name | Last Name | Invite Type | Apps | Beta Groups |
| :-- | :-- | :-- | :-- | :-- | :-- |
| joe@example.com | Jo | Example | EMAIL | com.iba.app1 | Group 1, Group 2 |

## 🔨 How To Test

`asc testflight betatesters invite jo@example.com Joe Example com.iba.app1 --groups "Group 1" "Group 2"`
