### PR TITLE
Implement awaitResult to synchronously wait for API results

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
@@ -19,11 +19,13 @@ struct DeleteBundleIdCommand: CommonParsableCommand {
     var identifier: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = try api
+        let result = try service
             .bundleIdResourceId(matching: identifier)
-            .flatMap { api.request(APIEndpoint.delete(bundleWithId: $0)) }
-            .renderResult(format: common.outputFormat)
+            .flatMap { service.request(APIEndpoint.delete(bundleWithId: $0)) }
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
@@ -20,16 +20,18 @@ struct ListBundleIdsCommand: CommonParsableCommand {
     var filters: FilterOptions
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.listBundleIds(
             filter: [BundleIds.Filter](filters),
             limit: limit
         )
 
-        _ = api.request(request)
+        let result = service.request(request)
             .map { $0.data.map(BundleId.init) }
-            .renderResult(format: common.outputFormat)            
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }
 

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
@@ -22,12 +22,14 @@ struct ModifyBundleIdCommand: CommonParsableCommand {
     var name: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = try api
+        let result = try service
             .bundleIdResourceId(matching: identifier)
-            .flatMap { api.request(APIEndpoint.modifyBundleId(id: $0, name: self.name)) }
+            .flatMap { service.request(APIEndpoint.modifyBundleId(id: $0, name: self.name)) }
             .map(BundleId.init)
-            .renderResult(format: common.outputFormat)            
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
@@ -18,12 +18,14 @@ struct ReadBundleIdCommand: CommonParsableCommand {
     var identifier: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = try api
+        let result = try service
             .bundleIdResourceId(matching: identifier)
-            .flatMap { api.request(APIEndpoint.readBundleIdInformation(id: $0)) }
+            .flatMap { service.request(APIEndpoint.readBundleIdInformation(id: $0)) }
             .map(BundleId.init)
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -26,12 +26,14 @@ struct RegisterBundleIdCommand: CommonParsableCommand {
     var platform: BundleIdPlatform
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.registerNewBundleId(id: identifier, name: name, platform: platform)
 
-        _ = api.request(request)
+        let result = service.request(request)
             .map(BundleId.init)
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
@@ -63,7 +63,7 @@ struct ListDevicesCommand: CommonParsableCommand {
     var filterUDID: [String]
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         var filters = [Devices.Filter]()
 
@@ -93,8 +93,10 @@ struct ListDevicesCommand: CommonParsableCommand {
             limit: limit
         )
 
-        _ = api.request(request)
+        let result = service.request(request)
             .map { $0.data.map(Device.init) }
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
@@ -24,15 +24,17 @@ struct ModifyDeviceCommand: CommonParsableCommand {
     var status: DeviceStatus
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = try api
+        let result = try service
             .deviceUDIDResourceId(matching: udid)
             .flatMap {
-                api.request(APIEndpoint.modifyRegisteredDevice(id: $0, name: self.name, status: self.status))
+                service.request(APIEndpoint.modifyRegisteredDevice(id: $0, name: self.name, status: self.status))
             }
             .map(Device.init)
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
@@ -31,13 +31,13 @@ struct ReadDeviceInfoCommand: CommonParsableCommand {
     var udid: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.listDevices(
             filter: [.udid([udid])]
         )
 
-        _ = api.request(request)
+        let result = service.request(request)
             .map(\.data)
             .tryMap { devices -> AppStoreConnect_Swift_SDK.Device in
                 guard let device = devices.first(where: { $0.attributes.udid == self.udid }) else {
@@ -47,7 +47,9 @@ struct ReadDeviceInfoCommand: CommonParsableCommand {
                 return device
             }
             .map(Device.init)
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
@@ -24,10 +24,12 @@ struct RegisterDeviceCommand: CommonParsableCommand {
     var platform: Platform
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = api.request(APIEndpoint.registerNewDevice(name: name, platform: platform, udid: udid))
+        let result = service.request(APIEndpoint.registerNewDevice(name: name, platform: platform, udid: udid))
             .map(Device.init)
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
@@ -45,7 +45,7 @@ struct ListAppsCommand: CommonParsableCommand {
     }
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let limits = limit.map { [ListApps.Limit.apps($0)] }
 
@@ -54,11 +54,10 @@ struct ListAppsCommand: CommonParsableCommand {
             limits: limits
         )
 
-        _ = api.request(request)
+        let result = service.request(request)
             .map { $0.data.map(App.init) }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
-            )
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
@@ -58,7 +58,7 @@ struct ListAppsCommand: CommonParsableCommand {
             .map { $0.data.map(App.init) }
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
+                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
             )
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/CreateBetaTesterCommand.swift
@@ -43,7 +43,7 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
     }
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request: AnyPublisher<BetaTesterResponse, Error>
 
@@ -58,12 +58,12 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
         switch (buildIds, groupNames) {
             case (let buildIds, _) where !buildIds.isEmpty:
                 let endpoint = createWithBuildIds(buildIds)
-                request = api.request(endpoint).eraseToAnyPublisher()
+                request = service.request(endpoint).eraseToAnyPublisher()
 
             case (_, let groupNames) where !groupNames.isEmpty:
                 let endpoint = APIEndpoint.betaGroups(filter: [ListBetaGroups.Filter.name(groupNames)])
 
-                let groupIds = api.request(endpoint).map { $0.data.map(\.id) }
+                let groupIds = service.request(endpoint).map { $0.data.map(\.id) }
 
                 request = groupIds
                     .flatMap { (groupIds: [String]) -> AnyPublisher<BetaTesterResponse, Error> in
@@ -73,15 +73,17 @@ struct CreateBetaTesterCommand: CommonParsableCommand {
 
                         let endpoint = createWithGroupIds(groupIds)
 
-                        return api.request(endpoint).eraseToAnyPublisher()
+                        return service.request(endpoint).eraseToAnyPublisher()
                     }
                     .eraseToAnyPublisher()
             case (_, _):
                 request = Fail(error: CommandError.invalidInput as Error).eraseToAnyPublisher()
         }
 
-        _ = request
+        let result = request
             .map { BetaTester($0.data, $0.included) }
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/GetBuildInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/GetBuildInfoCommand.swift
@@ -16,15 +16,14 @@ struct GetBuildInfoCommand: CommonParsableCommand {
     var buildId: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.build(withId: buildId)
 
-        _ = api.request(request)
+        let result = service.request(request)
             .map { $0.data }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
-            )
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/GetBuildInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/GetBuildInfoCommand.swift
@@ -24,7 +24,7 @@ struct GetBuildInfoCommand: CommonParsableCommand {
             .map { $0.data }
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
+                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
             )
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
@@ -36,7 +36,7 @@ struct ListBuildsCommand: CommonParsableCommand {
             .map { $0.data }
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
+                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
             )
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
@@ -18,9 +18,8 @@ struct GetUserInfoCommand: CommonParsableCommand {
     func run() throws {
         let service = try makeService()
         let options = GetUserInfoOptions(email: email)
+        let result = service.getUserInfo(with: options).awaitResult()
 
-        _ = service
-            .getUserInfo(with: options)
-            .renderResult(format: common.outputFormat)
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/CancelUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/CancelUserInvitationsCommand.swift
@@ -17,16 +17,15 @@ struct CancelUserInvitationsCommand: CommonParsableCommand {
     var email: String
 
     public func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        let cancelInvitation = { api.request(APIEndpoint.cancel(userInvitationWithId: $0)) }
+        let cancelInvitation = { service.request(APIEndpoint.cancel(userInvitationWithId: $0)) }
 
-        _ = try api
+        let result = try service
             .invitationIdentifier(matching: email)
             .flatMap(cancelInvitation)
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: { _ in }
-            )
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
@@ -67,7 +67,7 @@ struct InviteUserCommand: CommonParsableCommand {
             .map { $0.data }
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
+                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
             )
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -51,7 +51,7 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
             .map(\.data)
             .sink(
                 receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
+                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
             )
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -40,18 +40,17 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
     }
 
     public func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let endpoint = APIEndpoint.invitedUsers(
             limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] },
             filter: filters
         )
 
-        _ = api.request(endpoint)
+        let result = service.request(endpoint)
             .map(\.data)
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.DefaultRenderer(format: common.outputFormat).render
-            )
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -63,8 +63,10 @@ public struct ListUsersCommand: CommonParsableCommand {
             includeVisibleApps: includeVisibleApps
         )
 
-        _ = service
+        let result = service
             .listUsers(with: options)
-            .renderResult(format: common.outputFormat)
+            .awaitResult()
+
+        result.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -40,7 +40,7 @@ extension Publisher where Output: Renderable, Failure == Error {
     func renderResult(format: OutputFormat) -> AnyCancellable {
         self.sink(
             receiveCompletion: Renderers.CompletionRenderer().render,
-            receiveValue: Renderers.DefaultRenderer<Output>(format: format).render
+            receiveValue: Renderers.DefaultRenderer(format: format).render
         )
     }
 }

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -35,11 +35,12 @@ extension Publisher {
         return result
     }
 }
-extension Publisher where Output: ResultRenderable, Failure == Error {
+
+extension Publisher where Output: Renderable, Failure == Error {
     func renderResult(format: OutputFormat) -> AnyCancellable {
         self.sink(
             receiveCompletion: Renderers.CompletionRenderer().render,
-            receiveValue: Renderers.ResultRenderer<Output>(format: format).render
+            receiveValue: Renderers.DefaultRenderer<Output>(format: format).render
         )
     }
 }

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -3,6 +3,38 @@
 import Combine
 import Foundation
 
+extension Publisher {
+    func awaitResult() -> Result<[Output], Failure> {
+        var result: Result<[Output], Failure> = .success([])
+
+        let dispatchQueue = DispatchQueue.global(qos: .userInteractive)
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+
+        _ = self
+            .subscribe(on: dispatchQueue)
+            .collect()
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        break
+                    case .failure(let failure):
+                        result = .failure(failure)
+                    }
+
+                    dispatchGroup.leave()
+                },
+                receiveValue: {
+                    result = .success($0)
+                }
+            )
+
+        dispatchGroup.wait()
+
+        return result
+    }
+}
 extension Publisher where Output: ResultRenderable, Failure == Error {
     func renderResult(format: OutputFormat) -> AnyCancellable {
         self.sink(

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -35,21 +35,3 @@ extension Publisher {
         return result
     }
 }
-
-extension Publisher where Output: Renderable, Failure == Error {
-    func renderResult(format: OutputFormat) -> AnyCancellable {
-        self.sink(
-            receiveCompletion: Renderers.CompletionRenderer().render,
-            receiveValue: Renderers.DefaultRenderer(format: format).render
-        )
-    }
-}
-
-extension Publisher where Output == Void, Failure == Error {
-    func renderResult(format: OutputFormat) -> AnyCancellable {
-        self.sink(
-            receiveCompletion: Renderers.CompletionRenderer().render,
-            receiveValue: Renderers.null
-        )
-    }
-}

--- a/Sources/AppStoreConnectCLI/Helpers/Result+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Result+Helpers.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-extension Result where Success: Renderable, Failure == Error {
+extension Result {
     func render(format: OutputFormat) {
         Renderers.ResultRenderer(format: format).render(self)
     }

--- a/Sources/AppStoreConnectCLI/Helpers/Result+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Result+Helpers.swift
@@ -1,0 +1,9 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+extension Result where Success: Renderable, Failure == Error {
+    func render(format: OutputFormat) {
+        Renderers.ResultRenderer(format: format).render(self)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/App.swift
+++ b/Sources/AppStoreConnectCLI/Model/App.swift
@@ -5,7 +5,7 @@ import Combine
 import Foundation
 import SwiftyTextTable
 
-struct App: ResultRenderable {
+struct App: Renderable {
     var bundleId: String?
     var name: String?
     var primaryLocale: String?

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -5,7 +5,7 @@ import Combine
 import Foundation
 import SwiftyTextTable
 
-struct BetaTester: ResultRenderable {
+struct BetaTester: Renderable {
     let email: String?
     let firstName: String?
     let lastName: String?

--- a/Sources/AppStoreConnectCLI/Model/Build.swift
+++ b/Sources/AppStoreConnectCLI/Model/Build.swift
@@ -4,7 +4,7 @@ import AppStoreConnect_Swift_SDK
 import Foundation
 import SwiftyTextTable
 
-extension Build: ResultRenderable { }
+extension Build: Renderable { }
 
 extension Build: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {

--- a/Sources/AppStoreConnectCLI/Model/BundleId.swift
+++ b/Sources/AppStoreConnectCLI/Model/BundleId.swift
@@ -5,7 +5,7 @@ import Combine
 import Foundation
 import SwiftyTextTable
 
-struct BundleId: ResultRenderable {
+struct BundleId: Renderable {
     var identifier: String?
     var name: String?
     var platform: BundleIdPlatform?

--- a/Sources/AppStoreConnectCLI/Model/Device.swift
+++ b/Sources/AppStoreConnectCLI/Model/Device.swift
@@ -4,7 +4,7 @@ import Foundation
 import AppStoreConnect_Swift_SDK
 import SwiftyTextTable
 
-struct Device: ResultRenderable {
+struct Device: Renderable {
     var udid: String?
     var addedDate: Date?
     var name: String?

--- a/Sources/AppStoreConnectCLI/Model/User.swift
+++ b/Sources/AppStoreConnectCLI/Model/User.swift
@@ -5,7 +5,7 @@ import Combine
 import Foundation
 import SwiftyTextTable
 
-struct User: ResultRenderable {
+struct User: Renderable {
     var username: String
     var firstName: String
     var lastName: String

--- a/Sources/AppStoreConnectCLI/Model/UserInvitation.swift
+++ b/Sources/AppStoreConnectCLI/Model/UserInvitation.swift
@@ -5,7 +5,7 @@ import Combine
 import SwiftyTextTable
 import AppStoreConnect_Swift_SDK
 
-extension UserInvitation: ResultRenderable { }
+extension UserInvitation: Renderable { }
 
 extension UserInvitation: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -31,8 +31,14 @@ enum Renderers {
                 case .finished:
                     break
                 case .failure(let error):
-                    print("Error: \(error.localizedDescription)", to: &errorOutput)
+                    ErrorRenderer().render(error)
             }
+        }
+    }
+
+    struct ErrorRenderer: Renderer {
+        func render(_ input: Error) {
+            print("Error: \(input.localizedDescription)", to: &errorOutput)
         }
     }
 

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -29,9 +29,22 @@ enum Renderers {
         func render(_ input: Subscribers.Completion<Error>) {
             switch input {
                 case .finished:
-                    break
+                    Renderers.null(())
                 case .failure(let error):
                     ErrorRenderer().render(error)
+            }
+        }
+    }
+
+    struct ResultRenderer<T: Renderable>: Renderer {
+        let format: OutputFormat
+
+        func render(_ input: Result<T, Error>) {
+            switch input {
+            case .success(let success):
+                Renderers.DefaultRenderer(format: format).render(success)
+            case .failure(let error):
+                Renderers.ErrorRenderer().render(error)
             }
         }
     }
@@ -43,8 +56,6 @@ enum Renderers {
     }
 
     struct DefaultRenderer<T: Renderable>: Renderer {
-        typealias Input = T
-
         let format: OutputFormat
 
         func render(_ input: T) {

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -42,7 +42,7 @@ enum Renderers {
         }
     }
 
-    struct ResultRenderer<T: ResultRenderable>: Renderer {
+    struct DefaultRenderer<T: Renderable>: Renderer {
         typealias Input = T
 
         let format: OutputFormat
@@ -66,7 +66,7 @@ enum Renderers {
 /// Conformers to this protocol can be rendered as results in various formats.
 ///
 /// By also conforming to `TableInfoProvider`, conformers gain default implementations of all these functions.
-protocol ResultRenderable: Codable {
+protocol Renderable: Codable {
     /// Renders the receiver as a CSV string.
     func renderAsCSV() -> String
 
@@ -80,7 +80,7 @@ protocol ResultRenderable: Codable {
     func renderAsTable() -> String
 }
 
-extension ResultRenderable {
+extension Renderable {
     func renderAsJSON() -> String {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -106,7 +106,7 @@ protocol TableInfoProvider {
 
 }
 
-extension Array: ResultRenderable where Element: TableInfoProvider & Codable {
+extension Array: Renderable where Element: TableInfoProvider & Codable {
     func renderAsCSV() -> String {
         let headers = Element.tableColumns().map { $0.header }
         let rows = self.map { $0.tableRow.map { "\($0)" } }
@@ -122,7 +122,7 @@ extension Array: ResultRenderable where Element: TableInfoProvider & Codable {
     }
 }
 
-extension ResultRenderable where Self: TableInfoProvider {
+extension Renderable where Self: TableInfoProvider {
     func renderAsCSV() -> String {
         let headers = Self.tableColumns().map { $0.header }
         let row = self.tableRow.map { "\($0)" }

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -36,15 +36,17 @@ enum Renderers {
         }
     }
 
-    struct ResultRenderer<T: Renderable>: Renderer {
+    struct ResultRenderer<T, U: Error>: Renderer {
         let format: OutputFormat
 
-        func render(_ input: Result<T, Error>) {
+        func render(_ input: Result<T, U>) {
             switch input {
-            case .success(let success):
+            case .success(let success as Renderable):
                 Renderers.DefaultRenderer(format: format).render(success)
             case .failure(let error):
                 Renderers.ErrorRenderer().render(error)
+            default:
+                Renderers.null(())
             }
         }
     }
@@ -55,10 +57,10 @@ enum Renderers {
         }
     }
 
-    struct DefaultRenderer<T: Renderable>: Renderer {
+    struct DefaultRenderer: Renderer {
         let format: OutputFormat
 
-        func render(_ input: T) {
+        func render(_ input: Renderable) {
             switch format {
             case .csv:
                 print(input.renderAsCSV())

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -31,20 +31,8 @@ class AppStoreConnectService {
     ///   - endpoint: The API endpoint to request
     /// - Returns: `Future<T, Error>` that executes immediately (hot observable)
     func request<T: Decodable>(_ endpoint: APIEndpoint<T>) -> Future<T, Error> {
-        // We use dispatch group to make this blocking - due to the nature of the app as a CLI tool it is necessary for API calls to be blocking
-        let dispatchGroup = DispatchGroup()
-        return Future<T, Error> { [provider] promise in
-            dispatchGroup.enter()
-            provider.request(endpoint) { result in
-                switch result {
-                    case .success(let response):
-                        promise(.success(response))
-                    case .failure(let error):
-                        promise(.failure(error))
-                }
-                dispatchGroup.leave()
-            }
-            dispatchGroup.wait()
+        Future { [provider] promise in
+            provider.request(endpoint, completion: promise)
         }
     }
 
@@ -54,20 +42,8 @@ class AppStoreConnectService {
     ///   - endpoint: The API endpoint to request
     /// - Returns: `Future<Void, Error>` that executes immediately (hot observable)
     func request(_ endpoint: APIEndpoint<Void>) -> Future<Void, Error> {
-        // We use dispatch group to make this blocking - due to the nature of the app as a CLI tool it is necessary for API calls to be blocking
-        let dispatchGroup = DispatchGroup()
-        return Future<Void, Error> { [provider] promise in
-            dispatchGroup.enter()
-            provider.request(endpoint) { result in
-                switch result {
-                    case .success:
-                        promise(.success(()))
-                    case .failure(let error):
-                        promise(.failure(error))
-                }
-                dispatchGroup.leave()
-            }
-            dispatchGroup.wait()
+        Future { [provider] promise in
+            provider.request(endpoint, completion: promise)
         }
     }
 }

--- a/Tests/appstoreconnect-cliTests/Operations/GetUserInfoOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetUserInfoOperationTests.swift
@@ -61,11 +61,8 @@ private extension GetUserInfoOperationTests.Dependencies {
 
     static let noUsers = Self(
         usersResponse: { _ in
-            Future<UsersResponse, Error> { promise in
-                let usersResponse = try! jsonDecoder
-                    .decode(UsersResponse.self, from: noUsersResponse)
-                promise(.success(usersResponse))
-            }
+            let response = try! jsonDecoder.decode(UsersResponse.self, from: noUsersResponse)
+            return Future<UsersResponse, Error> { $0(.success(response)) }
         }
     )
 }


### PR DESCRIPTION
This is an attempt to move blocking calls out of `AppStoreConnectAPIService` and into a `Publisher` function called `awaitResult`.

It collects up all values and returns a `.success` with all the published values or it returns a `.failure` with the `Error` that completed the stream

# 📝 Summary of Changes

Changes proposed in this pull request:

- Rename `ResultRenderable` to `Renderable`
- Rename previous `ResultRenderer` to `DefaultRenderer`
- Adds a new `ResultRenderer` that renders `Result` types
- Removes `Publisher` extensions to render results
- Adds `awaitResult` `Publisher` extension to synchronously wait for a result of all output values or the error in the stream
- Changes all `Command`s to use the new await call and result renderer

# ⚠️ Items of Note

Since the Commands currently return an `AnyPublisher` we can't know how many elements will be returned. As such `awaitResult` wraps the output values in an `Array` meaning all JSON / YAML output is surrounded in an array.

We should discuss ways to get around this. E.g. returning something like a `Future` from the `AppStoreConnectAPIService` for commands that only emit once.

Or maybe the `AppStoreConnectAPIService` functions should be blocking calls that return a result.

Alternatively we `await` for a singular result and assert that we don't get more than one

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

All existing commands should still work as expected except for the aforementioned `Array` wrapping
