### PR TITLE
Add notFound Error for function deviceUDIDResourceId

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Devices/HTTPClient+DeviceId.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/HTTPClient+DeviceId.swift
@@ -10,12 +10,12 @@ extension AppStoreConnectService {
         case notUnique(String)
         case notFound(String)
 
-        var failureReason: String? {
+        var errorDescription: String? {
             switch self {
             case .notUnique(let identifier):
                 return "'\(identifier)' is not a unique Device UDID."
             case .notFound(let identifier):
-                return "Unable to find device with UDID of '\(identifier)'."
+                return "Unable to find device with UDID: '\(identifier)'."
             }
         }
     }
@@ -34,15 +34,14 @@ extension AppStoreConnectService {
         return self.request(request)
             .map { $0.data.filter { $0.attributes.udid == udid } }
             .tryMap { response -> String in
-                guard !response.isEmpty else {
+                switch response.first {
+                case .none:
                     throw DeviceIDError.notFound(udid)
-                }
-
-                guard response.count == 1 else {
+                case .some(let udid) where response.count == 1:
+                    return udid.id
+                case .some:
                     throw DeviceIDError.notUnique(udid)
                 }
-                
-                return response.first!.id
             }
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
Fixing Bug #77, show the correct error message when UDID doesn't exist.
Closes #77

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add `notFound` error case to `DeviceIDError`

# 🧐🗒 Reviewer Notes

## 💁 Example

` swift run asc devices modify abcdefghijklmnopqrst "Decheng's iPhone 8" ENABLED`

Sample result: 

`Error: The operation couldn’t be completed. Unable to find device with UDID of 'abcdefghijklmnopqrst'.`

## 🔨 How To Test

` swift run asc devices modify asdasdasdasdasdasdasd "New iPhone 8" ENABLED`
