### PR TITLE
Implement await function to synchronously wait for output throwing errors

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/DeleteBundleIdCommand.swift
@@ -19,11 +19,10 @@ struct DeleteBundleIdCommand: CommonParsableCommand {
     var identifier: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
+        let resourceId = try service.bundleIdResourceId(matching: identifier).await()
+        let deleteBundleId = APIEndpoint.delete(bundleWithId: resourceId)
 
-        _ = try api
-            .bundleIdResourceId(matching: identifier)
-            .flatMap { api.request(APIEndpoint.delete(bundleWithId: $0)) }
-            .renderResult(format: common.outputFormat)
+        try service.request(deleteBundleId).await()
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
@@ -20,16 +20,18 @@ struct ListBundleIdsCommand: CommonParsableCommand {
     var filters: FilterOptions
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.listBundleIds(
             filter: [BundleIds.Filter](filters),
             limit: limit
         )
 
-        _ = api.request(request)
+        let bundleId = try service.request(request)
             .map { $0.data.map(BundleId.init) }
-            .renderResult(format: common.outputFormat)            
+            .await()
+
+        bundleId.render(format: common.outputFormat)
     }
 }
 

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
@@ -22,12 +22,14 @@ struct ModifyBundleIdCommand: CommonParsableCommand {
     var name: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = try api
+        let bundleId = try service
             .bundleIdResourceId(matching: identifier)
-            .flatMap { api.request(APIEndpoint.modifyBundleId(id: $0, name: self.name)) }
+            .flatMap { service.request(APIEndpoint.modifyBundleId(id: $0, name: self.name)) }
             .map(BundleId.init)
-            .renderResult(format: common.outputFormat)            
+            .await()
+
+        bundleId.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
@@ -18,12 +18,14 @@ struct ReadBundleIdCommand: CommonParsableCommand {
     var identifier: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = try api
+        let bundleId = try service
             .bundleIdResourceId(matching: identifier)
-            .flatMap { api.request(APIEndpoint.readBundleIdInformation(id: $0)) }
+            .flatMap { service.request(APIEndpoint.readBundleIdInformation(id: $0)) }
             .map(BundleId.init)
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        bundleId.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -26,12 +26,14 @@ struct RegisterBundleIdCommand: CommonParsableCommand {
     var platform: BundleIdPlatform
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.registerNewBundleId(id: identifier, name: name, platform: platform)
 
-        _ = api.request(request)
+        let bundleId = try service.request(request)
             .map(BundleId.init)
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        bundleId.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
@@ -20,7 +20,7 @@ struct CreateCertificateCommand: CommonParsableCommand {
     var csrFile: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let csrContent = try String(contentsOfFile: csrFile, encoding: .utf8)
 
@@ -29,9 +29,11 @@ struct CreateCertificateCommand: CommonParsableCommand {
             csrContent: csrContent
         )
 
-        _ = api
+        let certificate = try service
             .request(endpoint)
             .map { Certificate($0.data) }
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        certificate.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
@@ -63,7 +63,7 @@ struct ListDevicesCommand: CommonParsableCommand {
     var filterUDID: [String]
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         var filters = [Devices.Filter]()
 
@@ -93,8 +93,10 @@ struct ListDevicesCommand: CommonParsableCommand {
             limit: limit
         )
 
-        _ = api.request(request)
+        let devices = try service.request(request)
             .map { $0.data.map(Device.init) }
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        devices.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
@@ -24,15 +24,17 @@ struct ModifyDeviceCommand: CommonParsableCommand {
     var status: DeviceStatus
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = try api
+        let device = try service
             .deviceUDIDResourceId(matching: udid)
             .flatMap {
-                api.request(APIEndpoint.modifyRegisteredDevice(id: $0, name: self.name, status: self.status))
+                service.request(APIEndpoint.modifyRegisteredDevice(id: $0, name: self.name, status: self.status))
             }
             .map(Device.init)
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        device.render(format: common.outputFormat)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
@@ -31,13 +31,13 @@ struct ReadDeviceInfoCommand: CommonParsableCommand {
     var udid: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.listDevices(
             filter: [.udid([udid])]
         )
 
-        _ = api.request(request)
+        let device = try service.request(request)
             .map(\.data)
             .tryMap { devices -> AppStoreConnect_Swift_SDK.Device in
                 guard let device = devices.first(where: { $0.attributes.udid == self.udid }) else {
@@ -47,7 +47,9 @@ struct ReadDeviceInfoCommand: CommonParsableCommand {
                 return device
             }
             .map(Device.init)
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        device.render(format: common.outputFormat)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
@@ -24,10 +24,12 @@ struct RegisterDeviceCommand: CommonParsableCommand {
     var platform: Platform
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = api.request(APIEndpoint.registerNewDevice(name: name, platform: platform, udid: udid))
+        let device = try service.request(APIEndpoint.registerNewDevice(name: name, platform: platform, udid: udid))
             .map(Device.init)
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        device.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
@@ -45,7 +45,7 @@ struct ListAppsCommand: CommonParsableCommand {
     }
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let limits = limit.map { [ListApps.Limit.apps($0)] }
 
@@ -54,11 +54,10 @@ struct ListAppsCommand: CommonParsableCommand {
             limits: limits
         )
 
-        _ = api.request(request)
+        let apps = try service.request(request)
             .map { $0.data.map(App.init) }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .await()
+
+        apps.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/DeleteBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/DeleteBetaTesterCommand.swift
@@ -68,37 +68,37 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
     }
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request: AnyPublisher<Void, Error>
 
         switch DeleteStrategy(options: (all, bundleId, betaGroupName, buildId)) {
             // Remove a beta tester's ability to test all apps.
             case .all:
-                request = try api
+                request = try service
                     .betaTesterResourceId(matching: email)
                     .flatMap {
-                        api.request(APIEndpoint.delete(betaTesterWithId: $0)).eraseToAnyPublisher()
+                        service.request(APIEndpoint.delete(betaTesterWithId: $0)).eraseToAnyPublisher()
                     }
                     .eraseToAnyPublisher()
 
             // Remove a specific beta tester's access to test any builds of one or more apps.
             case .removeFromApp(let bundleId):
-                request = try api
+                request = try service
                     .betaTesterResourceId(matching: email)
-                    .combineLatest(api.getAppResourceIdsFrom(bundleIds: [bundleId]))
+                    .combineLatest(service.getAppResourceIdsFrom(bundleIds: [bundleId]))
                     .flatMap {
-                        api.request(APIEndpoint.remove(accessOfBetaTesterWithId: $0, toAppsWithIds: $1))
+                        service.request(APIEndpoint.remove(accessOfBetaTesterWithId: $0, toAppsWithIds: $1))
                     }
                     .eraseToAnyPublisher()
 
             // Remove a specific beta tester from one or more beta groups, revoking their access to test builds associated with those groups.
             case .removeFromGroup(let betaGroupName):
-                request = try api
+                request = try service
                     .betaTesterResourceId(matching: email)
-                    .combineLatest(try api.betaGroupIdentifier(matching: betaGroupName))
+                    .combineLatest(try service.betaGroupIdentifier(matching: betaGroupName))
                     .flatMap {
-                        api.request(APIEndpoint.remove(
+                        service.request(APIEndpoint.remove(
                             betaTestersWithIds: [$0],
                             fromBetaGroupWithId: $1
                         ))
@@ -107,10 +107,10 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
 
             // Remove access to test a specific build from one or more individually assigned testers.
             case .removeFromBuild(let buildId):
-                request = try api
+                request = try service
                     .betaTesterResourceId(matching: email)
                     .flatMap {
-                        api.request(APIEndpoint.remove(
+                        service.request(APIEndpoint.remove(
                             individualTestersWithIds: [$0],
                             fromBuildWithId: buildId
                         ))
@@ -121,10 +121,6 @@ struct DeleteBetaTesterCommand: CommonParsableCommand {
                 request = Fail(error: error).eraseToAnyPublisher()
         }
 
-        _ = request
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: { _ in }
-            )
+        try request.await()
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -41,9 +41,9 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
     }
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _  = api
+        let betaTesters = try service
             .getAppResourceIdsFrom(bundleIds: [bundleId])
             .flatMap { [versions, preReleaseVersions] appIds -> AnyPublisher<BuildsResponse, Error> in
 
@@ -57,7 +57,7 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
                     filters.append(.preReleaseVersionVersion(preReleaseVersions))
                 }
 
-                return api.request(APIEndpoint.builds(filter: filters))
+                return service.request(APIEndpoint.builds(filter: filters))
                     .eraseToAnyPublisher()
             }
             .flatMap { [versions, preReleaseVersions] buildResponse -> AnyPublisher<BetaTestersResponse, Error> in
@@ -69,12 +69,14 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
                 let endpoint = APIEndpoint.betaTesters(filter: [.builds(buildResponse.data.map(\.id))],
                                                        include: [.apps, .betaGroups])
 
-                return api.request(endpoint).eraseToAnyPublisher()
+                return service.request(endpoint).eraseToAnyPublisher()
             }
             .map { response in
                 response.data.map { BetaTester($0, response.included) }
             }
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        betaTesters.render(format: common.outputFormat)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -98,10 +98,12 @@ struct ListBetaTestersCommand: CommonParsableCommand {
                     .eraseToAnyPublisher()
         }
 
-        _ = request
+        let betaTesters = try request
             .map { response in
                 response.data.map { BetaTester($0, response.included) }
             }
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        betaTesters.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/GetBuildInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/GetBuildInfoCommand.swift
@@ -16,15 +16,14 @@ struct GetBuildInfoCommand: CommonParsableCommand {
     var buildId: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let request = APIEndpoint.build(withId: buildId)
 
-        _ = api.request(request)
+        let build = try service.request(request)
             .map { $0.data }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .await()
+
+        build.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
@@ -17,9 +17,9 @@ struct ListBuildsCommand: CommonParsableCommand {
     var bundleId: String
 
     func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        _ = api
+        let builds = try service
             .getAppResourceIdsFrom(bundleIds: [bundleId])
             .flatMap { (resoureceIds: [String]) -> AnyPublisher<BuildsResponse, Error> in
                 guard let appId = resoureceIds.first else {
@@ -31,12 +31,11 @@ struct ListBuildsCommand: CommonParsableCommand {
                     sort: [ListBuilds.Sort.uploadedDateAscending]
                 )
 
-                return api.request(endpoint).eraseToAnyPublisher()
+                return service.request(endpoint).eraseToAnyPublisher()
             }
             .map { $0.data }
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .await()
+
+        builds.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
@@ -19,8 +19,8 @@ struct GetUserInfoCommand: CommonParsableCommand {
         let service = try makeService()
         let options = GetUserInfoOptions(email: email)
 
-        _ = service
-            .getUserInfo(with: options)
-            .renderResult(format: common.outputFormat)
+        let user = try service.getUserInfo(with: options).await()
+
+        user.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/CancelUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/CancelUserInvitationsCommand.swift
@@ -17,16 +17,13 @@ struct CancelUserInvitationsCommand: CommonParsableCommand {
     var email: String
 
     public func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
-        let cancelInvitation = { api.request(APIEndpoint.cancel(userInvitationWithId: $0)) }
+        let cancelInvitation = { service.request(APIEndpoint.cancel(userInvitationWithId: $0)) }
 
-        _ = try api
+        try service
             .invitationIdentifier(matching: email)
             .flatMap(cancelInvitation)
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: { _ in }
-            )
+            .await()
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -40,18 +40,17 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
     }
 
     public func run() throws {
-        let api = try makeService()
+        let service = try makeService()
 
         let endpoint = APIEndpoint.invitedUsers(
             limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] },
             filter: filters
         )
 
-        _ = api.request(endpoint)
+        let invitations = try service.request(endpoint)
             .map(\.data)
-            .sink(
-                receiveCompletion: Renderers.CompletionRenderer().render,
-                receiveValue: Renderers.ResultRenderer(format: common.outputFormat).render
-            )
+            .await()
+
+        invitations.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -63,8 +63,10 @@ public struct ListUsersCommand: CommonParsableCommand {
             includeVisibleApps: includeVisibleApps
         )
 
-        _ = service
+        let users = try service
             .listUsers(with: options)
-            .renderResult(format: common.outputFormat)
+            .await()
+
+        users.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -21,8 +21,8 @@ enum PublisherAwaitError: LocalizedError {
 }
 
 extension Publisher {
-    func await(timeout: DispatchTime = .now() + 30) throws -> Output {
-        let allOutput = try awaitMany()
+    func await(timeout: DispatchTime = .distantFuture) throws -> Output {
+        let allOutput = try awaitMany(timeout: timeout)
 
         guard let output = allOutput.first, allOutput.count == 1 else {
             throw PublisherAwaitError.expectedSingleOutput(outputCount: allOutput.count)
@@ -31,7 +31,7 @@ extension Publisher {
         return output
     }
 
-    func awaitMany(timeout: DispatchTime = .now() + 30) throws -> [Output] {
+    func awaitMany(timeout: DispatchTime = .distantFuture) throws -> [Output] {
         var result: Result<[Output], Failure>?
 
         let dispatchQueue = DispatchQueue.global(qos: .userInteractive)

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -3,6 +3,76 @@
 import Combine
 import Foundation
 
+enum PublisherAwaitError: LocalizedError {
+    case timedOut(timeout: DispatchTime)
+    case expectedOutput
+    case expectedSingleOutput(outputCount: Int)
+
+    var failureReason: String? {
+        switch self {
+        case .timedOut(let timeout):
+            return "Expected publisher output but timed out with timeout: \(timeout)"
+        case .expectedOutput:
+            return "Expected publisher output but none received"
+        case .expectedSingleOutput(let outputCount):
+            return "Expected single publisher output but received \(outputCount)"
+        }
+    }
+}
+
+extension Publisher {
+    func await(timeout: DispatchTime = .now() + 30) throws -> Output {
+        let allOutput = try awaitMany()
+
+        guard let output = allOutput.first, allOutput.count == 1 else {
+            throw PublisherAwaitError.expectedSingleOutput(outputCount: allOutput.count)
+        }
+
+        return output
+    }
+
+    func awaitMany(timeout: DispatchTime = .now() + 30) throws -> [Output] {
+        var result: Result<[Output], Failure>?
+
+        let dispatchQueue = DispatchQueue.global(qos: .userInteractive)
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+
+        let cancellable = self
+            .subscribe(on: dispatchQueue)
+            .collect()
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        break
+                    case .failure(let failure):
+                        result = .failure(failure)
+                    }
+
+                    dispatchGroup.leave()
+                },
+                receiveValue: {
+                    result = .success($0)
+                }
+            )
+
+        let timeoutResult = dispatchGroup.wait(timeout: timeout)
+        cancellable.cancel()
+
+        switch (result, timeoutResult) {
+        case (_, .timedOut):
+            throw PublisherAwaitError.timedOut(timeout: timeout)
+        case (.none, .success):
+            throw PublisherAwaitError.expectedOutput
+        case (.some(.success(let output)), .success):
+            return output
+        case (.some(.failure(let error)), .success):
+            throw error
+        }
+    }
+}
+
 extension Publisher where Output: ResultRenderable, Failure == Error {
     func renderResult(format: OutputFormat) -> AnyCancellable {
         self.sink(

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -8,7 +8,7 @@ enum PublisherAwaitError: LocalizedError {
     case expectedOutput
     case expectedSingleOutput(outputCount: Int)
 
-    var failureReason: String? {
+    var errorDescription: String? {
         switch self {
         case .timedOut(let timeout):
             return "Expected publisher output but timed out with timeout: \(timeout)"

--- a/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Publisher+Helpers.swift
@@ -72,21 +72,3 @@ extension Publisher {
         }
     }
 }
-
-extension Publisher where Output: ResultRenderable, Failure == Error {
-    func renderResult(format: OutputFormat) -> AnyCancellable {
-        self.sink(
-            receiveCompletion: Renderers.CompletionRenderer().render,
-            receiveValue: Renderers.ResultRenderer<Output>(format: format).render
-        )
-    }
-}
-
-extension Publisher where Output == Void, Failure == Error {
-    func renderResult(format: OutputFormat) -> AnyCancellable {
-        self.sink(
-            receiveCompletion: Renderers.CompletionRenderer().render,
-            receiveValue: Renderers.null
-        )
-    }
-}

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -87,6 +87,10 @@ extension ResultRenderable {
         let yaml = try! yamlEncoder.encode(self)
         return yaml
     }
+
+    func render(format: OutputFormat) {
+        Renderers.ResultRenderer(format: format).render(self)
+    }
 }
 
 /// Provides the necessary info to be able to render a table with SwiftyTable

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -13,29 +13,7 @@ protocol Renderer {
     func render(_ input: Input)
 }
 
-private final class StandardErrorOutputStream: TextOutputStream {
-    func write(_ string: String) {
-        FileHandle.standardError.write(Data(string.utf8))
-    }
-}
-
 enum Renderers {
-
-    static func null(_ input: Void) {}
-
-    private static var errorOutput = StandardErrorOutputStream()
-
-    struct CompletionRenderer: Renderer {
-        func render(_ input: Subscribers.Completion<Error>) {
-            switch input {
-                case .finished:
-                    break
-                case .failure(let error):
-                    print("Error: \(error.localizedDescription)", to: &errorOutput)
-            }
-        }
-    }
-
     struct ResultRenderer<T: ResultRenderable>: Renderer {
         typealias Input = T
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -31,20 +31,8 @@ class AppStoreConnectService {
     ///   - endpoint: The API endpoint to request
     /// - Returns: `Future<T, Error>` that executes immediately (hot observable)
     func request<T: Decodable>(_ endpoint: APIEndpoint<T>) -> Future<T, Error> {
-        // We use dispatch group to make this blocking - due to the nature of the app as a CLI tool it is necessary for API calls to be blocking
-        let dispatchGroup = DispatchGroup()
-        return Future<T, Error> { [provider] promise in
-            dispatchGroup.enter()
-            provider.request(endpoint) { result in
-                switch result {
-                    case .success(let response):
-                        promise(.success(response))
-                    case .failure(let error):
-                        promise(.failure(error))
-                }
-                dispatchGroup.leave()
-            }
-            dispatchGroup.wait()
+        Future { [provider] promise in
+            provider.request(endpoint, completion: promise)
         }
     }
 
@@ -54,20 +42,8 @@ class AppStoreConnectService {
     ///   - endpoint: The API endpoint to request
     /// - Returns: `Future<Void, Error>` that executes immediately (hot observable)
     func request(_ endpoint: APIEndpoint<Void>) -> Future<Void, Error> {
-        // We use dispatch group to make this blocking - due to the nature of the app as a CLI tool it is necessary for API calls to be blocking
-        let dispatchGroup = DispatchGroup()
-        return Future<Void, Error> { [provider] promise in
-            dispatchGroup.enter()
-            provider.request(endpoint) { result in
-                switch result {
-                    case .success:
-                        promise(.success(()))
-                    case .failure(let error):
-                        promise(.failure(error))
-                }
-                dispatchGroup.leave()
-            }
-            dispatchGroup.wait()
+        Future { [provider] promise in
+            provider.request(endpoint, completion: promise)
         }
     }
 }

--- a/Tests/appstoreconnect-cliTests/Operations/GetUserInfoOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetUserInfoOperationTests.swift
@@ -13,31 +13,21 @@ final class GetUserInfoOperationTests: XCTestCase {
 
     func testCouldNotFindUserError() {
         let dependencies: Dependencies = .noUsers
-        let options = Options(email: "bob@bob.com")
+        let email = "bob@bob.com"
+        let options = Options(email: email)
         let operation = GetUserInfoOperation(options: options)
+        let expectedError = OperationError.couldNotFindUser(email: email)
 
-        let expectation = XCTestExpectation(description: "Publisher will complete")
-        var operationError: Error?
+        let result = Result {
+            try operation.execute(with: dependencies).await()
+        }
 
-        _ = operation
-            .execute(with: dependencies)
-            .sink(
-                receiveCompletion: { completion in
-                    if case .failure(let error) = completion {
-                        operationError = error
-                    }
-
-                    expectation.fulfill()
-                },
-                receiveValue: { _ in
-                    XCTFail("Expected no values")
-                }
-            )
-
-        XCTAssertEqual(
-            operationError?.localizedDescription,
-            OperationError.couldNotFindUser(email: "bob@bob.com").localizedDescription
-        )
+        switch result {
+        case .failure(let error as OperationError):
+            XCTAssertEqual(error.localizedDescription, expectedError.localizedDescription)
+        default:
+            XCTFail("Expected failure with: \(expectedError), got: \(result)")
+        }
     }
 }
 


### PR DESCRIPTION
A throwing re-imagining of #84 

This seems like a nicer solution overall and throws `PublisherAwaitError`s if waiting doesn't go as we expect.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds `await` and `awaitMany` to synchronously wait for publisher results
- Adds `render` function to `ResultRenderable` to conveniently render it in the provided format
- Removes old `Renderers` and rendering extensions
- Errors are now thrown from a Commands `run` function

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

All existing commands should still work as expected however as we have discovered `Error`s need to be migrated to use `errorDescription` for nice printing
