### PR TITLE
Implement CreateCertificateCommand

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
@@ -8,7 +8,7 @@ struct CertificatesCommand: ParsableCommand {
         commandName: "certificates",
         abstract: "Create, download, and revoke signing certificates for app development and distribution.",
         subcommands: [
-            /* TODO */
+            CreateCertificateCommand.self
         ]
         // defaultSubcommand: ListCertificatesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
@@ -1,0 +1,69 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Combine
+import Foundation
+
+struct CreateCertificateCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "create",
+        abstract: "Create a new certificate")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The type of certificate. (eg. IOS_DEVELOPMENT)")
+    var certificateType: String
+
+    @Option(help: "The file path of your CSR file. (eg. folder/CertificateSigningRequest.certSigningRequest)")
+    var csrFile: String
+
+    enum CommandError: LocalizedError {
+        case invalidCertificateType(String)
+        case invalidCSRFilePath(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidCertificateType(let type):
+                return "\(type) is not a valid certificate type"
+            case .invalidCSRFilePath(let path):
+                return "\(path) is not a valid CSR file path"
+            }
+        }
+    }
+
+    func run() throws {
+        let api = try makeService()
+
+        let type = try getCertificateType(matching: certificateType)
+
+        let csrContent = try readCSRContent(from: csrFile)
+
+        let endpoint = APIEndpoint.create(
+            certificateWithCertificateType: type,
+            csrContent: csrContent
+        )
+
+        _ = api
+            .request(endpoint)
+            .map { Certificate($0.data) }
+            .renderResult(format: common.outputFormat)
+    }
+
+    func getCertificateType(matching type: String) throws -> CertificateType {
+        guard let type = CertificateType(rawValue: certificateType) else {
+            throw CommandError.invalidCertificateType(certificateType)
+        }
+
+        return type
+    }
+
+    func readCSRContent(from filePath: String) throws -> String {
+        do {
+            return try String(contentsOfFile: csrFile, encoding: .utf8)
+        } catch {
+            throw CommandError.invalidCSRFilePath(csrFile)
+        }
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/API/CertificateType+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/CertificateType+ExpressibleByArgument.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+extension CertificateType: CaseIterable, ExpressibleByArgument, CustomStringConvertible {
+    public typealias AllCases = [CertificateType]
+    public static var allCases: AllCases {
+        [
+            .iOSDevelopment,
+            .iOSDistribution,
+            .macAppDistribution,
+            .macInstallerDistribution,
+            .macAppDevelopment,
+            .developerIdKext,
+            .developerIdApplication
+        ]
+    }
+
+    public init?(argument: String) {
+        self.init(rawValue: argument.uppercased())
+    }
+
+    public var description: String {
+        rawValue.lowercased()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/Certificate.swift
+++ b/Sources/AppStoreConnectCLI/Model/Certificate.swift
@@ -1,0 +1,44 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Foundation
+import SwiftyTextTable
+
+struct Certificate: ResultRenderable {
+    let name: String?
+    let type: CertificateType?
+    let content: String?
+    let platform: BundleIdPlatform?
+    let expirationDate: Date?
+}
+
+extension Certificate {
+    init(_ certificate: AppStoreConnect_Swift_SDK.Certificate) {
+        let attributes = certificate.attributes
+        self.init(name: attributes.name,
+                  type: attributes.certificateType,
+                  content: attributes.certificateContent,
+                  platform: attributes.platform,
+                  expirationDate: attributes.expirationDate)
+    }
+}
+
+extension Certificate: TableInfoProvider {
+    static func tableColumns() -> [TextTableColumn] {
+        [
+            TextTableColumn(header: "Name"),
+            TextTableColumn(header: "Type"),
+            TextTableColumn(header: "Platform"),
+            TextTableColumn(header: "Expiration Date"),
+        ]
+    }
+
+    var tableRow: [CustomStringConvertible] {
+        [
+            self.name ?? "",
+            self.type?.rawValue ?? "",
+            self.platform?.rawValue ?? "",
+            self.expirationDate ?? ""
+        ]
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/Certificate.swift
+++ b/Sources/AppStoreConnectCLI/Model/Certificate.swift
@@ -14,12 +14,17 @@ struct Certificate: ResultRenderable {
 
 extension Certificate {
     init(_ certificate: AppStoreConnect_Swift_SDK.Certificate) {
-        let attributes = certificate.attributes
-        self.init(name: attributes.name,
-                  type: attributes.certificateType,
-                  content: attributes.certificateContent,
-                  platform: attributes.platform,
-                  expirationDate: attributes.expirationDate)
+        self.init(certificate.attributes)
+    }
+
+    init(_ attributes: AppStoreConnect_Swift_SDK.Certificate.Attributes) {
+        self.init(
+            name: attributes.name,
+            type: attributes.certificateType,
+            content: attributes.certificateContent,
+            platform: attributes.platform,
+            expirationDate: attributes.expirationDate
+        )
     }
 }
 


### PR DESCRIPTION
Implement create certificate command.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Closes #85
- Create CreateCertificateCommand
- Create struct `Certificate`
- Makes `CertificateType` `ExpressibleByArgument`

# ⚠️ Items of Note

There will also be a `certificateContent` in CertificateResponse, which is too long to render in table. So I remove it from the table but keep it when output format is `--json` or `--yaml`

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage: 
`asc certificates create <certificate-type> --csr-file <csr-file>`

Example output: 
| Name | Type | Platform | Expiration Date |
| :-- | :-- | :-- | :-- |
| Mac Installer Distribution: Jo | MAC_INSTALLER_DISTRIBUTION | MAC_OS | 2021-04-22 06:09:33 +0000 |

## 🔨 How To Test

`swift run asc certificates create IOS_DEVELOPMENT --csr-file yourFilePath/CertificateSigningRequest.certSigningRequest`
