### PR TITLE
Use Operations in CreateCertificateCommand

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
@@ -24,16 +24,10 @@ struct CreateCertificateCommand: CommonParsableCommand {
 
         let csrContent = try String(contentsOfFile: csrFile, encoding: .utf8)
 
-        let endpoint = APIEndpoint.create(
-            certificateWithCertificateType: certificateType,
-            csrContent: csrContent
-        )
+        let options = CreateCertificateOptions(certificateType: certificateType, csrContent: csrContent)
 
-        let certificate = try service
-            .request(endpoint)
-            .map { Certificate($0.data) }
-            .await()
-
+        let certificate = try service.createCertificate(with: options).await()
+        
         certificate.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -25,6 +25,13 @@ class AppStoreConnectService {
         return operation.execute(with: dependencies)
     }
 
+    func createCertificate(with options: CreateCertificateOptions) -> AnyPublisher<Certificate, Error> {
+        let dependencies = CreateCertificateOperation.Dependencies(certificateResponse: request)
+        let operation = CreateCertificateOperation(options: options)
+
+        return operation.execute(with: dependencies)
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateCertificateOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateCertificateOperation.swift
@@ -1,0 +1,29 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct CreateCertificateOperation: APIOperation {
+
+    struct CreateCertificateDependencies {
+        let certificateResponse: (APIEndpoint<CertificateResponse>) -> Future<CertificateResponse, Error>
+    }
+
+    private let endpoint: APIEndpoint<CertificateResponse>
+
+    init(options: CreateCertificateOptions) {
+        endpoint = APIEndpoint.create(
+            certificateWithCertificateType: options.certificateType,
+            csrContent: options.csrContent
+        )
+    }
+
+    func execute(with dependencies: CreateCertificateDependencies) -> AnyPublisher<Certificate, Error> {
+        dependencies
+            .certificateResponse(endpoint)
+            .map { Certificate($0.data) }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/Options/CreateCertificateOptions.swift
+++ b/Sources/AppStoreConnectCLI/Services/Options/CreateCertificateOptions.swift
@@ -1,0 +1,9 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+struct CreateCertificateOptions {
+    let certificateType: CertificateType
+    let csrContent: String
+}

--- a/Tests/appstoreconnect-cliTests/Operations/CreateCertificateOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/CreateCertificateOperationTests.swift
@@ -1,0 +1,85 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+@testable import AppStoreConnectCLI
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+import XCTest
+
+final class CreateCertificateOperationTests: XCTestCase {
+    typealias Dependencies = CreateCertificateOperation.Dependencies
+
+    func testCreateCertificate_success() {
+        let dependencies: Dependencies = .createdSuccess
+
+        let options = CreateCertificateOptions(
+            certificateType: .iOSDevelopment,
+            csrContent: "")
+
+        let operation = CreateCertificateOperation(options: options)
+
+        let result = Result {
+            operation.execute(with: dependencies)
+        }
+
+        switch result {
+            case .success(let publisher):
+                _ = publisher.sink(
+                receiveCompletion: { _ in },
+                receiveValue: { certificate in
+                    XCTAssertEqual(certificate.name, "Mac Installer Distribution: Hello")
+                    XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS)
+                    XCTAssertEqual(certificate.content, "MIIFpDCCBIygAwIBAgIIbgb/7NS42MgwDQ")
+                })
+            default:
+                XCTFail("Error happened when parsing create certificate response")
+        }
+
+    }
+}
+
+private extension CreateCertificateOperationTests.Dependencies {
+    static let jsonDecoder: JSONDecoder = {
+        let jsonDecoder = JSONDecoder()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        jsonDecoder.dateDecodingStrategy = .formatted(dateFormatter)
+
+        return jsonDecoder
+    }()
+
+    static let createdSuccessResponse = """
+    {
+      "data" : {
+        "type" : "certificates",
+        "id" : "1234ABCD",
+        "attributes" : {
+          "serialNumber" : "6E06FFECD4B8D8C8",
+          "certificateContent" : "MIIFpDCCBIygAwIBAgIIbgb/7NS42MgwDQ",
+          "displayName" : "Hello",
+          "name" : "Mac Installer Distribution: Hello",
+          "csrContent" : null,
+          "platform" : "MAC_OS",
+          "expirationDate" : "2021-04-22T08:02:15.000+0000",
+          "certificateType" : "MAC_INSTALLER_DISTRIBUTION"
+        },
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/certificates/1234ABCD"
+        }
+      },
+      "links" : {
+        "self" : "https://api.appstoreconnect.apple.com/v1/certificates"
+      }
+    }
+    """.data(using: .utf8)!
+
+    static let createdSuccess = Self(
+        certificateResponse: { _ in
+            Future<CertificateResponse, Error> { promise in
+                let certificateResponse = try! jsonDecoder
+                    .decode(CertificateResponse.self, from: createdSuccessResponse)
+                promise(.success(certificateResponse))
+            }
+        }
+    )
+}

--- a/Tests/appstoreconnect-cliTests/Operations/CreateCertificateOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/CreateCertificateOperationTests.swift
@@ -19,22 +19,17 @@ final class CreateCertificateOperationTests: XCTestCase {
         let operation = CreateCertificateOperation(options: options)
 
         let result = Result {
-            operation.execute(with: dependencies)
+            try operation.execute(with: dependencies).await()
         }
 
         switch result {
-            case .success(let publisher):
-                _ = publisher.sink(
-                receiveCompletion: { _ in },
-                receiveValue: { certificate in
-                    XCTAssertEqual(certificate.name, "Mac Installer Distribution: Hello")
-                    XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS)
-                    XCTAssertEqual(certificate.content, "MIIFpDCCBIygAwIBAgIIbgb/7NS42MgwDQ")
-                })
+            case .success(let certificate):
+                XCTAssertEqual(certificate.name, "Mac Installer Distribution: Hello")
+                XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS)
+                XCTAssertEqual(certificate.content, "MIIFpDCCBIygAwIBAgIIbgb/7NS42MgwDQ")
             default:
                 XCTFail("Error happened when parsing create certificate response")
         }
-
     }
 }
 


### PR DESCRIPTION
We have implemented the `CreateCertificateCommand`, this PR is to apply Operations (our new way of fetching data) to this command 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add function `createCertificate` to `AppStoreConnectService`
- Create struct CreateCertificateOperation and CreateCertificateOptions
- Apply these to `CreateCertificateCommand`

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage: 

`asc certificates create [--api-issuer <uuid>] [--api-key-id <keyid>] [--csv] [--json] [--table] [--yaml] <certificate-type> <csr-file>`

## 🔨 How To Test

`swift run asc certificates create MAC_INSTALLER_DISTRIBUTION filePath`
