### PR TITLE
Implement ListDownloadCertificate Command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
@@ -8,7 +8,8 @@ struct CertificatesCommand: ParsableCommand {
         commandName: "certificates",
         abstract: "Create, download, and revoke signing certificates for app development and distribution.",
         subcommands: [
-            CreateCertificateCommand.self
+            CreateCertificateCommand.self,
+            ListDownloadCertificate.self
         ]
         // defaultSubcommand: ListCertificatesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
@@ -9,7 +9,7 @@ struct CertificatesCommand: ParsableCommand {
         abstract: "Create, download, and revoke signing certificates for app development and distribution.",
         subcommands: [
             CreateCertificateCommand.self,
-            ListDownloadCertificate.self
+            ListDownloadCertificates.self
         ]
         // defaultSubcommand: ListCertificatesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListDownloadCertificate.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListDownloadCertificate.swift
@@ -1,0 +1,115 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Combine
+import Foundation
+
+struct ListDownloadCertificate: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "Find and list certificates and download their data.")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Option(help: "The certificate’s serial number. (eg. 1A23BCDEF4G5D6C7)")
+    var filterSerial: String?
+
+    @Option(
+        parsing: .unconditional,
+        help: ArgumentHelp(
+            "Sort the results using the provided key \(Certificates.Sort.allCases).",
+            discussion: "The `-` prefix indicates descending order."
+        )
+    )
+    var sort: Certificates.Sort?
+
+    @Option(help: "The type of certificate to create \(CertificateType.allCases).")
+    var filterType: CertificateType?
+
+    @Option(help: "The certificate’s display name. (eg. Mac Installer Distribution: TeamName)")
+    var filterDisplayName: String?
+
+    @Option(help: "Limit the number of resources (maximum 200).")
+    var limit: Int?
+
+    @Option(help: "The file download path. (eg. ~/Documents)")
+    var downloadPath: String?
+
+    enum CommandError: LocalizedError {
+        case invalidPath(String)
+        case invalidContent
+        case notFound
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidPath(let path):
+                return "Download failed, please check the path \(path) you input and try again"
+            case .invalidContent:
+                return "The certificate in the response doesn't have a proper content"
+            case .notFound:
+                return "Unable to find certificate with input filters."
+            }
+        }
+    }
+
+    func run() throws {
+        let api = try makeService()
+
+        var filters = [Certificates.Filter]()
+
+        if let filterSerial = filterSerial {
+            filters.append(.serialNumber([filterSerial]))
+        }
+
+        if let filterType = filterType {
+            filters.append(.certificateType(filterType))
+        }
+
+        if let filterDisplayName = filterDisplayName {
+            filters.append(.displayName([filterDisplayName]))
+        }
+
+        let endpoint = APIEndpoint.listDownloadCertificates(
+            filter: filters,
+            sort: [sort].compactMap { $0 },
+            limit: limit
+        )
+
+        _ = api
+            .request(endpoint)
+            .map { $0.data.map(Certificate.init) }
+            .sink(
+                receiveCompletion: Renderers.CompletionRenderer().render,
+                receiveValue: { [common, downloadPath] (certificates: [Certificate]) in
+                    guard !certificates.isEmpty else {
+                        print(CommandError.notFound.errorDescription!)
+                        return
+                    }
+
+                    if let downloadPath = downloadPath {
+                        _ = certificates.map { (certificate: Certificate) in
+                            guard let content = certificate.content else {
+                                print(CommandError.invalidContent.errorDescription!)
+                                return
+                            }
+
+                            let filePath = "\(downloadPath)/\(certificate.serialNumber ?? "serial").cer"
+                            let result = FileManager
+                                .default
+                                .createFile(atPath: filePath, contents: Data(base64Encoded: content))
+
+                            result ?
+                                print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(filePath)")
+                                :
+                                print(CommandError.invalidPath(filePath).errorDescription!)
+                        }
+                    }
+
+                    Renderers.ResultRenderer(format: common.outputFormat).render(certificates)
+                }
+            )
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListDownloadCertificates.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListDownloadCertificates.swift
@@ -5,7 +5,7 @@ import ArgumentParser
 import Combine
 import Foundation
 
-struct ListDownloadCertificate: CommonParsableCommand {
+struct ListDownloadCertificates: CommonParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "list",
         abstract: "Find and list certificates and download their data.")

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListDownloadCertificates.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListDownloadCertificates.swift
@@ -64,7 +64,7 @@ struct ListDownloadCertificates: CommonParsableCommand {
         )
 
         let certificates = try service
-            .listCertificate(with: options)
+            .listCertificates(with: options)
             .await()
 
         if let downloadPath = downloadPath {

--- a/Sources/AppStoreConnectCLI/Model/API/Certificates.Sort+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/Certificates.Sort+ExpressibleByArgument.swift
@@ -1,0 +1,11 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+extension Certificates.Sort: Codable, ExpressibleByArgument, CustomStringConvertible {
+    public var description: String {
+        rawValue
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/Certificate.swift
+++ b/Sources/AppStoreConnectCLI/Model/Certificate.swift
@@ -10,6 +10,7 @@ struct Certificate: ResultRenderable {
     let content: String?
     let platform: BundleIdPlatform?
     let expirationDate: Date?
+    let serialNumber: String?
 }
 
 extension Certificate {
@@ -23,7 +24,8 @@ extension Certificate {
             type: attributes.certificateType,
             content: attributes.certificateContent,
             platform: attributes.platform,
-            expirationDate: attributes.expirationDate
+            expirationDate: attributes.expirationDate,
+            serialNumber: attributes.serialNumber
         )
     }
 }
@@ -31,6 +33,7 @@ extension Certificate {
 extension Certificate: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         [
+            TextTableColumn(header: "SerialNumber"),
             TextTableColumn(header: "Name"),
             TextTableColumn(header: "Type"),
             TextTableColumn(header: "Platform"),
@@ -40,6 +43,7 @@ extension Certificate: TableInfoProvider {
 
     var tableRow: [CustomStringConvertible] {
         [
+            self.serialNumber ?? "",
             self.name ?? "",
             self.type?.rawValue ?? "",
             self.platform?.rawValue ?? "",

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -25,6 +25,13 @@ class AppStoreConnectService {
         return operation.execute(with: dependencies)
     }
 
+    func listCertificate(with options: ListCertificatesOptions) -> AnyPublisher<[Certificate], Error> {
+        let dependencies = ListCertificatesOpertaion.Dependencies(certificatesResponse: request)
+        let operation = ListCertificatesOpertaion(options: options)
+
+        return operation.execute(with: dependencies)
+    }
+
     func createCertificate(with options: CreateCertificateOptions) -> AnyPublisher<Certificate, Error> {
         let dependencies = CreateCertificateOperation.Dependencies(certificateResponse: request)
         let operation = CreateCertificateOperation(options: options)

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -25,7 +25,7 @@ class AppStoreConnectService {
         return operation.execute(with: dependencies)
     }
 
-    func listCertificate(with options: ListCertificatesOptions) -> AnyPublisher<[Certificate], Error> {
+    func listCertificates(with options: ListCertificatesOptions) -> AnyPublisher<[Certificate], Error> {
         let dependencies = ListCertificatesOpertaion.Dependencies(certificatesResponse: request)
         let operation = ListCertificatesOpertaion(options: options)
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -26,8 +26,8 @@ class AppStoreConnectService {
     }
 
     func listCertificates(with options: ListCertificatesOptions) -> AnyPublisher<[Certificate], Error> {
-        let dependencies = ListCertificatesOpertaion.Dependencies(certificatesResponse: request)
-        let operation = ListCertificatesOpertaion(options: options)
+        let dependencies = ListCertificatesOperation.Dependencies(certificatesResponse: request)
+        let operation = ListCertificatesOperation(options: options)
 
         return operation.execute(with: dependencies)
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -13,7 +13,7 @@ struct ListCertificatesOpertaion: APIOperation {
     enum ListCertificatesError: LocalizedError {
         case couldNotFindCertificate
 
-        var failureReason: String? {
+        var errorDescription: String? {
             switch self {
             case .couldNotFindCertificate:
                 return "Couldn't find certificate with input filters"

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -1,0 +1,63 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ListCertificatesOpertaion: APIOperation {
+
+    struct ListCertificatesDependencies {
+        let certificatesResponse: (APIEndpoint<CertificatesResponse>) -> Future<CertificatesResponse, Error>
+    }
+
+    enum ListCertificatesError: LocalizedError {
+        case couldNotCertificate
+
+        var failureReason: String? {
+            switch self {
+            case .couldNotCertificate:
+                return "Couldn't find certificate with input filters"
+            }
+        }
+    }
+
+    private let endpoint: APIEndpoint<CertificatesResponse>
+
+    init(options: ListCertificatesOptions) {
+        typealias Filter = Certificates.Filter
+
+        var filters = [Certificates.Filter]()
+
+        if let filterSerial = options.filterSerial {
+            filters.append(.serialNumber([filterSerial]))
+        }
+
+        if let filterType = options.filterType {
+            filters.append(.certificateType(filterType))
+        }
+
+        if let filterDisplayName = options.filterDisplayName {
+            filters.append(.displayName([filterDisplayName]))
+        }
+
+        endpoint = APIEndpoint.listDownloadCertificates(
+            filter: filters,
+            sort: [options.sort].compactMap { $0 },
+            limit: options.limit
+        )
+    }
+
+    func execute(with dependencies: ListCertificatesDependencies) -> AnyPublisher<[Certificate], Error> {
+        dependencies
+            .certificatesResponse(endpoint)
+            .tryMap { (response: CertificatesResponse) -> [Certificate] in
+                guard !response.data.isEmpty else {
+                    throw ListCertificatesError.couldNotCertificate
+                }
+
+                return response.data.map(Certificate.init)
+            }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -11,11 +11,11 @@ struct ListCertificatesOpertaion: APIOperation {
     }
 
     enum ListCertificatesError: LocalizedError {
-        case couldNotCertificate
+        case couldNotFindCertificate
 
         var failureReason: String? {
             switch self {
-            case .couldNotCertificate:
+            case .couldNotFindCertificate:
                 return "Couldn't find certificate with input filters"
             }
         }
@@ -52,7 +52,7 @@ struct ListCertificatesOpertaion: APIOperation {
             .certificatesResponse(endpoint)
             .tryMap { (response: CertificatesResponse) -> [Certificate] in
                 guard !response.data.isEmpty else {
-                    throw ListCertificatesError.couldNotCertificate
+                    throw ListCertificatesError.couldNotFindCertificate
                 }
 
                 return response.data.map(Certificate.init)

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -4,7 +4,7 @@ import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
 
-struct ListCertificatesOpertaion: APIOperation {
+struct ListCertificatesOperation: APIOperation {
 
     struct ListCertificatesDependencies {
         let certificatesResponse: (APIEndpoint<CertificatesResponse>) -> Future<CertificatesResponse, Error>

--- a/Sources/AppStoreConnectCLI/Services/Options/ListCertificatesOptions.swift
+++ b/Sources/AppStoreConnectCLI/Services/Options/ListCertificatesOptions.swift
@@ -1,0 +1,12 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+struct ListCertificatesOptions {
+    let filterSerial: String?
+    let sort: Certificates.Sort?
+    let filterType: CertificateType?
+    let filterDisplayName: String?
+    let limit: Int?
+}

--- a/Tests/appstoreconnect-cliTests/Operations/ListCertificateOperations.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListCertificateOperations.swift
@@ -7,8 +7,8 @@ import Foundation
 import XCTest
 
 final class ListCertificateOperationsTests: XCTestCase {
-    typealias Dependencies = ListCertificatesOpertaion.Dependencies
-    typealias OperationError = ListCertificatesOpertaion.ListCertificatesError
+    typealias Dependencies = ListCertificatesOperation.Dependencies
+    typealias OperationError = ListCertificatesOperation.ListCertificatesError
 
     func testCouldNotFindCertificate() {
         let dependencies: Dependencies = .noCertificate
@@ -22,7 +22,7 @@ final class ListCertificateOperationsTests: XCTestCase {
 
         let expectedError = OperationError.couldNotFindCertificate
 
-        let operation = ListCertificatesOpertaion(options: options)
+        let operation = ListCertificatesOperation(options: options)
 
         let result = Result {
             try operation.execute(with: dependencies).await()

--- a/Tests/appstoreconnect-cliTests/Operations/ListCertificateOperations.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListCertificateOperations.swift
@@ -1,0 +1,69 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+@testable import AppStoreConnectCLI
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+import XCTest
+
+final class ListCertificateOperationsTests: XCTestCase {
+    typealias Dependencies = ListCertificatesOpertaion.Dependencies
+    typealias OperationError = ListCertificatesOpertaion.ListCertificatesError
+
+    func testCouldNotFindCertificate() {
+        let dependencies: Dependencies = .noCertificate
+        let options = ListCertificatesOptions(
+            filterSerial: nil,
+            sort: nil,
+            filterType: nil,
+            filterDisplayName: nil,
+            limit: nil
+        )
+
+        let expectedError = OperationError.couldNotFindCertificate
+
+        let operation = ListCertificatesOpertaion(options: options)
+
+        let result = Result {
+            try operation.execute(with: dependencies).await()
+        }
+
+        switch result {
+        case .failure(let error as OperationError):
+            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+        default:
+            XCTFail("Expected failed with \(expectedError), got: \(result)")
+        }
+    }
+}
+
+private extension ListCertificateOperationsTests.Dependencies {
+    static let jsonDecoder = JSONDecoder()
+
+    static let noCertificatesResponse = """
+    {
+      "data" : [ ],
+      "links": {
+        "self": "https://api.appstoreconnect.apple.com/v1/certificates"
+      },
+      "meta" : {
+        "paging" : {
+          "total" : 0,
+          "limit" : 50
+        }
+      }
+    }
+    """.data(using: .utf8)!
+
+    static let noCertificate = Self(
+        certificatesResponse: { _ in
+            Future<CertificatesResponse, Error> { promise in
+                let certificatesResponse = try! jsonDecoder.decode(
+                    CertificatesResponse.self, from: noCertificatesResponse
+                )
+
+                promise(.success(certificatesResponse))
+            }
+        }
+    )
+}


### PR DESCRIPTION
This PR is to Implement the list and download certificates feature.
Closes issue #86 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add `serialNumber` to model `Certificate` 
- Create `ListCertificatesOptions` and `ListCertificatesOpertaion`
- Implement `ListDownloadCertificates`, support viewing and downloading certificates


# 🧐🗒 Reviewer Notes

## 💁 Example

Usage: `asc certificates list [--filter-serial <filter-serial>] [--sort <sort>] [--filter-type <filter-type>] [--filter-display-name <filter-display-name>] [--limit <limit>] [--download-path <download-path>]`

Sample output:
- without download file path: 

| SerialNumber | Name | Display Name |  Platform | Type | Expiration Date | 
| --- | --- | --- | --- | --- | --- |
| XXXYY | iOS Development: Created via API | Something | IOS | IOS_DEVELOPMENT | 2021-04-22 01:23:45 +0000 | 

- with download file path:

`📥 Certificate 'iOS Development: Created via API' downloaded to: /Documents/github/XXXYY.cer`
| SerialNumber | Name | Display Name |  Platform | Type | Expiration Date | 
| --- | --- | --- | --- | --- | --- |
| XXXYY | iOS Development: Created via API | Something | IOS | IOS_DEVELOPMENT | 2021-04-22 01:23:45 +0000 | 

## 🔨 How To Test
`swift run asc certificates list`

`swift run asc certificates list --download-path ~/Documents/github `