### PR TITLE
Implement Revoke Certificates Command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
@@ -10,7 +10,8 @@ struct CertificatesCommand: ParsableCommand {
         subcommands: [
             CreateCertificateCommand.self,
             ListCertificatesCommand.self,
-            ReadCertificateCommand.self
+            ReadCertificateCommand.self,
+            RevokeCertificatesCommand.self
         ]
         // defaultSubcommand: ListCertificatesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
@@ -1,0 +1,33 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import Foundation
+
+struct RevokeCertificatesCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "revoke",
+        abstract: "Revoke lost, stolen, compromised, or expiring signing certificates."
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The certificates' serial numbers. (eg. 1A23BCDEF4G5D6C7)")
+    var serials: [String]
+
+    func validate() throws {
+        if serials.isEmpty {
+            throw ValidationError("Invalid input, you must provide at least one certificate serial number")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+        _ = try service.revokeCertificates(serials: serials)
+
+        serials.forEach {
+            print("🚮 Certificate `\($0)` revoked.")
+        }
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -43,7 +43,7 @@ class AppStoreConnectService {
                 .execute(with: requestor)
                 .await()
                 .id
-            }
+        }
 
         _ = try RevokeCertificatesOperation(options: .init(ids: certificatesIds))
             .execute(with: requestor)

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -37,7 +37,7 @@ class AppStoreConnectService {
         CreateCertificateOperation(options: options).execute(with: requestor)
     }
 
-    func revokeCertificates(serials: [String]) throws -> [Void] {
+    func revokeCertificates(serials: [String]) throws {
         let certificatesIds = try serials.map {
             try ReadCertificateOperation(options: .init(serial: $0))
                 .execute(with: requestor)
@@ -45,7 +45,7 @@ class AppStoreConnectService {
                 .id
             }
 
-        return try RevokeCertificatesOperation(options: .init(ids: certificatesIds))
+        _ = try RevokeCertificatesOperation(options: .init(ids: certificatesIds))
             .execute(with: requestor)
             .awaitMany()
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadCertificateOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadCertificateOperation.swift
@@ -36,14 +36,14 @@ struct ReadCertificateOperation: APIOperation {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Certificate, Swift.Error> {
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<AppStoreConnect_Swift_SDK.Certificate, Swift.Error> {
         requestor.request(endpoint)
-            .tryMap { [serial = options.serial] (response: CertificatesResponse) -> Certificate in
+            .tryMap { [serial = options.serial] (response: CertificatesResponse) -> AppStoreConnect_Swift_SDK.Certificate in
                 switch response.data.count {
                 case 0:
                     throw Error.couldNotFindCertificate(serial)
                 case 1:
-                    return Certificate(response.data.first!)
+                    return response.data.first!
                 default:
                     throw Error.serialNumberNotUnique(serial)
                 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/RevokeCertificateOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/RevokeCertificateOperation.swift
@@ -1,0 +1,29 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct RevokeCertificatesOperation: APIOperation {
+
+    struct Options {
+        let ids: [String]
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Void, Swift.Error> {
+        let requests = options.ids.compactMap {
+                requestor
+                    .request(APIEndpoint.revokeCertificate(withId: $0))
+                    .eraseToAnyPublisher()
+            }
+
+        return Publishers.ConcatenateMany(requests).eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/RevokeCertificateOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/RevokeCertificateOperation.swift
@@ -16,12 +16,10 @@ struct RevokeCertificatesOperation: APIOperation {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Void, Swift.Error> {
-        let requests = options.ids.compactMap {
-                requestor
-                    .request(APIEndpoint.revokeCertificate(withId: $0))
-                    .eraseToAnyPublisher()
-            }
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Void, Error> {
+        let requests = options.ids.map {
+            requestor.request(APIEndpoint.revokeCertificate(withId: $0))
+        }
 
         return Publishers.ConcatenateMany(requests).eraseToAnyPublisher()
     }

--- a/Tests/appstoreconnect-cliTests/Operations/ReadCertificateOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ReadCertificateOperationTests.swift
@@ -42,7 +42,8 @@ final class ReadCertificateOperationTests: XCTestCase {
         }
 
         switch result {
-        case .success(let certificate):
+        case .success(let sdkCertificate):
+            let certificate = Certificate(sdkCertificate)
             XCTAssertEqual(certificate.name, "Mac Installer Distribution: Hello")
             XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS)
             XCTAssertEqual(certificate.content, "MIIFpDCCBIygAwIBAgIIbgb/7NS42MgwDQ")


### PR DESCRIPTION
Implement Revoke Certificate Command, Closes #87 
 
# 📝 Summary of Changes

Changes proposed in this pull request:

- Implement RevokeCertificatesCommand

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage `asc certificates revoke [<serials> ...]`

Example Output: 
```
🚮 Certificate `12345ABCDE` revoked.
🚮 Certificate `54321ZXCVB` revoked.
```

## 🔨 How To Test

`swift run certificates revoke  12345ABCDE 54321ZXCVB`

