### PR TITLE
Remove Dependencies pattern in favour of using requestors

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -6,58 +6,35 @@ import Foundation
 
 class AppStoreConnectService {
     private let provider: APIProvider
+    private let requestor: EndpointRequestor
 
     init(configuration: APIConfiguration) {
         provider = APIProvider(configuration: configuration)
+        requestor = DefaultEndpointRequestor(provider: provider)
     }
 
     func listUsers(with options: ListUsersOptions) -> AnyPublisher<[User], Error> {
-        let dependencies = ListUsersOperation.Dependencies(users: request)
-        let operation = ListUsersOperation(options: options)
-
-        return operation.execute(with: dependencies)
+        ListUsersOperation(options: options).execute(with: requestor)
     }
 
     func getUserInfo(with options: GetUserInfoOptions) -> AnyPublisher<User, Error> {
-        let dependencies = GetUserInfoOperation.Dependencies(usersResponse: request)
-        let operation = GetUserInfoOperation(options: options)
-
-        return operation.execute(with: dependencies)
+        GetUserInfoOperation(options: options).execute(with: requestor)
     }
 
     func listCertificates(with options: ListCertificatesOptions) -> AnyPublisher<[Certificate], Error> {
-        let dependencies = ListCertificatesOperation.Dependencies(certificatesResponse: request)
-        let operation = ListCertificatesOperation(options: options)
-
-        return operation.execute(with: dependencies)
+        ListCertificatesOperation(options: options).execute(with: requestor)
     }
 
     func createCertificate(with options: CreateCertificateOptions) -> AnyPublisher<Certificate, Error> {
-        let dependencies = CreateCertificateOperation.Dependencies(certificateResponse: request)
-        let operation = CreateCertificateOperation(options: options)
-
-        return operation.execute(with: dependencies)
+        CreateCertificateOperation(options: options).execute(with: requestor)
     }
 
     func inviteBetaTesterToGroups(with options: InviteBetaTesterOptions) throws -> AnyPublisher<BetaTester, Error> {
-        let dependencies = InviteTesterOperation.Dependencies(
-            appsResponse: request,
-            betaGroupsResponse: request,
-            betaTesterResponse: request
-        )
-
-        let operation = InviteTesterOperation(options: options)
-
-        return try operation.execute(with: dependencies)
+        try InviteTesterOperation(options: options).execute(with: requestor)
     }
 
     func createBetaGroup(with options: CreateBetaGroupOptions) -> AnyPublisher<BetaGroup, Error> {
-        let dependencies = CreateBetaGroupOperation.Dependencies(
-            apps: request,
-            createBetaGroup: request)
-        let operation = CreateBetaGroupOperation(options: options)
-
-        return operation.execute(with: dependencies)
+        CreateBetaGroupOperation(options: options).execute(with: requestor)
     }
 
     /// Make a request for something `Decodable`.

--- a/Sources/AppStoreConnectCLI/Services/EndpointRequestor.swift
+++ b/Sources/AppStoreConnectCLI/Services/EndpointRequestor.swift
@@ -1,0 +1,26 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+protocol EndpointRequestor {
+    func request<T: Decodable>(_ endpoint: APIEndpoint<T>) -> Future<T, Error>
+    func request(_ endpoint: APIEndpoint<Void>) -> Future<Void, Error>
+}
+
+struct DefaultEndpointRequestor: EndpointRequestor {
+    let provider: APIProvider
+
+    func request<T: Decodable>(_ endpoint: APIEndpoint<T>) -> Future<T, Error> {
+        Future { [provider] promise in
+            provider.request(endpoint, completion: promise)
+        }
+    }
+
+    func request(_ endpoint: APIEndpoint<Void>) -> Future<Void, Error> {
+        Future { [provider] promise in
+            provider.request(endpoint, completion: promise)
+        }
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/APIOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/APIOperation.swift
@@ -5,10 +5,9 @@ import Foundation
 
 protocol APIOperation {
     associatedtype Options
-    associatedtype Dependencies
     associatedtype Output
 
     init(options: Options)
 
-    func execute(with dependencies: Dependencies) throws -> AnyPublisher<Output, Error>
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Output, Error>
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateBetaGroupOperation.swift
@@ -5,10 +5,6 @@ import Combine
 import Foundation
 
 struct CreateBetaGroupOperation: APIOperation {
-    struct CreateBetaGroupDependencies {
-        let apps: (APIEndpoint<AppsResponse>) -> Future<AppsResponse, Error>
-        let createBetaGroup: (APIEndpoint<BetaGroupResponse>) -> Future<BetaGroupResponse, Error>
-    }
 
     private let options: CreateBetaGroupOptions
 
@@ -19,13 +15,13 @@ struct CreateBetaGroupOperation: APIOperation {
     private typealias AppAttributes = AppStoreConnect_Swift_SDK.App.Attributes
     private typealias BetaGroupAttributes = AppStoreConnect_Swift_SDK.BetaGroup.Attributes
 
-    func execute(with dependencies: CreateBetaGroupDependencies) -> AnyPublisher<BetaGroup, Error> {
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<BetaGroup, Error> {
         let options = self.options
 
         let app = GetAppsOperation(
                 options: .init(bundleIds: [options.appBundleId])
             )
-            .execute(with: .init(apps: dependencies.apps))
+            .execute(with: requestor)
             .compactMap(\.first)
 
         let appAndGroupAttributes = app
@@ -38,7 +34,7 @@ struct CreateBetaGroupOperation: APIOperation {
                     publicLinkLimitEnabled: options.publicLinkLimit != nil
                 )
 
-                let betaGroupResponse = dependencies.createBetaGroup(endpoint)
+                let betaGroupResponse = requestor.request(endpoint)
 
                 return betaGroupResponse
                     .map({ (app.attributes, $0.data.attributes) })

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateCertificateOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateCertificateOperation.swift
@@ -6,10 +6,6 @@ import Foundation
 
 struct CreateCertificateOperation: APIOperation {
 
-    struct CreateCertificateDependencies {
-        let certificateResponse: (APIEndpoint<CertificateResponse>) -> Future<CertificateResponse, Error>
-    }
-
     private let endpoint: APIEndpoint<CertificateResponse>
 
     init(options: CreateCertificateOptions) {
@@ -19,9 +15,9 @@ struct CreateCertificateOperation: APIOperation {
         )
     }
 
-    func execute(with dependencies: CreateCertificateDependencies) -> AnyPublisher<Certificate, Error> {
-        dependencies
-            .certificateResponse(endpoint)
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Certificate, Error> {
+        requestor
+            .request(endpoint)
             .map { Certificate($0.data) }
             .eraseToAnyPublisher()
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetAppsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetAppsOperation.swift
@@ -5,9 +5,6 @@ import Combine
 import Foundation
 
 struct GetAppsOperation: APIOperation {
-    struct GetAppsDependencies {
-        let apps: (APIEndpoint<AppsResponse>) -> Future<AppsResponse, Error>
-    }
 
     enum GetAppIdsError: LocalizedError {
         case couldntFindAnyAppsMatching(bundleIds: [String])
@@ -30,12 +27,12 @@ struct GetAppsOperation: APIOperation {
     }
 
     func execute(
-        with dependencies: GetAppsDependencies
+        with requestor: EndpointRequestor
     ) -> AnyPublisher<[AppStoreConnect_Swift_SDK.App], Error> {
         let bundleIds = options.bundleIds
         let endpoint = APIEndpoint.apps(filters: [.bundleId(bundleIds)])
 
-        return dependencies.apps(endpoint)
+        return requestor.request(endpoint)
             .tryMap { (response: AppsResponse) throws -> [AppStoreConnect_Swift_SDK.App] in
                 guard !response.data.isEmpty else {
                     throw GetAppIdsError.couldntFindAnyAppsMatching(bundleIds: bundleIds)
@@ -53,4 +50,5 @@ struct GetAppsOperation: APIOperation {
             }
             .eraseToAnyPublisher()
     }
+
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaTesterInfoOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaTesterInfoOperation.swift
@@ -6,10 +6,6 @@ import Foundation
 
 struct GetBetaTesterInfoOperation: APIOperation {
 
-    struct GetBetaTesterInfoDependencies {
-        let betaTesterResponse: (APIEndpoint<BetaTesterResponse>) -> Future<BetaTesterResponse, Error>
-    }
-
     private let endpoint: APIEndpoint<BetaTesterResponse>
 
     init(options: GetBetaTesterInfoOptions) {
@@ -18,8 +14,8 @@ struct GetBetaTesterInfoOperation: APIOperation {
             include: [.betaGroups, .apps])
     }
 
-    func execute(with dependencies: GetBetaTesterInfoDependencies) -> AnyPublisher<BetaTester, Error> {
-        dependencies.betaTesterResponse(endpoint)
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<BetaTester, Error> {
+        requestor.request(endpoint)
             .map { BetaTester($0.data, $0.included) }
             .eraseToAnyPublisher()
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
@@ -6,10 +6,6 @@ import Foundation
 
 struct GetUserInfoOperation: APIOperation {
 
-    struct GetUserInfoDependencies {
-        let usersResponse: (APIEndpoint<UsersResponse>) -> Future<UsersResponse, Error>
-    }
-
     enum GetUserInfoError: LocalizedError {
         case couldNotFindUser(email: String)
 
@@ -30,8 +26,8 @@ struct GetUserInfoOperation: APIOperation {
         email = options.email
     }
 
-    func execute(with dependencies: GetUserInfoDependencies) -> AnyPublisher<User, Error> {
-        dependencies.usersResponse(endpoint)
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<User, Error> {
+        requestor.request(endpoint)
             .tryMap { [email] response in
                 let users = User.fromAPIResponse(response)
                 guard let user = users.first, users.count == 1 else {

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -6,10 +6,6 @@ import Foundation
 
 struct ListCertificatesOperation: APIOperation {
 
-    struct ListCertificatesDependencies {
-        let certificatesResponse: (APIEndpoint<CertificatesResponse>) -> Future<CertificatesResponse, Error>
-    }
-
     enum ListCertificatesError: LocalizedError {
         case couldNotFindCertificate
 
@@ -47,9 +43,8 @@ struct ListCertificatesOperation: APIOperation {
         )
     }
 
-    func execute(with dependencies: ListCertificatesDependencies) -> AnyPublisher<[Certificate], Error> {
-        dependencies
-            .certificatesResponse(endpoint)
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<[Certificate], Error> {
+        requestor.request(endpoint)
             .tryMap { (response: CertificatesResponse) -> [Certificate] in
                 guard !response.data.isEmpty else {
                     throw ListCertificatesError.couldNotFindCertificate

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
@@ -5,10 +5,6 @@ import Combine
 
 struct ListUsersOperation: APIOperation {
 
-    struct ListUsersDependencies {
-        let users: (APIEndpoint<UsersResponse>) -> Future<UsersResponse, Error>
-    }
-
     private let endpoint: APIEndpoint<UsersResponse>
 
     init(options: ListUsersOptions) {
@@ -42,8 +38,8 @@ struct ListUsersOperation: APIOperation {
         )
     }
 
-    func execute(with dependencies: ListUsersDependencies) -> AnyPublisher<[User], Error> {
-        dependencies.users(endpoint)
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<[User], Error> {
+        requestor.request(endpoint)
             .map(User.fromAPIResponse)
             .eraseToAnyPublisher()
     }

--- a/Tests/appstoreconnect-cliTests/Operations/TestRequestors.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/TestRequestors.swift
@@ -1,0 +1,56 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+@testable import AppStoreConnectCLI
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+extension EndpointRequestor {
+    func request<T>(_ endpoint: APIEndpoint<T>) -> Future<T, Error> where T : Decodable {
+        Future { $0(.failure(TestError.somethingBadHappened)) }
+    }
+
+    func request(_ endpoint: APIEndpoint<Void>) -> Future<Void, Error> {
+        Future { $0(.failure(TestError.somethingBadHappened)) }
+    }
+}
+
+struct OneEndpointTestRequestor<U: Decodable>: EndpointRequestor {
+    let response: (APIEndpoint<U>) -> Future<U, Error>
+
+    func request<T>(_ endpoint: APIEndpoint<T>) -> Future<T, Error> where T: Decodable {
+        guard
+            let endpoint = endpoint as? APIEndpoint<U>,
+            let response = response(endpoint) as? Future<T, Error>
+        else {
+            return Future { $0(.failure(TestError.somethingBadHappened)) }
+        }
+
+        return response
+    }
+}
+
+struct TwoEndpointTestRequestor<U: Decodable, V: Decodable>: EndpointRequestor {
+    let response: (APIEndpoint<U>) -> Future<U, Error>
+    let response2: (APIEndpoint<V>) -> Future<V, Error>
+
+    func request<T>(_ endpoint: APIEndpoint<T>) -> Future<T, Error> where T : Decodable {
+        if
+            let endpoint = endpoint as? APIEndpoint<U>,
+            let response = response(endpoint) as? Future<T, Error>
+        {
+            return response
+        }
+
+        if
+            let endpoint = endpoint as? APIEndpoint<V>,
+            let response = response2(endpoint) as? Future<T, Error>
+        {
+            return response
+        }
+
+        return Future { $0(.failure(TestError.somethingBadHappened)) }
+    }
+}
+
+struct FailureTestRequestor: EndpointRequestor {}


### PR DESCRIPTION
This is an attempt to make things simpler with a Requestor interface rather than defining dependencies per operation

# 📝 Summary of Changes

Changes proposed in this pull request:

- Delete Dependencies associated type on `APIOperation`
- Add EndpointRequestor and DefaultEndpointRequestor
- Add supporting test requestors
- Update operations and tests to use new requestors

# ⚠️ Items of Note

There are some generic casting dances that need to happen to support testing. However the operation code has become cleaner as a result. The requestor can be passed to all operations without needing to create multiple different kinds of dependencies.

# 🧐🗒 Reviewer Notes

Please provide any thoughts / feedback on this change
