### PR TITLE
Move Beta Group Operation Output to be a typealias

### DIFF
--- a/Sources/AppStoreConnectCLI/Model/API/ExtendedBetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/ExtendedBetaGroup.swift
@@ -1,8 +1,0 @@
-// Copyright 2020 Itty Bitty Apps Pty Ltd
-
-import AppStoreConnect_Swift_SDK
-
-struct ExtendedBetaGroup {
-    let app: AppStoreConnect_Swift_SDK.App
-    let betaGroup: AppStoreConnect_Swift_SDK.BetaGroup
-}

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -47,15 +47,18 @@ struct BetaGroup: TableInfoProvider, ResultRenderable, Equatable {
 }
 
 extension BetaGroup {
-    init(extendedBetaGroup: ExtendedBetaGroup) {
-        app = App(extendedBetaGroup.app)
-        groupName = extendedBetaGroup.betaGroup.attributes?.name
-        isInternal = extendedBetaGroup.betaGroup.attributes?.isInternalGroup
-        publicLink = extendedBetaGroup.betaGroup.attributes?.publicLink
-        publicLinkEnabled = extendedBetaGroup.betaGroup.attributes?.publicLinkEnabled
-        publicLinkLimit = extendedBetaGroup.betaGroup.attributes?.publicLinkLimit
-        publicLinkLimitEnabled = extendedBetaGroup.betaGroup.attributes?.publicLinkLimitEnabled
-        creationDate = extendedBetaGroup.betaGroup.attributes?.createdDate?.formattedDate
+    init(
+        _ apiApp: AppStoreConnect_Swift_SDK.App,
+        _ apiBetaGroup: AppStoreConnect_Swift_SDK.BetaGroup
+    ) {
+        app = App(apiApp)
+        groupName = apiBetaGroup.attributes?.name
+        isInternal = apiBetaGroup.attributes?.isInternalGroup
+        publicLink = apiBetaGroup.attributes?.publicLink
+        publicLinkEnabled = apiBetaGroup.attributes?.publicLinkEnabled
+        publicLinkLimit = apiBetaGroup.attributes?.publicLinkLimit
+        publicLinkLimitEnabled = apiBetaGroup.attributes?.publicLinkLimitEnabled
+        creationDate = apiBetaGroup.attributes?.createdDate?.formattedDate
     }
 }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateBetaGroupOperation.swift
@@ -13,13 +13,18 @@ struct CreateBetaGroupOperation: APIOperation {
         let publicLinkLimit: Int?
     }
 
+    typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
+    typealias App = AppStoreConnect_Swift_SDK.App
+
+    typealias Output = (app: App, betaGroup: BetaGroup)
+
     private let options: Options
 
     init(options: Options) {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) -> AnyPublisher<ExtendedBetaGroup, Error> {
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Error> {
         let endpoint = APIEndpoint.create(
             betaGroupForAppWithId: options.app.id,
             name: options.groupName,
@@ -30,7 +35,7 @@ struct CreateBetaGroupOperation: APIOperation {
 
         return requestor
             .request(endpoint)
-            .map { ExtendedBetaGroup(app: self.options.app, betaGroup: $0.data) }
+            .map { (self.options.app, $0.data) }
             .eraseToAnyPublisher()
     }
 }

--- a/Tests/appstoreconnect-cliTests/Operations/CreateBetaGroupOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/CreateBetaGroupOperationTests.swift
@@ -16,7 +16,7 @@ final class CreateBetaGroupOperationTests: XCTestCase {
         }
     )
 
-    func testExecute_success() {
+    func testExecute_success() throws {
         let app = Self.appsResponse.data.first!
 
         let options = Options(
@@ -26,17 +26,10 @@ final class CreateBetaGroupOperationTests: XCTestCase {
             publicLinkLimit: nil
         )
 
-        let operation = Operation(options: options)
+        let output = try Operation(options: options).execute(with: successRequestor).await()
 
-        let result = Result { try operation.execute(with: successRequestor).await() }
-
-        switch result {
-        case .success(let output):
-            XCTAssertEqual(output.app.id, app.id)
-            XCTAssertEqual(output.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
-        case .failure(let error):
-            XCTFail("Expected success, got: \(error)")
-        }
+        XCTAssertEqual(output.app.id, app.id)
+        XCTAssertEqual(output.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
     }
 
     func testExecute_propagatesUpstreamErrors() {

--- a/Tests/appstoreconnect-cliTests/Operations/CreateBetaGroupOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/CreateBetaGroupOperationTests.swift
@@ -31,9 +31,9 @@ final class CreateBetaGroupOperationTests: XCTestCase {
         let result = Result { try operation.execute(with: successRequestor).await() }
 
         switch result {
-        case .success(let extendedBetaGroup):
-            XCTAssertEqual(extendedBetaGroup.app.id, app.id)
-            XCTAssertEqual(extendedBetaGroup.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
+        case .success(let output):
+            XCTAssertEqual(output.app.id, app.id)
+            XCTAssertEqual(output.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
         case .failure(let error):
             XCTFail("Expected success, got: \(error)")
         }

--- a/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
@@ -14,19 +14,14 @@ final class ListBetaGroupsOperationTests: XCTestCase {
         response: { _ in Future({ $0(.success(response)) }) }
     )
 
-    func testExecute_success() {
+    func testExecute_success() throws {
         let operation = Operation(options: Options(appIds: []))
 
-        let result = Result { try operation.execute(with: successRequestor).await() }
+        let output = try operation.execute(with: successRequestor).await()
 
-        switch result {
-        case .success(let output):
-            XCTAssertEqual(output.count, 1)
-            XCTAssertEqual(output.first?.app.id, "1234567890")
-            XCTAssertEqual(output.first?.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
-        case .failure(let error):
-            XCTFail("Expected success, got: \(error.localizedDescription)")
-        }
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(output.first?.app.id, "1234567890")
+        XCTAssertEqual(output.first?.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
     }
 
     func testExecute_propagatesUpstreamErrors() {

--- a/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
@@ -20,10 +20,10 @@ final class ListBetaGroupsOperationTests: XCTestCase {
         let result = Result { try operation.execute(with: successRequestor).await() }
 
         switch result {
-        case .success(let extendedBetaGroups):
-            XCTAssertEqual(extendedBetaGroups.count, 1)
-            XCTAssertEqual(extendedBetaGroups.first?.app.id, "1234567890")
-            XCTAssertEqual(extendedBetaGroups.first?.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
+        case .success(let output):
+            XCTAssertEqual(output.count, 1)
+            XCTAssertEqual(output.first?.app.id, "1234567890")
+            XCTAssertEqual(output.first?.betaGroup.id, "12345678-90ab-cdef-1234-567890abcdef")
         case .failure(let error):
             XCTFail("Expected success, got: \(error.localizedDescription)")
         }


### PR DESCRIPTION
Simple PR that removes an unnecessary intermediate type and simplifies some tests

# 📝 Summary of Changes

Changes proposed in this pull request:

- Delete ExtendedBetaGroup
- Add Output typealiases
- Make success tests throw instead of requiring a result type
