### PR TITLE
Implement ListBetaTesterCommand

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -13,30 +13,61 @@ struct ListBetaTestersCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(help: "Beta tester's email.")
-    var filterEmail: String?
-
-    @Option(help: "Beta tester's first name.")
-    var filterFirstName: String?
-
-    @Option(help: "Beta tester's last name.")
-    var filterLastName: String?
+    @Option(
+        help: ArgumentHelp(
+            "Beta tester's email.",
+            valueName: "email"
+        )
+    ) var filterEmail: String?
 
     @Option(
-        help: """
-        An invite type that indicates if a beta tester was invited by an email invite or used a TestFlight public link to join a beta test. \n
-        Possible values \(BetaInviteType.allCases).
-        """
+        help: ArgumentHelp(
+            "Beta tester's first name.",
+            valueName: "first-name"
+        )
+    ) var filterFirstName: String?
+
+    @Option(
+        help: ArgumentHelp(
+            "Beta tester's last name.",
+            valueName: "last-name"
+        )
+    ) var filterLastName: String?
+
+    @Option(
+        help: ArgumentHelp(
+            """
+            An invite type that indicates if a beta tester was invited by an email invite or used a TestFlight public link to join a beta test. \n
+            Possible values \(BetaInviteType.allCases).
+            """,
+            valueName: "invite-type"
+        )
     ) var filterInviteType: BetaInviteType?
 
     @Option(
         parsing: .upToNextOption,
-        help: "Application Bundle Ids. (eg. com.example.app)"
-    ) var filterApps: [String]
+        help: ArgumentHelp(
+            "Filter by app AppStore ID. eg. 432156789",
+            discussion: "This option is mutually exclusive with --filter-bundle-ids.",
+            valueName: "app-id"
+        )
+    ) var filterAppIds: [String]
 
     @Option(
         parsing: .upToNextOption,
-        help: "TestFlight beta group names."
+        help: ArgumentHelp(
+            "Filter by app bundle identifier. eg. com.example.App",
+            discussion: "This option is mutually exclusive with --filter-app-ids.",
+            valueName: "bundle-id"
+        )
+    ) var filterBundleIds: [String]
+
+    @Option(
+        parsing: .upToNextOption,
+        help: ArgumentHelp(
+            "TestFlight beta group names.",
+            valueName: "group-name"
+        )
     ) var filterGroupNames: [String]
 
     @Option(help: "Number of resources to return. (maximum: 200)")
@@ -54,8 +85,12 @@ struct ListBetaTestersCommand: CommonParsableCommand {
     var relatedResourcesLimit: Int?
 
     func validate() throws {
-        if !filterApps.isEmpty && !filterGroupNames.isEmpty {
-            throw ValidationError("Only one of these relationship filters ('filterApps', 'filterGroupNames') can be applied.")
+        if !filterAppIds.isEmpty && !filterBundleIds.isEmpty {
+            throw ValidationError("Filtering by both Bundle ID and App ID is not supported!")
+        }
+
+        if (!filterAppIds.isEmpty || !filterBundleIds.isEmpty) && !filterGroupNames.isEmpty {
+            throw ValidationError("Only one of these relationship filters ('app-id, bundle-id', 'group-name') can be applied.")
         }
     }
 
@@ -67,7 +102,8 @@ struct ListBetaTestersCommand: CommonParsableCommand {
             firstName: filterFirstName,
             lastName: filterLastName,
             inviteType: filterInviteType,
-            apps: filterApps,
+            appIds: filterAppIds,
+            bundleIds: filterBundleIds,
             groupNames: filterGroupNames,
             sort: sort,
             limit: limit,

--- a/Sources/AppStoreConnectCLI/Model/API/BetaInviteType+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/BetaInviteType+ExpressibleByArgument.swift
@@ -1,0 +1,19 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+
+extension BetaInviteType: CustomStringConvertible, ExpressibleByArgument {
+    public typealias AllCases = [BetaInviteType]
+    public static var allCases: AllCases {
+        [.email, .publicLink]
+    }
+
+    public init?(argument: String) {
+        self.init(rawValue: argument.uppercased())
+    }
+
+    public var description: String {
+        rawValue.lowercased()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/API/ListBetaTesters.Sort+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/ListBetaTesters.Sort+ExpressibleByArgument.swift
@@ -1,0 +1,10 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+
+extension ListBetaTesters.Sort: CustomStringConvertible, ExpressibleByArgument {
+    public var description: String {
+        rawValue
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -93,6 +93,51 @@ class AppStoreConnectService {
             .execute(with: requestor)
             .awaitMany()
     }
+
+    func listBetaTesters(
+        email: String?,
+        firstName: String?,
+        lastName: String?,
+        inviteType: BetaInviteType?,
+        apps: [String],
+        groupNames: [String],
+        sort: ListBetaTesters.Sort?,
+        limit: Int?,
+        relatedResourcesLimit: Int?
+    ) throws -> [BetaTester] {
+
+        var appIds: [String] = []
+        if !apps.isEmpty {
+            appIds = try GetAppsOperation(options: .init(bundleIds: apps))
+                .execute(with: requestor)
+                .await()
+                .map(\.id)
+        }
+
+        var groupIds: [String] = []
+        if !groupNames.isEmpty {
+            groupIds = try groupNames.map {
+                try betaGroupIdentifier(matching: $0).await()
+            }
+        }
+
+        return try ListBetaTestersOperation(options:
+                .init(
+                    email: email,
+                    firstName: firstName,
+                    lastName: lastName,
+                    inviteType: inviteType,
+                    appIds: appIds,
+                    groupIds: groupIds,
+                    sort: sort,
+                    limit: limit,
+                    relatedResourcesLimit: relatedResourcesLimit
+                )
+            )
+            .execute(with: requestor)
+            .await()
+            .map(BetaTester.init)
+    }
         
     func createBetaGroup(
         appBundleId: String,

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -99,16 +99,17 @@ class AppStoreConnectService {
         firstName: String?,
         lastName: String?,
         inviteType: BetaInviteType?,
-        apps: [String],
+        appIds: [String],
+        bundleIds: [String],
         groupNames: [String],
         sort: ListBetaTesters.Sort?,
         limit: Int?,
         relatedResourcesLimit: Int?
     ) throws -> [BetaTester] {
 
-        var appIds: [String] = []
-        if !apps.isEmpty {
-            appIds = try GetAppsOperation(options: .init(bundleIds: apps))
+        var appIds: [String] = appIds
+        if !bundleIds.isEmpty && appIds.isEmpty {
+            appIds = try GetAppsOperation(options: .init(bundleIds: bundleIds))
                 .execute(with: requestor)
                 .await()
                 .map(\.id)

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
@@ -29,70 +29,6 @@ struct ListBetaTestersOperation: APIOperation {
         }
     }
 
-    var limits: [ListBetaTesters.Limit] {
-        var limits: [ListBetaTesters.Limit] = []
-
-        if let resourcesLimit = options.relatedResourcesLimit {
-            limits.append(.apps(resourcesLimit))
-            limits.append(.betaGroups(resourcesLimit))
-        }
-
-        if let limit = options.limit {
-            limits.append(.betaTesters(limit))
-        }
-
-        return limits
-    }
-
-    var sorts: [ListBetaTesters.Sort] {
-        var sorts: [ListBetaTesters.Sort] = []
-
-        if let sort = options.sort {
-            sorts.append(sort)
-        }
-
-        return sorts
-    }
-
-    var filters: [ListBetaTesters.Filter] {
-        var filters: [ListBetaTesters.Filter] = []
-
-        if let firstName = options.firstName {
-            filters.append(.firstName([firstName]))
-        }
-
-        if let lastName = options.lastName {
-            filters.append(.lastName([lastName]))
-        }
-
-        if let email = options.email {
-            filters.append(.email([email]))
-        }
-
-        if let inviteType = options.inviteType {
-            filters.append(.inviteType([inviteType.rawValue]))
-        }
-
-        if let appIds = options.appIds {
-            filters.append(.apps(appIds))
-        }
-
-        if let groupIds = options.groupIds {
-            filters.append(.betaGroups(groupIds))
-        }
-
-        return filters
-    }
-
-    var endpoint: APIEndpoint<BetaTestersResponse> {
-        .betaTesters(
-            filter: filters,
-            include: [.apps, .betaGroups],
-            limit: limits,
-            sort: sorts
-        )
-    }
-
     private let options: Options
 
     typealias Output = [GetBetaTesterOperation.Output]
@@ -102,7 +38,71 @@ struct ListBetaTestersOperation: APIOperation {
     }
 
     func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Output, Swift.Error> {
-        requestor.request(endpoint)
+        var limits: [ListBetaTesters.Limit] {
+            var limits: [ListBetaTesters.Limit] = []
+
+            if let resourcesLimit = options.relatedResourcesLimit {
+                limits.append(.apps(resourcesLimit))
+                limits.append(.betaGroups(resourcesLimit))
+            }
+
+            if let limit = options.limit {
+                limits.append(.betaTesters(limit))
+            }
+
+            return limits
+        }
+
+        var sorts: [ListBetaTesters.Sort] {
+            var sorts: [ListBetaTesters.Sort] = []
+
+            if let sort = options.sort {
+                sorts.append(sort)
+            }
+
+            return sorts
+        }
+
+        var filters: [ListBetaTesters.Filter] {
+            var filters: [ListBetaTesters.Filter] = []
+
+            if let firstName = options.firstName {
+                filters.append(.firstName([firstName]))
+            }
+
+            if let lastName = options.lastName {
+                filters.append(.lastName([lastName]))
+            }
+
+            if let email = options.email {
+                filters.append(.email([email]))
+            }
+
+            if let inviteType = options.inviteType {
+                filters.append(.inviteType([inviteType.rawValue]))
+            }
+
+            if let appIds = options.appIds, !appIds.isEmpty {
+                filters.append(.apps(appIds))
+            }
+
+            if let groupIds = options.groupIds, !groupIds.isEmpty {
+                filters.append(.betaGroups(groupIds))
+            }
+
+            return filters
+        }
+
+        var endpoint: APIEndpoint<BetaTestersResponse> {
+            .betaTesters(
+                filter: filters,
+                include: [.apps, .betaGroups],
+                limit: limits,
+                sort: sorts
+            )
+        }
+
+        return requestor.request(endpoint)
             .tryMap { (response: BetaTestersResponse) -> Output in
                 guard !response.data.isEmpty else {
                     throw Error.notFound

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
@@ -1,0 +1,118 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ListBetaTestersOperation: APIOperation {
+
+    struct Options {
+        let email: String?
+        let firstName: String?
+        let lastName: String?
+        let inviteType: BetaInviteType?
+        let appIds: [String]?
+        let groupIds: [String]?
+        let sort: ListBetaTesters.Sort?
+        let limit: Int?
+        let relatedResourcesLimit: Int?
+    }
+
+    enum Error: LocalizedError {
+        case notFound
+
+        var errorDescription: String? {
+            switch self {
+            case .notFound:
+                return "Beta testers with provided filters not found."
+            }
+        }
+    }
+
+    var limits: [ListBetaTesters.Limit] {
+        var limits: [ListBetaTesters.Limit] = []
+
+        if let resourcesLimit = options.relatedResourcesLimit {
+            limits.append(.apps(resourcesLimit))
+            limits.append(.betaGroups(resourcesLimit))
+        }
+
+        if let limit = options.limit {
+            limits.append(.betaTesters(limit))
+        }
+
+        return limits
+    }
+
+    var sorts: [ListBetaTesters.Sort] {
+        var sorts: [ListBetaTesters.Sort] = []
+
+        if let sort = options.sort {
+            sorts.append(sort)
+        }
+
+        return sorts
+    }
+
+    var filters: [ListBetaTesters.Filter] {
+        var filters: [ListBetaTesters.Filter] = []
+
+        if let firstName = options.firstName {
+            filters.append(.firstName([firstName]))
+        }
+
+        if let lastName = options.lastName {
+            filters.append(.lastName([lastName]))
+        }
+
+        if let email = options.email {
+            filters.append(.email([email]))
+        }
+
+        if let inviteType = options.inviteType {
+            filters.append(.inviteType([inviteType.rawValue]))
+        }
+
+        if let appIds = options.appIds {
+            filters.append(.apps(appIds))
+        }
+
+        if let groupIds = options.groupIds {
+            filters.append(.betaGroups(groupIds))
+        }
+
+        return filters
+    }
+
+    var endpoint: APIEndpoint<BetaTestersResponse> {
+        .betaTesters(
+            filter: filters,
+            include: [.apps, .betaGroups],
+            limit: limits,
+            sort: sorts
+        )
+    }
+
+    private let options: Options
+
+    typealias Output = [GetBetaTesterOperation.Output]
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Output, Swift.Error> {
+        requestor.request(endpoint)
+            .tryMap { (response: BetaTestersResponse) -> Output in
+                guard !response.data.isEmpty else {
+                    throw Error.notFound
+                }
+
+                return response.data.map {
+                    .init(betaTester: $0, includes: response.included)
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+
+}


### PR DESCRIPTION
Implement ListBetaTesterCommand, Closes #107 

# 📝 Summary of Changes

Changes proposed in this pull request:

- ReImplement List Beta Tester Command, follows #107
- Create extensions: `ListBetaTesters.Sort, BetaInviteType + ExpressibleByArgument`
- Create function `listBetaTesters` and `ListBetaTesterOperations`

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage: 
`asc testflight betatesters list <options>`

```
OPTIONS:
  --filter-email <filter-email>
                          Beta tester's email. 
  --filter-first-name <filter-first-name>
                          Beta tester's first name. 
  --filter-last-name <filter-last-name>
                          Beta tester's last name. 
  --filter-invite-type <filter-invite-type>
                          An invite type that indicates if a beta tester was invited by an email invite or used a TestFlight public link to join a beta test. 

                          Possible values [email, public_link]. 
  --filter-apps <filter-apps>
                          Application Bundle Ids. (eg. com.example.app) 
  --filter-group-names <filter-group-names>
                          The name of the beta group. 
  --limit <limit>         Number of resources to return. (maximum: 200) 
  --sort <sort>           Sort the results using the provided key [+email, -email, +firstName, -firstName, +inviteType, -inviteType, +lastName, -lastName]. 
        The `-` prefix indicates descending order.
  --related-resources-limit <related-resources-limit>
                          Number of included related resources to return. 
```

## 🔨 How To Test
eg.
`swift run asc testflight betatesters list --filter-first-name Foo --filter-apps com.example.yourApp`
