### PR TITLE
Rename GetBetaTesterInfoCommand 

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ReadBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ReadBetaTesterCommand.swift
@@ -5,9 +5,9 @@ import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
 
-struct GetBetaTesterInfoCommand: CommonParsableCommand {
+struct ReadBetaTesterCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
-        commandName: "info",
+        commandName: "read",
         abstract: "Get information about a beta tester")
 
     @OptionGroup()

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
@@ -12,7 +12,7 @@ public struct TestFlightBetaTestersCommand: ParsableCommand {
              DeleteBetaTesterCommand.self,
              ListBetaTestersCommand.self,
              ListBetaTesterByBuildsCommand.self,
-             GetBetaTesterInfoCommand.self,
+             ReadBetaTesterCommand.self,
         ])
 
     public init() {


### PR DESCRIPTION
Rename filename and command name of GetBetaTesterInfo, for matching #108 , Closes #108 

# 📝 Summary of Changes

Changes proposed in this pull request:

- `GetBetaTesterInfoCommand` -> `ReadBetaTesterCommand`
- command: `info` -> `read`

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

`swift run asc testflight betatesters read youremail@gmail.com`
