### PR TITLE
Implement delete beta group

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
@@ -12,6 +12,7 @@ struct TestFlightBetaGroupCommand: ParsableCommand {
         """,
         subcommands: [
             CreateBetaGroupCommand.self,
+            DeleteBetaGroupCommand.self,
             ListBetaGroupsCommand.self,
             ModifyBetaGroupCommand.self
         ],

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/DeleteBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/DeleteBetaGroupCommand.swift
@@ -1,0 +1,35 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import Foundation
+
+struct DeleteBetaGroupCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Delete a beta group"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(
+        help: """
+        The reverse-DNS bundle ID of the app which the group is associated with. \
+        Must be unique. (eg. com.example.app)
+        """
+    ) var appBundleId: String
+
+    @Argument(
+        help: ArgumentHelp(
+            "The name of the beta group to be deleted",
+            discussion: """
+            This name will be used to search for a unique beta group matching the specified \
+            app bundle id
+            """,
+            valueName: "beta-group-name"
+        )
+    ) var betaGroupName: String
+
+    func run() throws {
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/DeleteBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/DeleteBetaGroupCommand.swift
@@ -31,5 +31,8 @@ struct DeleteBetaGroupCommand: CommonParsableCommand {
     ) var betaGroupName: String
 
     func run() throws {
+        let service = try makeService()
+
+        try service.deleteBetaGroup(appBundleId: appBundleId, betaGroupName: betaGroupName)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/DeleteBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/DeleteBetaGroupCommand.swift
@@ -25,8 +25,7 @@ struct DeleteBetaGroupCommand: CommonParsableCommand {
             discussion: """
             This name will be used to search for a unique beta group matching the specified \
             app bundle id
-            """,
-            valueName: "beta-group-name"
+            """
         )
     ) var betaGroupName: String
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -140,20 +140,20 @@ class AppStoreConnectService {
         let getAppsOperation = GetAppsOperation(options: .init(bundleIds: [appBundleId]))
         let app = try getAppsOperation.execute(with: requestor).compactMap(\.first).await()
 
-        let modifyBetaGroupOperation = ModifyBetaGroupOperation(
-            options: .init(
-                app: app,
-                currentGroupName: currentGroupName,
-                newGroupName: newGroupName,
-                publicLinkEnabled: publicLinkEnabled,
-                publicLinkLimit: publicLinkLimit,
-                publicLinkLimitEnabled: publicLinkLimitEnabled
-            )
-        )
+        let getBetaGroupOperation = GetBetaGroupOperation(
+            options: .init(app: app, betaGroupName: currentGroupName))
+        let betaGroup = try getBetaGroupOperation.execute(with: requestor).await()
 
-        let betaGroup = try modifyBetaGroupOperation.execute(with: requestor).await()
+        let modifyBetaGroupOptions = ModifyBetaGroupOperation.Options(
+            betaGroup: betaGroup,
+            betaGroupName: newGroupName,
+            publicLinkEnabled: publicLinkEnabled,
+            publicLinkLimit: publicLinkLimit,
+            publicLinkLimitEnabled: publicLinkLimitEnabled)
+        let modifyBetaGroupOperation = ModifyBetaGroupOperation(options: modifyBetaGroupOptions)
+        let modifiedBetaGroup = try modifyBetaGroupOperation.execute(with: requestor).await()
 
-        return BetaGroup(app, betaGroup)
+        return BetaGroup(app, modifiedBetaGroup)
     }
 
     func readBuild(bundleId: String, buildNumber: String, preReleaseVersion: String) throws -> BuildDetailsInfo {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -127,7 +127,7 @@ class AppStoreConnectService {
             .execute(with: requestor)
             .await()
 
-        try DeleteBetaGroupOperation(options: .init(betaGroup: betaGroup))
+        try DeleteBetaGroupOperation(options: .init(betaGroupId: betaGroup.id))
             .execute(with: requestor)
             .await()
     }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -116,6 +116,22 @@ class AppStoreConnectService {
         return try betaGroupResponse.map(BetaGroup.init).await()
     }
 
+    func deleteBetaGroup(appBundleId: String, betaGroupName: String) throws {
+        let app = try GetAppsOperation(options: .init(bundleIds: [appBundleId]))
+            .execute(with: requestor)
+            .compactMap(\.first)
+            .await()
+
+        let betaGroup = try GetBetaGroupOperation(
+            options: .init(app: app, betaGroupName: betaGroupName))
+            .execute(with: requestor)
+            .await()
+
+        try DeleteBetaGroupOperation(options: .init(betaGroup: betaGroup))
+            .execute(with: requestor)
+            .await()
+    }
+
     func listBetaGroups(bundleIds: [String]) throws -> [BetaGroup] {
         let operation = GetAppsOperation(options: .init(bundleIds: bundleIds))
         let appIds = try operation.execute(with: requestor).await().map(\.id)

--- a/Sources/AppStoreConnectCLI/Services/Operations/DeleteBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/DeleteBetaGroupOperation.swift
@@ -8,7 +8,7 @@ struct DeleteBetaGroupOperation: APIOperation {
     typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
 
     struct Options {
-        let betaGroup: BetaGroup
+        let betaGroupId: String
     }
 
     let options: Options
@@ -18,7 +18,7 @@ struct DeleteBetaGroupOperation: APIOperation {
     }
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<Void, Error> {
-        let endpoint = APIEndpoint.delete(betaGroupWithId: options.betaGroup.id)
+        let endpoint = APIEndpoint.delete(betaGroupWithId: options.betaGroupId)
 
         return requestor.request(endpoint).eraseToAnyPublisher()
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/DeleteBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/DeleteBetaGroupOperation.swift
@@ -1,0 +1,25 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct DeleteBetaGroupOperation: APIOperation {
+    typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
+
+    struct Options {
+        let betaGroup: BetaGroup
+    }
+
+    let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Void, Error> {
+        let endpoint = APIEndpoint.delete(betaGroupWithId: options.betaGroup.id)
+
+        return requestor.request(endpoint).eraseToAnyPublisher()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
@@ -1,0 +1,57 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct GetBetaGroupOperation: APIOperation {
+    struct Options {
+        let app: App
+        let betaGroupName: String
+    }
+
+    enum Error: LocalizedError {
+        case betaGroupNotFound(groupName: String, bundleId: String)
+        case betaGroupNotUniqueToApp(groupName: String, bundleId: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .betaGroupNotFound(let groupName, let bundleId):
+                return "No beta group found with name: \(groupName) and bundle id: \(bundleId)"
+            case .betaGroupNotUniqueToApp(let groupName, let bundleId):
+                return "Multiple beta groups found with name: \(groupName) and app id: \(bundleId)"
+            }
+        }
+    }
+
+    typealias App = AppStoreConnect_Swift_SDK.App
+    typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<BetaGroup, Swift.Error> {
+        let betaGroupName = options.betaGroupName
+        let bundleId = options.app.attributes?.bundleId ?? ""
+
+        let endpoint = APIEndpoint.betaGroups(
+            filter: [.app([options.app.id]), .name([betaGroupName])]
+        )
+
+        let betaGroup = requestor.request(endpoint).tryMap { response -> BetaGroup in
+            switch response.data.first {
+            case .some(let betaGroup) where response.data.count == 1:
+                return betaGroup
+            case .some:
+                throw Error.betaGroupNotUniqueToApp(groupName: betaGroupName, bundleId: bundleId)
+            case .none:
+                throw Error.betaGroupNotFound(groupName: betaGroupName, bundleId: bundleId)
+            }
+        }
+
+        return betaGroup.eraseToAnyPublisher()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
@@ -42,12 +42,14 @@ struct GetBetaGroupOperation: APIOperation {
         )
 
         let betaGroup = requestor.request(endpoint).tryMap { response -> BetaGroup in
-            switch response.data.first {
-            case .some(let betaGroup) where response.data.count == 1:
+            let betaGroups = response.data.filter { $0.attributes?.name == betaGroupName }
+            
+            switch (betaGroups.first, betaGroups.count) {
+            case (.some(let betaGroup), 1):
                 return betaGroup
-            case .some:
+            case (.some, _):
                 throw Error.betaGroupNotUniqueToApp(groupName: betaGroupName, bundleId: bundleId)
-            case .none:
+            case (.none, _):
                 throw Error.betaGroupNotFound(groupName: betaGroupName, bundleId: bundleId)
             }
         }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ModifyBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ModifyBetaGroupOperation.swift
@@ -6,26 +6,11 @@ import Foundation
 
 struct ModifyBetaGroupOperation: APIOperation {
     struct Options {
-        let app: App
-        let currentGroupName: String
-        let newGroupName: String?
+        let betaGroup: BetaGroup
+        let betaGroupName: String?
         let publicLinkEnabled: Bool?
         let publicLinkLimit: Int?
         let publicLinkLimitEnabled: Bool?
-    }
-
-    enum Error: LocalizedError {
-        case betaGroupNotFound(groupName: String, bundleId: String)
-        case betaGroupNotUniqueToApp(groupName: String, bundleId: String)
-
-        var errorDescription: String? {
-            switch self {
-            case .betaGroupNotFound(let groupName, let bundleId):
-                return "No beta group found with name: \(groupName) and bundle id: \(bundleId)"
-            case .betaGroupNotUniqueToApp(let groupName, let bundleId):
-                return "Multiple beta groups found with name: \(groupName) and app id: \(bundleId)"
-            }
-        }
     }
 
     typealias App = AppStoreConnect_Swift_SDK.App
@@ -37,26 +22,10 @@ struct ModifyBetaGroupOperation: APIOperation {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<BetaGroup, Swift.Error> {
-        let groupName = options.currentGroupName
-        let appId = options.app.id
-        let bundleId = options.app.attributes?.bundleId ?? ""
-
-        let betaGroupsEndpoint = APIEndpoint.betaGroups(filter: [.app([appId]), .name([groupName])])
-        let betaGroups = try requestor.request(betaGroupsEndpoint).await().data
-
-        guard betaGroups.count == 1, let betaGroup = betaGroups.first else {
-            switch betaGroups.count {
-            case 0:
-                throw Error.betaGroupNotFound(groupName: groupName, bundleId: bundleId)
-            default:
-                throw Error.betaGroupNotUniqueToApp(groupName: groupName, bundleId: bundleId)
-            }
-        }
-
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<BetaGroup, Swift.Error> {
         let endpoint: APIEndpoint<BetaGroupResponse> = .modify(
-            betaGroupWithId: betaGroup.id,
-            name: options.newGroupName,
+            betaGroupWithId: options.betaGroup.id,
+            name: options.betaGroupName,
             publicLinkEnabled: options.publicLinkEnabled,
             publicLinkLimit: options.publicLinkLimit,
             publicLinkLimitEnabled: options.publicLinkLimitEnabled

--- a/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
@@ -1,0 +1,119 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+@testable import AppStoreConnectCLI
+@testable import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+import XCTest
+
+final class GetBetaGroupOperationTests: XCTestCase {
+    typealias Operation = GetBetaGroupOperation
+    typealias Options = Operation.Options
+    typealias App = AppStoreConnect_Swift_SDK.App
+    typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
+
+    let testUrl = URL(fileURLWithPath: "test")
+
+    var app: App {
+        App(
+            attributes: App.Attributes(
+                bundleId: "com.example.test",
+                name: nil,
+                primaryLocale: nil,
+                sku: nil
+            ),
+            id: "1234567890",
+            relationships: nil,
+            links: ResourceLinks(self: testUrl)
+        )
+    }
+
+    var options: Options {
+        Options(
+            app: app,
+            betaGroupName: "Some Group"
+        )
+    }
+
+    var betaGroup: BetaGroup {
+        BetaGroup(
+            attributes: nil,
+            id: "1234",
+            relationships: nil,
+            links: ResourceLinks(self: testUrl)
+        )
+    }
+
+    var betaGroupsResponseFuture: Future<BetaGroupsResponse, Error> {
+        let response = BetaGroupsResponse(
+            data: [self.betaGroup],
+            included: nil,
+            links: PagedDocumentLinks(first: nil, next: nil, self: self.testUrl),
+            meta: nil
+        )
+
+        return Future { $0(.success(response)) }
+    }
+
+    func testSuccess() throws {
+        let successRequestor = OneEndpointTestRequestor(
+            response: { _ in self.betaGroupsResponseFuture }
+        )
+
+        let output = try Operation(options: options).execute(with: successRequestor).await()
+
+        XCTAssertEqual(output.id, "1234")
+    }
+
+    func testBetaGroupNotFound() {
+        let betaGroupNotFoundRequestor = OneEndpointTestRequestor(
+            response: { (endpoint: APIEndpoint<BetaGroupsResponse>) -> Future<BetaGroupsResponse, Error> in
+                let response = BetaGroupsResponse(
+                    data: [],
+                    included: nil,
+                    links: PagedDocumentLinks(first: nil, next: nil, self: self.testUrl),
+                    meta: nil
+                )
+
+                return Future { $0(.success(response)) }
+            }
+        )
+
+        let result = Result {
+            try Operation(options: options).execute(with: betaGroupNotFoundRequestor).await()
+        }
+
+        switch result {
+        case .failure(Operation.Error.betaGroupNotFound(groupName: "Some Group", bundleId: "com.example.test")):
+            break
+        default:
+            XCTFail()
+        }
+    }
+
+    func testBetaGroupNotUniqueToApp() {
+        let betaGroupNotUniqueRequestor = OneEndpointTestRequestor(
+            response: { (endpoint: APIEndpoint<BetaGroupsResponse>) -> Future<BetaGroupsResponse, Error> in
+                let response = BetaGroupsResponse(
+                    data: [self.betaGroup, self.betaGroup],
+                    included: nil,
+                    links: PagedDocumentLinks(first: nil, next: nil, self: self.testUrl),
+                    meta: nil
+                )
+
+                return Future { $0(.success(response)) }
+            }
+        )
+
+        let result = Result {
+            try Operation(options: options).execute(with: betaGroupNotUniqueRequestor).await()
+        }
+
+        switch result {
+        case .failure(Operation.Error.betaGroupNotUniqueToApp(groupName: "Some Group", bundleId: "com.example.test")):
+            break
+        default:
+            XCTFail()
+        }
+    }
+}

--- a/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
@@ -37,7 +37,16 @@ final class GetBetaGroupOperationTests: XCTestCase {
 
     var betaGroup: BetaGroup {
         BetaGroup(
-            attributes: nil,
+            attributes: BetaGroup.Attributes(
+                isInternalGroup: false,
+                name: "Some Group",
+                publicLink: nil,
+                publicLinkEnabled: nil,
+                publicLinkId: nil,
+                publicLinkLimit: nil,
+                publicLinkLimitEnabled: nil,
+                createdDate: nil
+            ),
             id: "1234",
             relationships: nil,
             links: ResourceLinks(self: testUrl)
@@ -70,6 +79,48 @@ final class GetBetaGroupOperationTests: XCTestCase {
             response: { (endpoint: APIEndpoint<BetaGroupsResponse>) -> Future<BetaGroupsResponse, Error> in
                 let response = BetaGroupsResponse(
                     data: [],
+                    included: nil,
+                    links: PagedDocumentLinks(first: nil, next: nil, self: self.testUrl),
+                    meta: nil
+                )
+
+                return Future { $0(.success(response)) }
+            }
+        )
+
+        let result = Result {
+            try Operation(options: options).execute(with: betaGroupNotFoundRequestor).await()
+        }
+
+        switch result {
+        case .failure(Operation.Error.betaGroupNotFound(groupName: "Some Group", bundleId: "com.example.test")):
+            break
+        default:
+            XCTFail()
+        }
+    }
+
+    func testBetaGroupNotFoundWithDifferentName() {
+        let betaGroup = BetaGroup(
+            attributes: BetaGroup.Attributes(
+                isInternalGroup: false,
+                name: "Just Some Group",
+                publicLink: nil,
+                publicLinkEnabled: nil,
+                publicLinkId: nil,
+                publicLinkLimit: nil,
+                publicLinkLimitEnabled: nil,
+                createdDate: nil
+            ),
+            id: "5678",
+            relationships: nil,
+            links: ResourceLinks(self: testUrl)
+        )
+
+        let betaGroupNotFoundRequestor = OneEndpointTestRequestor(
+            response: { (endpoint: APIEndpoint<BetaGroupsResponse>) -> Future<BetaGroupsResponse, Error> in
+                let response = BetaGroupsResponse(
+                    data: [betaGroup],
                     included: nil,
                     links: PagedDocumentLinks(first: nil, next: nil, self: self.testUrl),
                     meta: nil


### PR DESCRIPTION
Closes #98 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds `DeleteBetaGroupCommand` and `DeleteBetaGroupOperation`
- Adds `GetBetaGroupOperation` to reuse for delete and modify service functions
- Moves get beta group tests from modify to shared get beta group operation

# 🧐🗒 Reviewer Notes

## 💁 Example

`Usage: asc testflight betagroup delete [--api-issuer <uuid>] [--api-key-id <keyid>] [--csv] [--json] [--table] [--yaml] <app-bundle-id> <beta-group-name>`

## 🔨 How To Test

- Use create to create a beta group
e.g. `asc testflight betagroup create com.example.app myGroup`
- Use list to verify
e.g. `asc testflight betagroup list --filter-bundle-ids com.example.app`
- Use delete to delete the group
e.g. `asc testflight betagroup delete com.example.app myGroup`
- Use list to verify again
e.g. `asc testflight betagroup list --filter-bundle-ids com.example.app`