### PR TITLE
Add name filtering to the list beta group command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
@@ -30,6 +30,18 @@ struct ListBetaGroupsCommand: CommonParsableCommand {
         )
     ) var filterBundleIds: [String]
 
+    @Option(
+        parsing: .upToNextOption,
+        help: ArgumentHelp(
+            "Filter by beta group name",
+            discussion: """
+            This filter works on partial matches in a case insensitive fashion, \
+            e.g. 'group' will match 'myGroup'
+            """,
+            valueName: "filter-names"
+        )
+    ) var filterNames: [String]
+
     func validate() throws {
         if filterAppIds.isEmpty == false && filterBundleIds.isEmpty == false {
             throw ValidationError("Filtering by both Bundle ID and App ID is not supported!")
@@ -40,8 +52,8 @@ struct ListBetaGroupsCommand: CommonParsableCommand {
         let service = try makeService()
 
         let betaGroups = filterBundleIds.isEmpty
-            ? try service.listBetaGroups(appIds: filterAppIds)
-            : try service.listBetaGroups(bundleIds: filterBundleIds)
+            ? try service.listBetaGroups(appIds: filterAppIds, names: filterNames)
+            : try service.listBetaGroups(bundleIds: filterBundleIds, names: filterNames)
 
         betaGroups.render(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -178,15 +178,15 @@ class AppStoreConnectService {
             .await()
     }
 
-    func listBetaGroups(bundleIds: [String]) throws -> [BetaGroup] {
+    func listBetaGroups(bundleIds: [String], names: [String]) throws -> [BetaGroup] {
         let operation = GetAppsOperation(options: .init(bundleIds: bundleIds))
         let appIds = try operation.execute(with: requestor).await().map(\.id)
 
-        return try listBetaGroups(appIds: appIds)
+        return try listBetaGroups(appIds: appIds, names: names)
     }
 
-    func listBetaGroups(appIds: [String]) throws -> [BetaGroup] {
-        let operation = ListBetaGroupsOperation(options: .init(appIds: appIds))
+    func listBetaGroups(appIds: [String], names: [String]) throws -> [BetaGroup] {
+        let operation = ListBetaGroupsOperation(options: .init(appIds: appIds, names: names))
 
         return try operation.execute(with: requestor).await().map(BetaGroup.init)
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
@@ -8,6 +8,7 @@ struct ListBetaGroupsOperation: APIOperation {
 
     struct Options {
         let appIds: [String]
+        let names: [String]
     }
 
     typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
@@ -33,7 +34,10 @@ struct ListBetaGroupsOperation: APIOperation {
     }
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Swift.Error> {
-        let filters = options.appIds.isEmpty ? [] : [ListBetaGroups.Filter.app(options.appIds)]
+        var filters: [ListBetaGroups.Filter] = []
+        filters += options.appIds.isEmpty ? [] : [.app(options.appIds)]
+        filters += options.names.isEmpty ? [] : [.name(options.names)]
+
         let endpoint = APIEndpoint.betaGroups(filter: filters, include: [.app])
         let response = requestor.request(endpoint)
 

--- a/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
@@ -15,7 +15,7 @@ final class ListBetaGroupsOperationTests: XCTestCase {
     )
 
     func testExecute_success() throws {
-        let operation = Operation(options: Options(appIds: []))
+        let operation = Operation(options: Options(appIds: [], names: []))
 
         let output = try operation.execute(with: successRequestor).await()
 
@@ -25,7 +25,7 @@ final class ListBetaGroupsOperationTests: XCTestCase {
     }
 
     func testExecute_propagatesUpstreamErrors() {
-        let operation = Operation(options: Options(appIds: []))
+        let operation = Operation(options: Options(appIds: [], names: []))
 
         let result = Result { try operation.execute(with: FailureTestRequestor()).await() }
 


### PR DESCRIPTION
Adds the ability to specify group names (or partial group names) for filtering down the beta group list

# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds `filterNames` (`--filter-names`) to `ListBetaGroupsCommand`
- Implements the filter by passing the argument through to the operation and endpoint

# ⚠️ Items of Note
It is interesting that the matching is partial and case insensitive
Something to keep in mind if re-using this operation as well

# 🧐🗒 Reviewer Notes

## 💁 Example

`USAGE: asc testflight betagroup list [--api-issuer <uuid>] [--api-key-id <keyid>] [--csv] [--json] [--table] [--yaml] [--filter-app-ids <app-id> ...] [--filter-bundle-ids <bundle-id> ...] [--filter-names <filter-names> ...]`

## 🔨 How To Test

- Run the list command with no filters
- Run the list command with the filter name argument with one of the previously displayed names to narrow the results