### PR TITLE
Implement read app command 

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
@@ -1,0 +1,52 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+struct ReadAppCommand: CommonParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        commandName: "read",
+        abstract: "Find and read app info"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Option(
+        help: ArgumentHelp(
+            "Filter by app AppStore ID. eg. 432156789",
+            discussion: "This option is mutually exclusive with --filter-bundle-id.",
+            valueName: "app-id"
+        )
+    ) var filterAppId: String?
+
+    @Option(
+        help: ArgumentHelp(
+            "Filter by app bundle identifier. eg. com.example.App",
+            discussion: "This option is mutually exclusive with --filter-app-id.",
+            valueName: "bundle-id"
+        )
+    ) var filterBundleId: String?
+
+    func validate() throws {
+        if filterAppId == nil && filterBundleId == nil {
+            throw ValidationError("Missing expected argument '<app-id>' or '<bundle-id>'")
+        }
+
+        if filterAppId != nil && filterBundleId != nil {
+            throw ValidationError("Filtering by both Bundle ID and App ID is not supported!")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        let app = filterAppId == nil ?
+            try service.readApp(bundleId: filterBundleId!):
+            try service.readApp(appId: filterAppId!)
+
+        app.render(format: common.outputFormat)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
@@ -40,14 +40,7 @@ struct ReadAppCommand: CommonParsableCommand {
     func run() throws {
         let service = try makeService()
 
-        var app: App
-
-        switch identifier {
-        case .appId(let appId):
-            app = try service.readApp(appId: appId)
-        case .bundleId(let bundleId):
-            app = try service.readApp(bundleId: bundleId)
-        }
+        let app = try service.readApp(identifier: identifier)
 
         app.render(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
@@ -16,13 +16,14 @@ struct ReadAppCommand: CommonParsableCommand {
 
     @Argument(
         help: ArgumentHelp(
-            "Filter by app AppStore ID. eg. 432156789 or app bundle identifier. eg. com.example.App",
+            "The app AppStore ID. eg. 432156789 or app bundle identifier. eg. com.example.App",
             discussion: "Please input either app id or bundle Id",
             valueName: "app-id / bundle-id"
-        )
-    ) var appIdOrBundleId: String
+        ),
+        transform: Identifier.init
+    ) var identifier: Identifier
 
-    enum CommandArgument {
+    enum Identifier {
         case appId(String)
         case bundleId(String)
 
@@ -41,7 +42,7 @@ struct ReadAppCommand: CommonParsableCommand {
 
         var app: App
 
-        switch CommandArgument(appIdOrBundleId) {
+        switch identifier {
         case .appId(let appId):
             app = try service.readApp(appId: appId)
         case .bundleId(let bundleId):

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
@@ -14,38 +14,39 @@ struct ReadAppCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(
+    @Argument(
         help: ArgumentHelp(
-            "Filter by app AppStore ID. eg. 432156789",
-            discussion: "This option is mutually exclusive with --filter-bundle-id.",
-            valueName: "app-id"
+            "Filter by app AppStore ID. eg. 432156789 or app bundle identifier. eg. com.example.App",
+            discussion: "Please input either app id or bundle Id",
+            valueName: "app-id / bundle-id"
         )
-    ) var filterAppId: String?
+    ) var appIdOrBundleId: String
 
-    @Option(
-        help: ArgumentHelp(
-            "Filter by app bundle identifier. eg. com.example.App",
-            discussion: "This option is mutually exclusive with --filter-app-id.",
-            valueName: "bundle-id"
-        )
-    ) var filterBundleId: String?
+    enum CommandArgument {
+        case appId(String)
+        case bundleId(String)
 
-    func validate() throws {
-        if filterAppId == nil && filterBundleId == nil {
-            throw ValidationError("Missing expected argument '<app-id>' or '<bundle-id>'")
-        }
-
-        if filterAppId != nil && filterBundleId != nil {
-            throw ValidationError("Filtering by both Bundle ID and App ID is not supported!")
+        init(_ argument: String) {
+            switch Int(argument) == nil {
+            case true:
+                self = .bundleId(argument)
+            case false:
+                self = .appId(argument)
+            }
         }
     }
 
     func run() throws {
         let service = try makeService()
 
-        let app = filterAppId == nil ?
-            try service.readApp(bundleId: filterBundleId!):
-            try service.readApp(appId: filterAppId!)
+        var app: App
+
+        switch CommandArgument(appIdOrBundleId) {
+        case .appId(let appId):
+            app = try service.readApp(appId: appId)
+        case .bundleId(let bundleId):
+            app = try service.readApp(bundleId: bundleId)
+        }
 
         app.render(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/TestFlightAppsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/TestFlightAppsCommand.swift
@@ -9,6 +9,7 @@ struct TestFlightAppsCommand: ParsableCommand {
         abstract: "Application commands",
         subcommands: [
             ListAppsCommand.self,
+            ReadAppCommand.self
             // GetAppInfoCommand.self,
             // More...
         ],

--- a/Sources/AppStoreConnectCLI/Model/App.swift
+++ b/Sources/AppStoreConnectCLI/Model/App.swift
@@ -33,15 +33,17 @@ extension App {
 extension App: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
-            TextTableColumn(header: "bundleId"),
-            TextTableColumn(header: "name"),
-            TextTableColumn(header: "primaryLocale"),
-            TextTableColumn(header: "sku"),
+            TextTableColumn(header: "App ID"),
+            TextTableColumn(header: "App Bundle ID"),
+            TextTableColumn(header: "Name"),
+            TextTableColumn(header: "Primary Locale"),
+            TextTableColumn(header: "SKU"),
         ]
     }
 
     var tableRow: [CustomStringConvertible] {
         return [
+            id,
             bundleId ?? "",
             name ?? "",
             primaryLocale ?? "",

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -278,6 +278,7 @@ class AppStoreConnectService {
         let appId = try appsOperation.execute(with: requestor)
             .compactMap(\.first)
             .await()
+            .id
 
         let output = try ReadAppOperation(options: .init(id: appId))
             .execute(with: requestor)

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -272,24 +272,13 @@ class AppStoreConnectService {
         return output.map(Build.init)
     }
 
-    func readApp(bundleId: String) throws -> App {
-        let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
-
-        let sdkApp = try appsOperation.execute(with: requestor)
-            .compactMap(\.first)
-            .await()
-
-        return App(sdkApp)
-    }
-
-    func readApp(appId: String) throws -> App {
-        let sdkApp = try ReadAppOperation(options: .init(id: appId))
+    func readApp(identifier: ReadAppCommand.Identifier) throws -> App {
+        let sdkApp = try ReadAppOperation(options: .init(identifier: identifier))
             .execute(with: requestor)
             .await()
 
         return App(sdkApp)
     }
-
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -275,24 +275,19 @@ class AppStoreConnectService {
     func readApp(bundleId: String) throws -> App {
         let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
 
-        let appId = try appsOperation.execute(with: requestor)
+        let sdkApp = try appsOperation.execute(with: requestor)
             .compactMap(\.first)
             .await()
-            .id
 
-        let output = try ReadAppOperation(options: .init(id: appId))
-            .execute(with: requestor)
-            .await()
-
-        return App(output.app)
+        return App(sdkApp)
     }
 
     func readApp(appId: String) throws -> App {
-        let output = try ReadAppOperation(options: .init(id: appId))
+        let sdkApp = try ReadAppOperation(options: .init(id: appId))
             .execute(with: requestor)
             .await()
 
-        return App(output.app)
+        return App(sdkApp)
     }
 
     /// Make a request for something `Decodable`.

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -272,6 +272,28 @@ class AppStoreConnectService {
         return output.map(Build.init)
     }
 
+    func readApp(bundleId: String) throws -> App {
+        let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
+
+        let appId = try appsOperation.execute(with: requestor)
+            .compactMap(\.first)
+            .await()
+
+        let output = try ReadAppOperation(options: .init(id: appId))
+            .execute(with: requestor)
+            .await()
+
+        return App(output.app)
+    }
+
+    func readApp(appId: String) throws -> App {
+        let output = try ReadAppOperation(options: .init(id: appId))
+            .execute(with: requestor)
+            .await()
+
+        return App(output.app)
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
@@ -10,24 +10,15 @@ struct ReadAppOperation: APIOperation {
         let id: String
     }
 
-    private var endpoint: APIEndpoint<AppStoreConnect_Swift_SDK.AppResponse> {
-        APIEndpoint.app(withId: options.id, include: [GetApp.Relationship.betaGroups, GetApp.Relationship.preReleaseVersions])
-    }
-
-    struct Output {
-        let app: AppStoreConnect_Swift_SDK.App
-        let includes: [AppStoreConnect_Swift_SDK.AppRelationship]?
-    }
-
     private let options: Options
 
     init(options: Options) {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Swift.Error> {
-        requestor.request(endpoint)
-            .map { Output(app: $0.data, includes: $0.included) }
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<AppStoreConnect_Swift_SDK.App, Swift.Error> {
+        requestor.request(.app(withId: options.id))
+            .map(\.data)
             .eraseToAnyPublisher()
     }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
@@ -16,7 +16,7 @@ struct ReadAppOperation: APIOperation {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) -> AnyPublisher<AppStoreConnect_Swift_SDK.App, Swift.Error> {
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<AppStoreConnect_Swift_SDK.App, Error> {
         requestor.request(.app(withId: options.id))
             .map(\.data)
             .eraseToAnyPublisher()

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
@@ -33,15 +33,17 @@ struct ReadAppOperation: APIOperation {
     }
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<App, Swift.Error> {
+        let result: AnyPublisher<App, Swift.Error>
+
         switch options.identifier {
         case .appId(let appId):
-            return requestor.request(.app(withId: appId))
+            result = requestor.request(.app(withId: appId))
                 .map(\.data)
                 .eraseToAnyPublisher()
         case .bundleId(let bundleId):
             let endpoint: APIEndpoint = .apps(filters: [.bundleId([bundleId])])
 
-            return requestor.request(endpoint)
+            result = requestor.request(endpoint)
                 .tryMap { (response: AppsResponse) throws -> App in
                     switch response.data.count {
                     case 0:
@@ -54,6 +56,8 @@ struct ReadAppOperation: APIOperation {
                 }
                 .eraseToAnyPublisher()
         }
+
+        return result
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
@@ -1,0 +1,34 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ReadAppOperation: APIOperation {
+
+    struct Options {
+        let id: String
+    }
+
+    private var endpoint: APIEndpoint<AppStoreConnect_Swift_SDK.AppResponse> {
+        APIEndpoint.app(withId: options.id, include: [GetApp.Relationship.betaGroups, GetApp.Relationship.preReleaseVersions])
+    }
+
+    struct Output {
+        let app: AppStoreConnect_Swift_SDK.App
+        let includes: [AppStoreConnect_Swift_SDK.AppRelationship]?
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Swift.Error> {
+        requestor.request(endpoint)
+            .map { Output(app: $0.data, includes: $0.included) }
+            .eraseToAnyPublisher()
+    }
+
+}


### PR DESCRIPTION
Closes #101 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create ReadAppOperation and service functions 
- Implement ReadAppCommand

# ⚠️ Items of Note

The issue itself is still in draft, so not sure our App Model has everything we want to show.

# 🧐🗒 Reviewer Notes

## 💁 Example

` asc testflight apps read [--filter-app-id <app-id>] [--filter-bundle-id <bundle-id>]`

## 🔨 How To Test

`swift run asc testflight apps read --filter-app-id 1123456678`
`swift run asc testflight apps read --filter-bundle-i com.Foo.Bar`
