### PR TITLE
Implement Remove build from groups command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/RemoveGroupsFromBuildCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/RemoveGroupsFromBuildCommand.swift
@@ -1,0 +1,44 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct RemoveBuildFromGroupsCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "removebetagroup",
+        abstract: "Remove access to a specific build for all beta testers in one or more beta groups")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "App bundle identifier. eg. com.example.App")
+    var bundleId: String
+
+    @Argument(help: "The pre-release version number of this build.")
+    var preReleaseVersion: String
+
+    @Argument(help: "The build number of this build.")
+    var buildNumber: String
+
+    @Argument(help: "Names of beta groups.")
+    var groupNames: [String]
+
+    func validate() throws {
+        if groupNames.isEmpty {
+            throw ValidationError("Missing expected argument '<group-names>'")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        try service.removeBuildFromGroups(
+            bundleId: bundleId,
+            version: preReleaseVersion,
+            buildNumber: buildNumber,
+            groupNames: groupNames
+        )
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/RemoveGroupsFromBuildCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/RemoveGroupsFromBuildCommand.swift
@@ -27,7 +27,7 @@ struct RemoveBuildFromGroupsCommand: CommonParsableCommand {
 
     func validate() throws {
         if groupNames.isEmpty {
-            throw ValidationError("Missing expected argument '<group-names>'")
+            throw ValidationError("Excepted at least one group name.'")
         }
     }
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/TestFlightBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/TestFlightBuildsCommand.swift
@@ -11,7 +11,7 @@ public struct TestFlightBuildsCommand: ParsableCommand {
              ListBuildsCommand.self,
              ReadBuildCommand.self,
              ExpireBuildCommand.self,
-            // More...
+             RemoveBuildFromGroupsCommand.self
         ])
 
     public init() {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -272,6 +272,41 @@ class AppStoreConnectService {
         return output.map(Build.init)
     }
 
+    func removeBuildFromGroups(
+        bundleId: String,
+        version: String,
+        buildNumber: String,
+        groupNames: [String]
+    ) throws {
+        let appId = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
+            .execute(with: requestor)
+            .await()
+            .id
+
+        let buildId = try ReadBuildOperation(
+                options: .init(
+                    appId: appId,
+                    buildNumber: buildNumber,
+                    preReleaseVersion: version
+                )
+            )
+            .execute(with: requestor)
+            .await()
+            .build
+            .id
+
+        let groupIds = try groupNames.flatMap {
+            try ListBetaGroupsOperation(options: .init(appIds: [appId], names: [$0]))
+                .execute(with: requestor)
+                .await()
+                .map(\.1.id)
+        }
+
+        try RemoveBuildFromGroupsOperation(options: .init(buildId: buildId, groupIds: groupIds))
+            .execute(with: requestor)
+            .await()
+    }
+
     func readApp(identifier: ReadAppCommand.Identifier) throws -> App {
         let sdkApp = try ReadAppOperation(options: .init(identifier: identifier))
             .execute(with: requestor)

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -339,7 +339,7 @@ class AppStoreConnectService {
             try ListBetaGroupsOperation(options: .init(appIds: [appId], names: [$0]))
                 .execute(with: requestor)
                 .await()
-                .map(\.1.id)
+                .map(\.betaGroup.id)
         }
 
         try RemoveBuildFromGroupsOperation(options: .init(buildId: buildId, groupIds: groupIds))

--- a/Sources/AppStoreConnectCLI/Services/Operations/RemoveBuildFromGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/RemoveBuildFromGroupsOperation.swift
@@ -1,0 +1,32 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct RemoveBuildFromGroupsOperation: APIOperation {
+
+    struct Options {
+        let buildId: String
+        let groupIds: [String]
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    var endpoint: APIEndpoint<Void> {
+        .remove(
+            accessForBetaGroupsWithIds: options.groupIds,
+            toBuildWithId: options.buildId
+        )
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Void, Error> {
+        requestor
+            .request(endpoint)
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
Closes #115 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create service function `removeBuildFromGroups` and `RemoveBuildOperation`
- Implement RemoveBuildFromGroupsCommand 

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage: 

`asc testflight builds removebetagroup <bundle-id> <pre-release-version> <build-number> [<group-names> ...]`

## 🔨 How To Test

`asc testflight builds removebetagroup com.example.exampleApp 1.0.0 2 TestGroup1 TestGroup2`
