### PR TITLE
Implement Add build to groups command

### DIFF
--- a/Sources/AppStoreConnectCLI/Arguments/BuildArguments.swift
+++ b/Sources/AppStoreConnectCLI/Arguments/BuildArguments.swift
@@ -1,0 +1,14 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+
+struct BuildArguments: ParsableArguments {
+    @Argument(help: "The bundle ID of an application. (eg. com.example.app).")
+    var bundleId: String
+
+    @Argument(help: "The pre-release version number of this build.")
+    var preReleaseVersion: String
+    
+    @Argument(help: "The build number of this build.")
+    var buildNumber: String
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/AddGroupsToBuildCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/AddGroupsToBuildCommand.swift
@@ -1,0 +1,37 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import Combine
+import Foundation
+
+struct AddGroupsToBuildCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "addbetagroup",
+        abstract: "Add access for beta groups to a build")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @OptionGroup()
+    var build: BuildArguments
+
+    @Argument(help: "Names of beta groups.")
+    var groupNames: [String]
+
+    func validate() throws {
+        if groupNames.isEmpty {
+            throw ValidationError("Excepted at least one group name.")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        try service.addGroupsToBuild(
+            bundleId: build.bundleId,
+            version: build.preReleaseVersion,
+            buildNumber: build.buildNumber,
+            groupNames: groupNames
+        )
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ExpireBuildCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ExpireBuildCommand.swift
@@ -13,18 +13,16 @@ struct ExpireBuildCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Argument(help: "An opaque resource ID that uniquely identifies the build")
-    var bundleId: String
-
-    @Argument(help: "The pre-release version number of this build")
-    var preReleaseVersion: String
-
-    @Argument(help: "The build number of this build")
-    var buildNumber: String
+    @OptionGroup()
+    var build: BuildArguments
 
     func run() throws {
         let service = try makeService()
 
-        _ = try service.expireBuild(bundleId: bundleId, buildNumber: buildNumber, preReleaseVersion: preReleaseVersion)
+        _ = try service.expireBuild(
+            bundleId: build.bundleId,
+            buildNumber: build.buildNumber,
+            preReleaseVersion: build.preReleaseVersion
+        )
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/TestFlightBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/TestFlightBuildsCommand.swift
@@ -11,7 +11,8 @@ public struct TestFlightBuildsCommand: ParsableCommand {
              ListBuildsCommand.self,
              ReadBuildCommand.self,
              ExpireBuildCommand.self,
-             RemoveBuildFromGroupsCommand.self
+             RemoveBuildFromGroupsCommand.self,
+             AddGroupsToBuildCommand.self
         ])
 
     public init() {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -405,31 +405,32 @@ class AppStoreConnectService {
         buildNumber: String,
         groupNames: [String]
     ) throws {
-        let appId = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
-            .execute(with: requestor)
-            .await()
-            .id
-
-        let buildId = try ReadBuildOperation(
-                options: .init(
-                    appId: appId,
-                    buildNumber: buildNumber,
-                    preReleaseVersion: version
-                )
-            )
-            .execute(with: requestor)
-            .await()
-            .build
-            .id
-
-        let groupIds = try groupNames.flatMap {
-            try ListBetaGroupsOperation(options: .init(appIds: [appId], names: [$0]))
-                .execute(with: requestor)
-                .await()
-                .map(\.betaGroup.id)
-        }
+        let (buildId, groupIds) = try getBuildIdAndGroupIdsFrom(
+            bundleId: bundleId,
+            version: version,
+            buildNumber: buildNumber,
+            groupNames: groupNames
+        )
 
         try RemoveBuildFromGroupsOperation(options: .init(buildId: buildId, groupIds: groupIds))
+            .execute(with: requestor)
+            .await()
+    }
+
+    func addGroupsToBuild(
+        bundleId: String,
+        version: String,
+        buildNumber: String,
+        groupNames: [String]
+    ) throws {
+        let (buildId, groupIds) = try getBuildIdAndGroupIdsFrom(
+            bundleId: bundleId,
+            version: version,
+            buildNumber: buildNumber,
+            groupNames: groupNames
+        )
+
+        try AddGroupsToBuildOperation(options: .init(groupIds: groupIds, buildId: buildId))
             .execute(with: requestor)
             .await()
     }
@@ -499,4 +500,41 @@ class AppStoreConnectService {
             provider.request(endpoint, completion: promise)
         }
     }
+}
+
+extension AppStoreConnectService {
+
+    func getBuildIdAndGroupIdsFrom(
+        bundleId: String,
+        version: String,
+        buildNumber: String,
+        groupNames: [String]
+    ) throws -> (buildId: String, groupIds: [String]) {
+        let appId = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
+            .execute(with: requestor)
+            .await()
+            .id
+
+        let buildId = try ReadBuildOperation(
+                options: .init(
+                    appId: appId,
+                    buildNumber: buildNumber,
+                    preReleaseVersion: version
+                )
+            )
+            .execute(with: requestor)
+            .await()
+            .build
+            .id
+
+        let groupIds = try groupNames.flatMap {
+            try ListBetaGroupsOperation(options: .init(appIds: [appId], names: [$0]))
+                .execute(with: requestor)
+                .await()
+                .map(\.betaGroup.id)
+        }
+
+        return (buildId, groupIds)
+    }
+
 }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -526,13 +526,16 @@ extension AppStoreConnectService {
             .await()
             .build
             .id
-
-        let groupIds = try groupNames.flatMap {
-            try ListBetaGroupsOperation(options: .init(appIds: [appId], names: [$0]))
-                .execute(with: requestor)
-                .await()
-                .map(\.betaGroup.id)
-        }
+        let groupIds = try ListBetaGroupsOperation(options: .init(appIds: [], names: []))
+            .execute(with: requestor)
+            .await()
+            .filter {
+                guard let groupName = $0.betaGroup.attributes?.name else {
+                    return false
+                }
+                return $0.app.id == appId && groupNames.contains(groupName)
+            }
+            .map(\.betaGroup.id)
 
         return (buildId, groupIds)
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/AddGroupsToBuildOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/AddGroupsToBuildOperation.swift
@@ -1,0 +1,29 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct AddGroupsToBuildOperation: APIOperation {
+
+    struct Options {
+        let groupIds: [String]
+        let buildId: String
+    }
+
+    private let options: Options
+
+    var endpoint: APIEndpoint<Void> {
+        .add(accessForBetaGroupsWithIds: options.groupIds, toBuildWithId: options.buildId)
+    }
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Void, Error> {
+        requestor
+            .request(endpoint)
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
Closes #114 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `BuildArguments` for reuse arguments 
- Implement `AddGroupsToBuildCommand` and `AddGroupsToBuildOperation`
- Add paingation to ListBetaGroupsOperation 
- Use local filter when finding groups.

# ⚠️ Items of Note

Can discuss if extract argument to OptionGroup is needed 

# 🧐🗒 Reviewer Notes

## 💁 Example

USAGE: 
`asc testflight builds addbetagroup <bundle-id> <pre-release-version> <build-number> [<group-names> ...]`

## 🔨 How To Test

`asc testflight builds addbetagroup com.example.foo 1.0.0 2 TestGroup`
