### PR TITLE
Implement Add tester's' to group's' Command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/AddTestersToGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/AddTestersToGroupCommand.swift
@@ -1,0 +1,34 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+
+struct AddTestersToGroupCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "adduser",
+        abstract: "Add testers to beta group"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The bundle ID of an application. (eg. com.example.app)")
+    var bundleId: String
+
+    @Argument(help: "Name of TestFlight beta tester group.")
+    var groupName: String
+
+    @Argument(help: "Beta testers' email addresses.")
+    var emails: [String]
+
+    func validate() throws {
+        if emails.isEmpty {
+            throw ValidationError("Expected at least one email.")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        try service.addTestersToGroup(bundleId: bundleId, groupName: groupName, emails: emails)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
@@ -15,7 +15,8 @@ struct TestFlightBetaGroupCommand: ParsableCommand {
             DeleteBetaGroupCommand.self,
             ListBetaGroupsCommand.self,
             ModifyBetaGroupCommand.self,
-            RemoveTestersFromGroupCommand.self
+            RemoveTestersFromGroupCommand.self,
+            AddTestersToGroupCommand.self
         ],
         defaultSubcommand: ListBetaGroupsCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/AddTesterToGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/AddTesterToGroupsCommand.swift
@@ -1,0 +1,34 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+
+struct AddTesterToGroupsCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "addgroup",
+        abstract: "Add tester to one or more groups"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "Beta testers' email address.")
+    var email: String
+
+    @Argument(help: "The bundle ID of an application. (eg. com.example.app)")
+    var bundleId: String
+
+    @Argument(help: "Name of TestFlight beta tester group.")
+    var groupNames: [String]
+
+    func validate() throws {
+        if groupNames.isEmpty {
+            throw ValidationError("Expected at least one group name.")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        try service.addTesterToGroups(email: email, bundleId: bundleId, groupNames: groupNames)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
@@ -13,7 +13,8 @@ public struct TestFlightBetaTestersCommand: ParsableCommand {
              ListBetaTestersCommand.self,
              ListBetaTesterByBuildsCommand.self,
              ReadBetaTesterCommand.self,
-             RemoveTesterFromGroupsCommand.self
+             RemoveTesterFromGroupsCommand.self,
+             AddTesterToGroupsCommand.self
         ])
 
     public init() {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -71,19 +71,16 @@ class AppStoreConnectService {
         emails: [String]
     ) throws {
         let testerIds = try emails.map {
-            try GetBetaTesterOperation(options: .init(id: nil, email: $0))
+            try GetBetaTesterOperation(options: .init(identifier: .email($0)))
                 .execute(with: requestor)
                 .await()
                 .betaTester
                 .id
         }
 
-        let app = try GetAppsOperation(
-                options: .init(bundleIds: [bundleId])
-            )
+        let app = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
             .execute(with: requestor)
             .await()
-            .first!
 
         let groupId = try GetBetaGroupOperation(
                 options: .init(app: app, betaGroupName: groupName)
@@ -106,18 +103,15 @@ class AppStoreConnectService {
         bundleId: String,
         groupNames: [String]
     ) throws {
-        let testerId = try GetBetaTesterOperation(options: .init(id: nil, email: email))
+        let testerId = try GetBetaTesterOperation(options: .init(identifier: .email(email)))
             .execute(with: requestor)
             .await()
             .betaTester
             .id
 
-        let app = try GetAppsOperation(
-                options: .init(bundleIds: [bundleId])
-            )
+        let app = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
             .execute(with: requestor)
             .await()
-            .first!
 
         let groupIds = try groupNames.map {
             try GetBetaGroupOperation(

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -65,6 +65,78 @@ class AppStoreConnectService {
         return BetaTester(output)
     }
 
+    func addTestersToGroup(
+        bundleId: String,
+        groupName: String,
+        emails: [String]
+    ) throws {
+        let testerIds = try emails.map {
+            try GetBetaTesterOperation(options: .init(id: nil, email: $0))
+                .execute(with: requestor)
+                .await()
+                .betaTester
+                .id
+        }
+
+        let app = try GetAppsOperation(
+                options: .init(bundleIds: [bundleId])
+            )
+            .execute(with: requestor)
+            .await()
+            .first!
+
+        let groupId = try GetBetaGroupOperation(
+                options: .init(app: app, betaGroupName: groupName)
+            )
+            .execute(with: requestor)
+            .await()
+            .id
+
+        try AddTesterToGroupOperation(
+                options: .init(
+                    addStrategy: .addTestersToGroup(testerIds: testerIds, groupId: groupId)
+                )
+            )
+            .execute(with: requestor)
+            .await()
+    }
+
+    func addTesterToGroups(
+        email: String,
+        bundleId: String,
+        groupNames: [String]
+    ) throws {
+        let testerId = try GetBetaTesterOperation(options: .init(id: nil, email: email))
+            .execute(with: requestor)
+            .await()
+            .betaTester
+            .id
+
+        let app = try GetAppsOperation(
+                options: .init(bundleIds: [bundleId])
+            )
+            .execute(with: requestor)
+            .await()
+            .first!
+
+        let groupIds = try groupNames.map {
+            try GetBetaGroupOperation(
+                    options: .init(app: app, betaGroupName: $0)
+                )
+                .execute(with: requestor)
+                .await()
+                .id
+        }
+
+        try AddTesterToGroupOperation(
+                options: .init(
+                    addStrategy: .addTesterToGroups(testerId: testerId, groupIds: groupIds)
+                )
+            )
+            .execute(with: requestor)
+            .await()
+    }
+
     func getBetaTester(
         email: String,
         limitApps: Int?,

--- a/Sources/AppStoreConnectCLI/Services/Operations/AddTesterToGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/AddTesterToGroupOperation.swift
@@ -1,0 +1,38 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct AddTesterToGroupOperation: APIOperation {
+
+    struct Options {
+        enum AddStrategy {
+            case addTestersToGroup(testerIds: [String], groupId: String)
+            case addTesterToGroups(testerId: String, groupIds: [String])
+        }
+
+        let addStrategy: AddStrategy
+    }
+
+    private let options: Options
+
+    var endpoint: APIEndpoint<Void> {
+        switch options.addStrategy {
+        case .addTestersToGroup(let testerIds, let groupId):
+            return .add(betaTestersWithIds: testerIds, toBetaGroupWithId: groupId)
+        case .addTesterToGroups(let testerId, let groupIds):
+            return .add(betaTesterWithId: testerId, toBetaGroupsWithIds: groupIds)
+        }
+    }
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Void, Error> {
+        requestor
+            .request(endpoint)
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
Closes #109 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Implement `AddTestersToGroupCommand` and `AddTesterToGroupsCommand`
- Create `AddTesterToGroupOperation` and service functions accordingly

# 🧐🗒 Reviewer Notes

## 💁 Example

USAGE:
```
asc testflight betagroup adduser <bundle-id> <group-name> [<emails> ...]
```
```
asc testflight betatesters addgroup <email> <bundle-id> [<group-names> ...]
```

## 🔨 How To Test
```
asc testflight betatesters addgroup foo@gmail.com com.example.app TestGroup1 TestGroup2
```

```
asc testflight betagroup adduser com.example.app TestGroup1 foo@gmail.com bar@gmail.com
```
