### PR TITLE
Read beta group

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
@@ -15,6 +15,7 @@ struct TestFlightBetaGroupCommand: ParsableCommand {
             DeleteBetaGroupCommand.self,
             ListBetaGroupsCommand.self,
             ModifyBetaGroupCommand.self,
+            ReadBetaGroupCommand.self,
             RemoveTestersFromGroupCommand.self,
             AddTestersToGroupCommand.self
         ],

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
@@ -12,7 +12,21 @@ struct ReadBetaGroupCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
+    @Argument(
+        help: """
+        The reverse-DNS bundle ID of the app which the group should be associated with. \
+        Must be unique. (eg. com.example.app)
+        """
+    ) var appBundleId: String
+
+    @Argument(help: "The name of the beta group")
+    var groupName: String
+
     func run() throws {
         let service = try makeService()
+
+        let betaGroup = try service.readBetaGroup(bundleId: appBundleId, groupName: groupName)
+
+        betaGroup.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
@@ -18,7 +18,7 @@ struct ReadBetaGroupCommand: CommonParsableCommand {
         """
     ) var appBundleId: String
 
-    @Argument(help: "The name of the beta group")
+    @Argument(help: "The name of the beta group.")
     var groupName: String
 
     func run() throws {

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
@@ -1,7 +1,6 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 import ArgumentParser
-import Foundation
 
 struct ReadBetaGroupCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
@@ -1,0 +1,18 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import Foundation
+
+struct ReadBetaGroupCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "read",
+        abstract: "Read a beta group"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    func run() throws {
+        let service = try makeService()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -253,6 +253,19 @@ class AppStoreConnectService {
 
         try operation.execute(with: requestor).await()
     }
+
+    func readBetaGroup(bundleId: String, groupName: String) throws -> BetaGroup {
+        let app = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
+            .execute(with: requestor)
+            .await()
+
+        let options = GetBetaGroupOperation.Options(app: app, betaGroupName: groupName)
+        let betaGroup = try GetBetaGroupOperation(options: options)
+            .execute(with: requestor)
+            .await()
+
+        return BetaGroup(app, betaGroup)
+    }
         
     func createBetaGroup(
         appBundleId: String,


### PR DESCRIPTION
Closes #100 

# 📝 Summary of Changes

Changes proposed in this pull request:
- Adds ReadBetaGroupCommand
- Adds readBetaGroup sevice function leveraging existing operations

# 🧐🗒 Reviewer Notes

## 💁 Example

`asc testflight betagroup read com.example.app testGroup --yaml`

```
app:
  id: 1234567890
  bundleId: com.example.app
  name: Test App
  primaryLocale: en-AU
  sku: TEST1
groupName: testGroup
isInternal: false
publicLinkEnabled: false
publicLinkLimitEnabled: false
creationDate: 2020-05-06T05:16:51Z
```

## 🔨 How To Test

Use the existing `asc testflight betagroup list` command
From the results pick a unique combination of bundle id and betagroup name and run the read command with the following usage:
`USAGE: asc testflight betagroup read [--api-issuer <uuid>] [--api-key-id <keyid>] [--csv] [--json] [--table] [--yaml] <app-bundle-id> <group-name>`
