### PR TITLE
Implement Sync Beta Group Commands

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "AppStoreConnect-Swift-SDK",
-        "repositoryURL": "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
+        "repositoryURL": "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
         "state": {
           "branch": "master",
           "revision": "65d95d0979734597e7fb7d2d30028c659594ac53",

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "AppStoreConnect-Swift-SDK",
-        "repositoryURL": "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
+        "repositoryURL": "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
         "state": {
           "branch": "master",
           "revision": "65d95d0979734597e7fb7d2d30028c659594ac53",

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
             from: "0.0.2"
         ),
         .package(
-            url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
+            url: "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
             .branch("master")
         ),
         .package(

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
             from: "0.0.2"
         ),
         .package(
-            url: "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
+            url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
             .branch("master")
         ),
         .package(

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
@@ -18,6 +18,7 @@ struct TestFlightBetaGroupCommand: ParsableCommand {
             ReadBetaGroupCommand.self,
             RemoveTestersFromGroupCommand.self,
             AddTestersToGroupCommand.self,
+            SyncBetaGroupsCommand.self,
         ],
         defaultSubcommand: ListBetaGroupsCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PullBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PullBetaGroupsCommand.swift
@@ -1,0 +1,30 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import FileSystem
+
+struct PullBetaGroupsCommand: CommonParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        commandName: "pull",
+        abstract: "Pull down server beta groups, refresh local beta group config files"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Option(
+        default: "./config/betagroups",
+        help: "Path to the Folder containing the information about beta groups. (default: './config/betagroups')"
+    ) var outputPath: String
+
+    func run() throws {
+        let service = try makeService()
+
+        let betaGroupWithTesters = try service.pullBetaGroups()
+
+        try BetaGroupProcessor(path: .folder(path: outputPath))
+            .write(groupsWithTesters: betaGroupWithTesters)
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PullBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PullBetaGroupsCommand.swift
@@ -7,7 +7,7 @@ struct PullBetaGroupsCommand: CommonParsableCommand {
 
     static var configuration = CommandConfiguration(
         commandName: "pull",
-        abstract: "Pull down server beta groups, refresh local beta group config files"
+        abstract: "Pull down existing beta groups, refreshing local beta group config files"
     )
 
     @OptionGroup()
@@ -15,7 +15,7 @@ struct PullBetaGroupsCommand: CommonParsableCommand {
 
     @Option(
         default: "./config/betagroups",
-        help: "Path to the Folder containing the information about beta groups. (default: './config/betagroups')"
+        help: "Path to the Folder containing the information about beta groups."
     ) var outputPath: String
 
     func run() throws {

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
@@ -1,6 +1,8 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 import ArgumentParser
+import FileSystem
+import Foundation
 import struct Model.BetaGroup
 
 struct PushBetaGroupsCommand: CommonParsableCommand {
@@ -22,7 +24,66 @@ struct PushBetaGroupsCommand: CommonParsableCommand {
     var dryRun: Bool
 
     func run() throws {
+        let service = try makeService()
 
+        let resourceProcessor = BetaGroupProcessor(path: .folder(path: inputPath))
+
+        let serverGroups = Set(try service.pullBetaGroups().map{ $0.betaGroup })
+        let localGroups = Set(try resourceProcessor.read())
+
+        let strategies = compareGroups(
+            localGroups: localGroups,
+            serverGroups: serverGroups
+        )
+
+        let renderer = Renderers.SyncResultRenderer<BetaGroup>()
+
+        if dryRun {
+            renderer.render(strategies, isDryRun: true)
+        } else {
+            try strategies.forEach { (strategy: SyncStrategy) in
+                switch strategy {
+                case .create(let group):
+                    _ = try service.createBetaGroup(
+                        appBundleId: group.app.bundleId!,
+                        groupName: group.groupName,
+                        publicLinkEnabled: group.publicLinkEnabled ?? false,
+                        publicLinkLimit: group.publicLinkLimit
+                    )
+                case .delete(let group):
+                    try service.deleteBetaGroup(with: group.id!)
+                case .update(let group):
+                    try service.updateBetaGroup(betaGroup: group)
+                }
+
+                renderer.render(strategy, isDryRun: false)
+            }
+
+            let betaGroupWithTesters = try service.pullBetaGroups()
+
+            try resourceProcessor.write(groupsWithTesters: betaGroupWithTesters)
+        }
+    }
+
+    func compareGroups(localGroups: Set<BetaGroup>, serverGroups: Set<BetaGroup>) -> [SyncStrategy<BetaGroup>] {
+        var strategies: [SyncStrategy<BetaGroup>] = []
+
+        let groupToCreate = localGroups.subtracting(serverGroups)
+        let groupToDelete = serverGroups.subtracting(localGroups)
+
+        groupToDelete.forEach { group in
+            if !localGroups.contains(where: { group.id == $0.id }) {
+                strategies.append(.delete(group))
+            }
+        }
+
+        groupToCreate.forEach { group in
+            serverGroups.contains(where: { group.id == $0.id })
+                ? strategies.append(.update(group))
+                : strategies.append(.create(group))
+        }
+
+        return strategies
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import struct Model.BetaGroup
+
+struct PushBetaGroupsCommand: CommonParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        commandName: "push",
+        abstract: "Push local beta group config files to server, update server beta groups"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Option(
+        default: "./config/betagroups",
+        help: "Path to the Folder containing the information about beta groups. (default: './config/betagroups')"
+    ) var inputPath: String
+
+    @Flag(help: "Perform a dry run.")
+    var dryRun: Bool
+
+    func run() throws {
+
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
@@ -43,26 +43,32 @@ struct PushBetaGroupsCommand: CommonParsableCommand {
             renderer.render(strategies, isDryRun: true)
         } else {
             try strategies.forEach { (strategy: SyncStrategy) in
-                switch strategy {
-                case .create(let group):
-                    _ = try service.createBetaGroup(
-                        appBundleId: group.app.bundleId!,
-                        groupName: group.groupName,
-                        publicLinkEnabled: group.publicLinkEnabled ?? false,
-                        publicLinkLimit: group.publicLinkLimit
-                    )
-                case .delete(let group):
-                    try service.deleteBetaGroup(with: group.id!)
-                case .update(let group):
-                    try service.updateBetaGroup(betaGroup: group)
-                }
-
+                try syncBetaGroup(strategy: strategy, with: service)
                 renderer.render(strategy, isDryRun: false)
             }
 
             let betaGroupWithTesters = try service.pullBetaGroups()
 
             try resourceProcessor.write(groupsWithTesters: betaGroupWithTesters)
+        }
+    }
+
+    func syncBetaGroup(
+        strategy: SyncStrategy<BetaGroup>,
+        with service: AppStoreConnectService
+    ) throws {
+        switch strategy {
+        case .create(let group):
+            _ = try service.createBetaGroup(
+                appBundleId: group.app.bundleId!,
+                groupName: group.groupName,
+                publicLinkEnabled: group.publicLinkEnabled ?? false,
+                publicLinkLimit: group.publicLinkLimit
+            )
+        case .delete(let group):
+            try service.deleteBetaGroup(with: group.id!)
+        case .update(let group):
+            try service.updateBetaGroup(betaGroup: group)
         }
     }
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/PushBetaGroupsCommand.swift
@@ -28,7 +28,7 @@ struct PushBetaGroupsCommand: CommonParsableCommand {
 
         let resourceProcessor = BetaGroupProcessor(path: .folder(path: inputPath))
 
-        let serverGroups = Set(try service.pullBetaGroups().map{ $0.betaGroup })
+        let serverGroups = Set(try service.pullBetaGroups().map { $0.betaGroup })
         let localGroups = Set(try resourceProcessor.read())
 
         let strategies = compareGroups(

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/SyncBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/SyncBetaGroupsCommand.swift
@@ -1,0 +1,17 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+
+struct SyncBetaGroupsCommand: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "sync",
+        abstract: """
+        Sync information about beta groups with provided configuration file.
+        """,
+        subcommands: [
+            PullBetaGroupsCommand.self,
+            PushBetaGroupsCommand.self,
+        ],
+        defaultSubcommand: PullBetaGroupsCommand.self
+    )
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/SyncBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/Sync/SyncBetaGroupsCommand.swift
@@ -5,13 +5,10 @@ import ArgumentParser
 struct SyncBetaGroupsCommand: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "sync",
-        abstract: """
-        Sync information about beta groups with provided configuration file.
-        """,
+        abstract: "Sync information about beta groups with provided configuration file.",
         subcommands: [
             PullBetaGroupsCommand.self,
             PushBetaGroupsCommand.self,
-        ],
-        defaultSubcommand: PullBetaGroupsCommand.self
+        ]
     )
 }

--- a/Sources/AppStoreConnectCLI/Model/App.swift
+++ b/Sources/AppStoreConnectCLI/Model/App.swift
@@ -38,7 +38,7 @@ extension App: TableInfoProvider {
 
     var tableRow: [CustomStringConvertible] {
         return [
-            id,
+            id ?? "",
             bundleId ?? "",
             name ?? "",
             primaryLocale ?? "",

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -81,7 +81,7 @@ extension BetaGroup: SyncResultRenderable {
 }
 
 extension BetaGroup: SyncResourceProcessable {
-    var compareIdentity: String? {
-        id
+    var compareIdentity: String {
+        id ?? ""
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -26,7 +26,7 @@ extension BetaGroup: TableInfoProvider, ResultRenderable {
 
     var tableRow: [CustomStringConvertible] {
         [
-            app.id,
+            app.id ?? "",
             app.bundleId ?? "",
             app.name ?? "",
             groupName,
@@ -77,5 +77,11 @@ extension BetaGroup {
 extension BetaGroup: SyncResultRenderable {
     var syncResultText: String {
         "\(app.bundleId ?? "" )_\(groupName)"
+    }
+}
+
+extension BetaGroup: SyncResourceProcessable {
+    var compareIdentity: String? {
+        id
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -73,3 +73,9 @@ extension BetaGroup {
         )
     }
 }
+
+extension BetaGroup: SyncResultRenderable {
+    var syncResultText: String {
+        "\(app.bundleId ?? "" )_\(groupName)"
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -29,7 +29,7 @@ extension BetaGroup: TableInfoProvider, ResultRenderable {
             app.id,
             app.bundleId ?? "",
             app.name ?? "",
-            groupName ?? "",
+            groupName,
             isInternal ?? "",
             publicLink ?? "",
             publicLinkEnabled ?? "",
@@ -41,13 +41,29 @@ extension BetaGroup: TableInfoProvider, ResultRenderable {
 }
 
 extension BetaGroup {
+    enum Error: LocalizedError {
+        case invalidName
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidName:
+                return "Beta group doesn't have a valid group name."
+            }
+        }
+    }
+
     init(
         _ apiApp: AppStoreConnect_Swift_SDK.App,
         _ apiBetaGroup: AppStoreConnect_Swift_SDK.BetaGroup
-    ) {
+    ) throws {
+        guard let groupName = apiBetaGroup.attributes?.name else {
+            throw Error.invalidName
+        }
+
         self.init(
             app: App(apiApp),
-            groupName: apiBetaGroup.attributes?.name,
+            id: apiBetaGroup.id,
+            groupName: groupName,
             isInternal: apiBetaGroup.attributes?.isInternalGroup,
             publicLink: apiBetaGroup.attributes?.publicLink,
             publicLinkEnabled: apiBetaGroup.attributes?.publicLinkEnabled,

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -114,7 +114,7 @@ extension ResultRenderable where Self: TableInfoProvider {
     }
 }
 
-protocol SyncResultRenderable {
+protocol SyncResultRenderable: Equatable {
     var syncResultText: String { get }
 }
 

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -150,5 +150,5 @@ extension Renderers {
             print("\(isDryRun ? "" : "✅") \(resultText)")
         }
     }
-    
+
 }

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -113,3 +113,42 @@ extension ResultRenderable where Self: TableInfoProvider {
         return table.render()
     }
 }
+
+protocol SyncResultRenderable {
+    var syncResultText: String { get }
+}
+
+enum SyncStrategy<T: SyncResultRenderable> {
+    case delete(T)
+    case create(T)
+    case update(T)
+}
+
+extension Renderers {
+
+    struct SyncResultRenderer<T: SyncResultRenderable> {
+
+        func render(_ strategy: [SyncStrategy<T>], isDryRun: Bool) {
+            strategy.forEach { renderResultText($0, isDryRun) }
+        }
+
+        func render(_ strategy: SyncStrategy<T>, isDryRun: Bool) {
+            renderResultText(strategy, isDryRun)
+        }
+
+        private func renderResultText(_ strategy: SyncStrategy<T>, _ isDryRun: Bool) {
+            let resultText: String
+            switch strategy {
+            case .create(let input):
+                resultText = "➕ \(input.syncResultText)"
+            case .delete(let input):
+                resultText = "➖ \(input.syncResultText)"
+            case .update(let input):
+                resultText = "⬆️  \(input.syncResultText)"
+            }
+
+            print("\(isDryRun ? "" : "✅") \(resultText)")
+        }
+    }
+    
+}

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -526,10 +526,15 @@ class AppStoreConnectService {
     }
 
     func updateBetaGroup(betaGroup: Model.BetaGroup) throws {
-        // TODO
-//        _ = try UpdateBetaGroupOperation(options: .init(betaGroup: betaGroup))
-//            .execute(with: requestor)
-//            .await()
+        _ = try UpdateBetaGroupOperation(options: .init(betaGroup: betaGroup))
+            .execute(with: requestor)
+            .await()
+    }
+
+    func deleteBetaGroup(with id: String) throws {
+        try DeleteBetaGroupOperation(options: .init(betaGroupId: id))
+            .execute(with: requestor)
+            .await()
     }
 
     func readBuild(bundleId: String, buildNumber: String, preReleaseVersion: String) throws -> Model.Build {

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
@@ -7,26 +7,15 @@ import Foundation
 struct ListBetaTestersOperation: APIOperation {
 
     struct Options {
-        let email: String?
-        let firstName: String?
-        let lastName: String?
-        let inviteType: BetaInviteType?
-        let appIds: [String]?
-        let groupIds: [String]?
-        let sort: ListBetaTesters.Sort?
-        let limit: Int?
-        let relatedResourcesLimit: Int?
-    }
-
-    enum Error: LocalizedError {
-        case notFound
-
-        var errorDescription: String? {
-            switch self {
-            case .notFound:
-                return "Beta testers with provided filters not found."
-            }
-        }
+        var email: String?
+        var firstName: String?
+        var lastName: String?
+        var inviteType: BetaInviteType?
+        var appIds: [String]?
+        var groupIds: [String]?
+        var sort: ListBetaTesters.Sort?
+        var limit: Int?
+        var relatedResourcesLimit: Int?
     }
 
     private let options: Options
@@ -107,13 +96,9 @@ struct ListBetaTestersOperation: APIOperation {
                     next: $0
                 )
             }
-            .tryMap { (responses: [BetaTestersResponse]) throws -> Output in
-                try responses.flatMap { (response: BetaTestersResponse) -> Output in
-                    guard !response.data.isEmpty else {
-                        throw Error.notFound
-                    }
-
-                    return response.data.map {
+            .map {
+                $0.flatMap { (response: BetaTestersResponse) -> Output in
+                    response.data.map {
                         .init(betaTester: $0, includes: response.included)
                     }
                 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/UpdateBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/UpdateBetaGroupOperation.swift
@@ -1,0 +1,34 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+import struct Model.BetaGroup
+
+struct UpdateBetaGroupOperation: APIOperation {
+
+    struct Options {
+        let betaGroup: BetaGroup
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<BetaGroupResponse, Error> {
+        let betaGroup = options.betaGroup
+
+        let endpoint = APIEndpoint.modify(
+            betaGroupWithId: betaGroup.id!,
+            name: betaGroup.groupName,
+            publicLinkEnabled: betaGroup.publicLinkEnabled,
+            publicLinkLimit: betaGroup.publicLinkLimit,
+            publicLinkLimitEnabled: betaGroup.publicLinkLimitEnabled
+        )
+
+        return requestor.request(endpoint).eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/SyncService.swift
+++ b/Sources/AppStoreConnectCLI/Services/SyncService.swift
@@ -7,7 +7,7 @@ protocol SyncResourceProcessable: SyncResourceComparable, SyncResultRenderable {
 protocol SyncResourceComparable: Hashable {
     associatedtype T: Comparable
 
-    var compareIdentity: T? { get }
+    var compareIdentity: T { get }
 }
 
 struct SyncResourceComparator<T: SyncResourceProcessable> {

--- a/Sources/AppStoreConnectCLI/Services/SyncService.swift
+++ b/Sources/AppStoreConnectCLI/Services/SyncService.swift
@@ -1,0 +1,42 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+protocol SyncResourceProcessable: SyncResourceComparable, SyncResultRenderable { }
+
+protocol SyncResourceComparable: Hashable {
+    associatedtype T: Comparable
+
+    var compareIdentity: T? { get }
+}
+
+struct SyncResourceComparator<T: SyncResourceProcessable> {
+
+    let localResources: [T]
+    let serverResources: [T]
+
+    private var localResourcesSet: Set<T> { Set(localResources) }
+    private var serverResourcesSet: Set<T> { Set(serverResources) }
+
+    func compare() -> [SyncStrategy<T>] {
+        serverResourcesSet
+            .subtracting(localResourcesSet)
+            .compactMap { resource -> SyncStrategy<T>? in
+                localResources
+                    .contains(where: { resource.compareIdentity == $0.compareIdentity })
+                    ? nil
+                    : .delete(resource)
+            }
+        +
+        localResourcesSet
+            .subtracting(serverResourcesSet)
+            .compactMap { resource -> SyncStrategy<T>? in
+                serverResourcesSet
+                    .contains(
+                        where: { resource.compareIdentity == $0.compareIdentity }
+                    )
+                    ? .update(resource)
+                    : .create(resource)
+        }
+    }
+}

--- a/Sources/FileSystem/Beta Group/BetaGroupProcessor.swift
+++ b/Sources/FileSystem/Beta Group/BetaGroupProcessor.swift
@@ -1,0 +1,44 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Files
+import Foundation
+import Model
+import Yams
+
+public struct BetaGroupProcessor: ResourceProcessor {
+
+    public init(path: ResourcePath) {
+        self.path = path
+    }
+
+    func write(_: [BetaGroup]) throws -> [File] {
+        fatalError()
+    }
+
+    var path: ResourcePath
+
+    func write(_ betaGroup: BetaGroup) throws -> File {
+        try writeFile(betaGroup)
+    }
+
+    func read() throws -> [BetaGroup] {
+        fatalError()
+    }
+
+    public func write(groupsWithTesters: [(betaGroup: BetaGroup, testers: [BetaTester])]) throws {
+        deleteFile()
+
+        try groupsWithTesters.map { try write($0.betaGroup) }
+    }
+
+}
+
+extension BetaGroup: FileProvider {
+    var fileName: String {
+        "\(app.id)_\(groupName).yml"
+    }
+
+    func fileContent() throws -> FileContent {
+        .string(try YAMLEncoder().encode(self))
+    }
+}

--- a/Sources/FileSystem/Beta Tester/BetaTesterProcessor.swift
+++ b/Sources/FileSystem/Beta Tester/BetaTesterProcessor.swift
@@ -1,0 +1,45 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import CodableCSV
+import Files
+import Foundation
+import Model
+
+struct BetaTesterProcessor {
+
+    let folder: Folder
+
+    typealias FilePath = String
+
+    func write(group: BetaGroup, testers: [BetaTester]) throws -> FilePath {
+        let file = try folder.createFile(named: "\(group.app.bundleId ?? "")_\(group.groupName)_beta-testers.csv")
+
+        try file.write(testers.renderAsCSV())
+
+        return file.name
+    }
+}
+
+// TODO: merge this with ResultRenderable in main module
+protocol CSVRenderable: Codable {
+    var headers: [String] { get }
+    var rows: [[String]] { get }
+}
+
+extension CSVRenderable {
+    func renderAsCSV() -> String {
+        let wholeTable = [headers] + rows
+
+        return try! CSVWriter.encode(rows: wholeTable, into: String.self) // swiftlint:disable:this force_try
+    }
+}
+
+extension Array: CSVRenderable where Element == BetaTester {
+    var headers: [String] {
+        ["Email", "First Name", "Last Name", "Invite Type"]
+    }
+
+    var rows: [[String]] {
+        self.map { [$0.email, $0.firstName, $0.lastName, $0.inviteType].compactMap { $0 } }
+    }
+}

--- a/Sources/FileSystem/Certificates/CertificateProcessor.swift
+++ b/Sources/FileSystem/Certificates/CertificateProcessor.swift
@@ -36,7 +36,7 @@ extension Certificate: FileProvider {
         }
     }
 
-    func fileContent() throws -> Data {
+    func fileContent() throws -> FileContent {
         guard
             let content = content,
             let data = Data(base64Encoded: content)
@@ -44,7 +44,7 @@ extension Certificate: FileProvider {
                 throw Error.noContent
         }
 
-        return data
+        return .data(data)
     }
 
     var fileName: String {

--- a/Sources/FileSystem/FileProvider.swift
+++ b/Sources/FileSystem/FileProvider.swift
@@ -1,0 +1,18 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+protocol FileProvider: FileNameProvider, FileContentProvider { }
+
+protocol FileNameProvider {
+    var fileName: String { get }
+}
+
+enum FileContent {
+    case data(Data)
+    case string(String)
+}
+
+protocol FileContentProvider {
+    func fileContent() throws -> FileContent
+}

--- a/Sources/FileSystem/Profile/ProfileProcessor.swift
+++ b/Sources/FileSystem/Profile/ProfileProcessor.swift
@@ -38,14 +38,14 @@ extension Profile: FileProvider {
         }
     }
 
-    func fileContent() throws -> Data {
+    func fileContent() throws -> FileContent {
         guard
             let content = profileContent,
             let data = Data(base64Encoded: content) else {
                 throw Error.noContent
             }
 
-        return data
+        return .data(data)
     }
 
     var fileName: String {

--- a/Sources/FileSystem/ResourceProcessor.swift
+++ b/Sources/FileSystem/ResourceProcessor.swift
@@ -58,7 +58,7 @@ extension ResourceWriter {
         case .file(let path):
             let standardizedPath = path as NSString
             fileName = standardizedPath.lastPathComponent
-        case .folder(_):
+        case .folder:
             fileName = resource.fileName
         }
 

--- a/Sources/Model/App.swift
+++ b/Sources/Model/App.swift
@@ -3,14 +3,14 @@
 import Foundation
 
 public struct App: Codable, Equatable {
-    public let id: String
+    public let id: String?
     public var bundleId: String?
     public var name: String?
     public var primaryLocale: String?
     public var sku: String?
 
     public init(
-        id: String,
+        id: String?,
         bundleId: String?,
         name: String?,
         primaryLocale: String?,

--- a/Sources/Model/BetaGroup.swift
+++ b/Sources/Model/BetaGroup.swift
@@ -4,25 +4,30 @@ import Foundation
 
 public struct BetaGroup: Codable, Equatable {
     public let app: App
-    public let groupName: String?
+    public let id: String?
+    public let groupName: String
     public let isInternal: Bool?
     public let publicLink: String?
     public let publicLinkEnabled: Bool?
     public let publicLinkLimit: Int?
     public let publicLinkLimitEnabled: Bool?
     public let creationDate: String?
+    public var testers: String? // tester csv file path
 
     public init(
         app: App,
-        groupName: String?,
+        id: String?,
+        groupName: String,
         isInternal: Bool?,
         publicLink: String?,
         publicLinkEnabled: Bool?,
         publicLinkLimit: Int?,
         publicLinkLimitEnabled: Bool?,
-        creationDate: String?
+        creationDate: String?,
+        testers: String? = nil
     ) {
         self.app = app
+        self.id = id
         self.groupName = groupName
         self.isInternal = isInternal
         self.publicLink = publicLink
@@ -30,5 +35,6 @@ public struct BetaGroup: Codable, Equatable {
         self.publicLinkLimit = publicLinkLimit
         self.publicLinkLimitEnabled = publicLinkLimitEnabled
         self.creationDate = creationDate
+        self.testers = testers
     }
 }

--- a/Sources/Model/BetaGroup.swift
+++ b/Sources/Model/BetaGroup.swift
@@ -38,3 +38,21 @@ public struct BetaGroup: Codable, Equatable {
         self.testers = testers
     }
 }
+
+extension BetaGroup: Hashable {
+    public static func == (lhs: BetaGroup, rhs: BetaGroup) -> Bool {
+        return lhs.id == rhs.id &&
+            lhs.groupName == rhs.groupName &&
+            lhs.publicLinkEnabled == rhs.publicLinkEnabled &&
+            lhs.publicLinkLimit == rhs.publicLinkLimit &&
+            lhs.publicLinkLimitEnabled == rhs.publicLinkLimitEnabled
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(groupName)
+        hasher.combine(publicLinkEnabled)
+        hasher.combine(publicLinkLimit)
+        hasher.combine(publicLinkLimitEnabled)
+    }
+}

--- a/Tests/appstoreconnect-cliTests/Serivces/SyncResourceComparatorTests.swift
+++ b/Tests/appstoreconnect-cliTests/Serivces/SyncResourceComparatorTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class SyncResourceComparatorTests: XCTestCase {
     func testCompare_returnCreateStrategies() throws {
-        let localGroups = [generateGroup(id: "123")]
+        let localGroups = [generateGroup(name: "a new group")]
 
         let strategies = SyncResourceComparator(
                 localResources: localGroups,

--- a/Tests/appstoreconnect-cliTests/Serivces/SyncResourceComparatorTests.swift
+++ b/Tests/appstoreconnect-cliTests/Serivces/SyncResourceComparatorTests.swift
@@ -1,0 +1,107 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+@testable import AppStoreConnectCLI
+import Model
+import Foundation
+import XCTest
+
+final class SyncResourceComparatorTests: XCTestCase {
+    func testCompare_returnCreateStrategies() throws {
+        let localGroups = [generateGroup(id: "123")]
+
+        let strategies = SyncResourceComparator(
+                localResources: localGroups,
+                serverResources: []
+            )
+            .compare()
+
+        XCTAssertEqual(strategies.count, 1)
+
+        XCTAssertEqual(strategies.first!, .create(localGroups.first!))
+    }
+
+    func testCompare_returnUpdateStrategies() throws {
+        let localGroups = [generateGroup(id: "123", name: "foo")]
+        let serverGroups = [generateGroup(id: "123", name: "bar")]
+
+        let strategies = SyncResourceComparator(
+                localResources: localGroups,
+                serverResources: serverGroups
+            )
+            .compare()
+
+        XCTAssertEqual(strategies.count, 1)
+        XCTAssertEqual(strategies.first!, .update(localGroups.first!))
+    }
+
+    func testCompare_returnDelete() {
+        let serverGroups = [generateGroup(id: "123"), generateGroup(id: "456")]
+
+        let strategies = SyncResourceComparator(
+                localResources: [],
+                serverResources: serverGroups
+            )
+            .compare()
+
+        XCTAssertEqual(strategies.count, 2)
+        XCTAssertEqual(strategies.contains(.delete(serverGroups.first!)), true)
+        XCTAssertEqual(strategies.contains(.delete(serverGroups[1])), true)
+        XCTAssertNotEqual(strategies.contains(.update(generateGroup(id: "1234"))), true)
+    }
+
+    func testCompare_returnDeleteAndUpdateAndCreate() {
+        let localGroups = [generateGroup(id: "1", publicLinkEnabled: true), generateGroup(name: "hi")]
+        let serverGroups = [generateGroup(id: "1", publicLinkEnabled: false), generateGroup(id: "3", name: "there")]
+
+        let strategies = SyncResourceComparator(
+                localResources: localGroups,
+                serverResources: serverGroups
+            )
+            .compare()
+
+        XCTAssertEqual(strategies.count, 3)
+
+        XCTAssertEqual(strategies.contains(.delete(serverGroups[1])), true)
+        XCTAssertEqual(strategies.contains(.create(localGroups[1])), true)
+        XCTAssertEqual(strategies.contains(.update(localGroups[0])), true)
+    }
+}
+
+private extension SyncResourceComparatorTests {
+    func generateGroup(
+        id: String? = nil,
+        name: String = "foo",
+        isInternal: Bool = false,
+        publicLinkEnabled: Bool = false,
+        publicLinkLimit: Int = 10,
+        publicLinkLimitEnabled: Bool = false
+    ) -> BetaGroup {
+        BetaGroup(
+            app: App(id: "", bundleId: "com.example.foo", name: "foo", primaryLocale: "", sku: ""),
+            id: id,
+            groupName: name,
+            isInternal: isInternal,
+            publicLink: "",
+            publicLinkEnabled: publicLinkEnabled,
+            publicLinkLimit: publicLinkLimit,
+            publicLinkLimitEnabled: publicLinkLimitEnabled,
+            creationDate: "",
+            testers: ""
+        )
+    }
+}
+
+extension SyncStrategy: Equatable {
+    public static func == (lhs: SyncStrategy<T>, rhs: SyncStrategy<T>) -> Bool {
+        switch (lhs, rhs) {
+        case (let .create(lhsItem), let .create(rhsItem)):
+            return lhsItem == rhsItem
+        case (let .update(lhsItem), let .update(rhsItem)):
+            return lhsItem == rhsItem
+        case (let .delete(lhsItem), let .delete(rhsItem)):
+            return lhsItem == rhsItem
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Implement basic sync beta group command.

- [x] Delete local group files -> request to remove groups in server
- [x] Create local group files -> request create groups in server 
- [x] After create -> pull back and sync local
- [x] Edit local group files -> update server groups 
- [x] Wrap up and restructure codes
- [x] Apply new file system on it
- [ ] Refactor file structure and remove duplicate data

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add `let id: String?` field to Beta Group model. I know we don't want to do this but it's a must coz two groups can have the same name.
- Add `var testers: [String]` to Beta Group for storing tester emails
- Make `BetaGroup` extend to `Equatable, Hashable` for comparing in `Set`, to `SyncResultRenderable` for rendering dry run and sync result, to `FileNameGettable` for generating a beatified filename (a String extension was made for snakeCased filename). 
- Create `SyncResultRenderer` for printing sync and dry run result 
- Create `enum SyncStrategy` for both rendering result and handle the update.
- Create `protocol ResourceFolderManager`and `BetaGroupFolderManager`, for managing folders and group files.
- Tweak `ListBetaTestersOperation` and create `UpdateBetaGroupOperation`. Create service function `pullBetaGroups`, `updateBetaGroup`, `deleteBetaGroup`. 
- Implement `SyncBetaGroupsCommand` which contains `PullBetaGroupsCommand` and `PushBetaGroupsCommand`.

# ⚠️ Items of Note
- When edit file to change group, only particular field are editable: for a beta group, only name, public link, link limit, link enabled can be changed (according to API), and if others are changed, when push it will have no effect. So this means the user must have some instructions.

# 🧐🗒 Reviewer Notes

## 💁 Example
#### Usage: 
`asc testflight betagroup sync pull [--output-path <output-path>]`
`asc testflight betagroup sync push [--input-path <input-path>] [--dry-run]`

`--output-path` and `--input-path` is a folder path. 

CLI will go through all the files in that folder and find file with a suffix of `yml` and read it as a beta group file.

#### Sample Output: 
###### TODO

#### Sample file structure 
###### TODO

## 🔨 How To Test

`asc testflight betagroup sync pull`

`asc testflight betagroup sync push --dry-run`

`asc testflight betagroup sync push`

## How to
### Note: Please run `pull` first to get server groups and testers before run push 
#### Create a new group via sync: 
1. Create a file, name it whatever you like in folder `./config/betagroups`(or the input folder path), suffix **must** be `yml`
2. Put some basic group info in it, eg
```
app:
  bundleId: com.example.foo // MUST HAVE
groupName: testgroup // MUST HAVE, MUST UNIQUE (please don't create group with the same name in same app)
publicLinkEnabled: false
publicLinkLimit: 5
publicLinkLimitEnabled: false
```
3. Run command `asc testflight betagroup sync push`

#### Delete a group 
1. Delete the group file in folder 
2. Run command `asc testflight betagroup sync push`

#### Update a group 
1. Directly edit the group file in the config folder 
fields that support editing: (edit other fields will not work)
```
groupName
publicLinkEnabled
publicLinkLimit
publicLinkLimitEnabled
```
2. Run command `asc testflight betagroup sync push`