### PR TITLE
Read prerelease version info

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -1,6 +1,5 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
-import AppStoreConnect_Swift_SDK
 import ArgumentParser
 
 struct ReadPreReleaseVersionCommand: CommonParsableCommand {
@@ -48,6 +47,6 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
         let service = try makeService()
 
         let prereleaseVersion = try service.readPreReleaseVersion(filterIdentifier: identifier, filterVersion: version)
-        prereleaseVersion.render(format:  common.outputFormat)
+        prereleaseVersion.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -21,6 +21,14 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
         transform: Identifier.init
     ) var identifier: Identifier
 
+    @Argument(
+        help: ArgumentHelp(
+            "The version no of the app",
+            discussion: "Please input a specific version no",
+            valueName: "version"
+        )
+    ) var version: String
+
     enum Identifier {
         case appId(String)
         case bundleId(String)
@@ -40,10 +48,10 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
 
         switch (identifier) {
         case .appId(let filterAppId):
-            let prereleaseVersion = try service.readPreReleaseVersion(filterAppId: filterAppId)
+            let prereleaseVersion = try service.readPreReleaseVersion(filterAppId: filterAppId, filterVersion: version)
             prereleaseVersion.render(format: common.outputFormat)
         case .bundleId(let filterBundleId):
-            let prereleaseVersion = try service.readPreReleaseVersion(filterBundleId: filterBundleId)
+            let prereleaseVersion = try service.readPreReleaseVersion(filterBundleId: filterBundleId , filterVersion: version)
             prereleaseVersion.render(format: common.outputFormat)
         }
     }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -39,11 +39,11 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
         let service = try makeService()
 
         switch (identifier) {
-        case .appId(let appId):
-            let prereleaseVersion = try service.readPreReleaseVersion(appId: appId)
+        case .appId(let filterAppId):
+            let prereleaseVersion = try service.readPreReleaseVersion(filterAppId: filterAppId)
             prereleaseVersion.render(format: common.outputFormat)
-        case .bundleId(let bundleId):
-            let prereleaseVersion = try service.readPreReleaseVersion(bundleId: bundleId)
+        case .bundleId(let filterBundleId):
+            let prereleaseVersion = try service.readPreReleaseVersion(filterBundleId: filterBundleId)
             prereleaseVersion.render(format: common.outputFormat)
         }
     }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -23,8 +23,7 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
     @Argument(
         help: ArgumentHelp(
             "The version no of the app",
-            discussion: "Please input a specific version no",
-            valueName: "version"
+            discussion: "Please input a specific version no"
         )
     )
     var version: String

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -19,7 +19,8 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
             valueName: "app-id / bundle-id"
         ),
         transform: Identifier.init
-    ) var identifier: Identifier
+    )
+    var identifier: Identifier
 
     @Argument(
         help: ArgumentHelp(
@@ -27,7 +28,8 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
             discussion: "Please input a specific version no",
             valueName: "version"
         )
-    ) var version: String
+    )
+    var version: String
 
     enum Identifier {
         case appId(String)

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -2,7 +2,6 @@
 
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
-import Foundation
 
 struct ReadPreReleaseVersionCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
@@ -48,13 +47,7 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
     func run() throws {
         let service = try makeService()
 
-        switch (identifier) {
-        case .appId(let filterAppId):
-            let prereleaseVersion = try service.readPreReleaseVersion(filterAppId: filterAppId, filterVersion: version)
-            prereleaseVersion.render(format: common.outputFormat)
-        case .bundleId(let filterBundleId):
-            let prereleaseVersion = try service.readPreReleaseVersion(filterBundleId: filterBundleId , filterVersion: version)
-            prereleaseVersion.render(format: common.outputFormat)
-        }
+        let prereleaseVersion = try service.readPreReleaseVersion(filterIdentifier: identifier, filterVersion: version)
+        prereleaseVersion.render(format:  common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -1,0 +1,50 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+struct ReadPreReleaseVersionCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "read",
+        abstract: "Get information about a specific prerelease version.")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(
+        help: ArgumentHelp(
+            "The app AppStore ID. eg. 432156789 or app bundle identifier. eg. com.example.App",
+            discussion: "Please input either app id or bundle Id",
+            valueName: "app-id / bundle-id"
+        ),
+        transform: Identifier.init
+    ) var identifier: Identifier
+
+    enum Identifier {
+        case appId(String)
+        case bundleId(String)
+
+        init(_ argument: String) {
+            switch Int(argument) == nil {
+            case true:
+                self = .bundleId(argument)
+            case false:
+                self = .appId(argument)
+            }
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        switch (identifier) {
+        case .appId(let appId):
+            let prereleaseVersion = try service.readPreReleaseVersion(appId: appId)
+            prereleaseVersion.render(format: common.outputFormat)
+        case .bundleId(let bundleId):
+            let prereleaseVersion = try service.readPreReleaseVersion(bundleId: bundleId)
+            prereleaseVersion.render(format: common.outputFormat)
+        }
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -22,7 +22,7 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
 
     @Argument(
         help: ArgumentHelp(
-            "The version no of the app",
+            "The version number of the prerelease version of your app.",
             discussion: "Please input a specific version no"
         )
     )

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/TestFlightPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/TestFlightPreReleaseVersionCommand.swift
@@ -6,7 +6,7 @@ import Foundation
 public struct TestFlightPreReleaseVersionCommand: ParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "prereleaseversion",
-        abstract: "PreRelease version commands.",
+        abstract: "Platform-specific versions of your app intended for distribution to beta testers.",
         subcommands: [
             ListPreReleaseVersionsCommand.self,
             ReadPreReleaseVersionCommand.self

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/TestFlightPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/TestFlightPreReleaseVersionCommand.swift
@@ -6,9 +6,10 @@ import Foundation
 public struct TestFlightPreReleaseVersionCommand: ParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "prereleaseversion",
-        abstract: "Platform-specific versions of your app intended for distribution to beta testers.",
+        abstract: "PreRelease version commands.",
         subcommands: [
-            ListPreReleaseVersionsCommand.self
+            ListPreReleaseVersionsCommand.self,
+            ReadPreReleaseVersionCommand.self
         ],
         defaultSubcommand: ListPreReleaseVersionsCommand.self)
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/TestFlightCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/TestFlightCommand.swift
@@ -12,7 +12,7 @@ public struct TestFlightCommand: ParsableCommand {
             TestFlightBetaGroupCommand.self,
             TestFlightBetaTestersCommand.self,
             TestFlightBuildsCommand.self,
-            TestFlightPreReleaseVersionCommand.self,
+            TestFlightPreReleaseVersionCommand.self
         ])
 
     public init() {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -482,19 +482,23 @@ class AppStoreConnectService {
         return output.map(PreReleaseVersion.init)
     }
 
+    func readPreReleaseVersion(filterIdentifier: ReadPreReleaseVersionCommand.Identifier, filterVersion: String) throws -> PreReleaseVersion {
+        var filterAppId: String = ""
+        var filterBundleId: String = ""
 
-    func readPreReleaseVersion(filterAppId: String, filterVersion: String) throws -> PreReleaseVersion {
+        switch (filterIdentifier) {
+        case .appId(let appId):
+            filterAppId = appId
+        case .bundleId(let bundleId):
+            filterBundleId = bundleId
+        }
+
+        if !filterBundleId.isEmpty {
+            let appsOperation = GetAppsOperation(options: .init(bundleIds: [filterBundleId]))
+            filterAppId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
+        }
+
         let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: filterAppId, filterVersion: filterVersion))
-
-        let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
-        return PreReleaseVersion(output.preReleaseVersion, output.relationships)
-     }
-
-     func readPreReleaseVersion(filterBundleId: String, filterVersion: String) throws -> PreReleaseVersion {
-        let appsOperation = GetAppsOperation(options: .init(bundleIds: [filterBundleId]))
-        let appId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
-
-        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: appId, filterVersion: filterVersion))
         let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
         return PreReleaseVersion(output.preReleaseVersion, output.relationships)
      }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -482,6 +482,26 @@ class AppStoreConnectService {
         return output.map(PreReleaseVersion.init)
     }
 
+
+    func readPreReleaseVersion(appId: String) throws -> PreReleaseVersionDetails {
+        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(appId: appId))
+
+        let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
+        return PreReleaseVersionDetails(output.preReleaseVersion, output.relationships)
+     }
+
+     func readPreReleaseVersion(bundleId: String) throws -> PreReleaseVersionDetails {
+        let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
+        let appId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
+
+        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(appId: appId))
+        let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
+        return PreReleaseVersionDetails(output.preReleaseVersion, output.relationships)
+     }
+
+
+
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -483,26 +483,21 @@ class AppStoreConnectService {
     }
 
 
-    func readPreReleaseVersion(appId: String) throws -> PreReleaseVersionDetails {
-        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(appId: appId))
-    func readPreReleaseVersion(filterAppId: String) throws -> PreReleaseVersionDetails {
-        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: filterAppId))
+    func readPreReleaseVersion(filterAppId: String, filterVersion: String) throws -> PreReleaseVersion {
+        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: filterAppId, filterVersion: filterVersion))
 
         let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
-        return PreReleaseVersionDetails(output.preReleaseVersion, output.relationships)
+        return PreReleaseVersion(output.preReleaseVersion, output.relationships)
      }
 
-     func readPreReleaseVersion(filterBundleId: String) throws -> PreReleaseVersionDetails {
+     func readPreReleaseVersion(filterBundleId: String, filterVersion: String) throws -> PreReleaseVersion {
         let appsOperation = GetAppsOperation(options: .init(bundleIds: [filterBundleId]))
         let appId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
 
-        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: appId))
+        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: appId, filterVersion: filterVersion))
         let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
-        return PreReleaseVersionDetails(output.preReleaseVersion, output.relationships)
+        return PreReleaseVersion(output.preReleaseVersion, output.relationships)
      }
-
-
-
 
     /// Make a request for something `Decodable`.
     ///

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -485,16 +485,18 @@ class AppStoreConnectService {
 
     func readPreReleaseVersion(appId: String) throws -> PreReleaseVersionDetails {
         let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(appId: appId))
+    func readPreReleaseVersion(filterAppId: String) throws -> PreReleaseVersionDetails {
+        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: filterAppId))
 
         let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
         return PreReleaseVersionDetails(output.preReleaseVersion, output.relationships)
      }
 
-     func readPreReleaseVersion(bundleId: String) throws -> PreReleaseVersionDetails {
-        let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
+     func readPreReleaseVersion(filterBundleId: String) throws -> PreReleaseVersionDetails {
+        let appsOperation = GetAppsOperation(options: .init(bundleIds: [filterBundleId]))
         let appId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
 
-        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(appId: appId))
+        let readPreReleaseVersionOperation = ReadPreReleaseVersionOperation(options: .init(filterAppId: appId))
         let output = try readPreReleaseVersionOperation.execute(with: requestor).await()
         return PreReleaseVersionDetails(output.preReleaseVersion, output.relationships)
      }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -484,17 +484,12 @@ class AppStoreConnectService {
 
     func readPreReleaseVersion(filterIdentifier: ReadPreReleaseVersionCommand.Identifier, filterVersion: String) throws -> PreReleaseVersion {
         var filterAppId: String = ""
-        var filterBundleId: String = ""
 
         switch (filterIdentifier) {
         case .appId(let appId):
             filterAppId = appId
         case .bundleId(let bundleId):
-            filterBundleId = bundleId
-        }
-
-        if !filterBundleId.isEmpty {
-            let appsOperation = GetAppsOperation(options: .init(bundleIds: [filterBundleId]))
+            let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
             filterAppId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
         }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
@@ -7,7 +7,7 @@ import Foundation
 struct ReadPreReleaseVersionOperation: APIOperation {
 
     struct Options {
-        var appId: String
+        var filterAppId: String
     }
 
     enum ReadPreReleaseVersionError: LocalizedError {
@@ -36,18 +36,18 @@ struct ReadPreReleaseVersionOperation: APIOperation {
     }
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Swift.Error> {
-        let endpoint = APIEndpoint.prereleaseVersion(
-            withId: options.appId,
+        var filters: [ListPrereleaseVersions.Filter] = []
+               filters += options.filterAppId.isEmpty ? [] : [.app([options.filterAppId])]
+
+        let endpoint = APIEndpoint.prereleaseVersions(
+            filter: filters,
             include: [.app]
         )
-
-
+        
         return requestor.request(endpoint)
-            .tryMap { (prereleaseVersionResponse) throws -> Output in
-
-                return (prereleaseVersionResponse.data, prereleaseVersionResponse.included)
-
-            }
-            .eraseToAnyPublisher()
+        .map{ response -> Output in
+            return Output(preReleaseVersion: response.data.first!, relationships: response.included)
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
@@ -12,12 +12,12 @@ struct ReadPreReleaseVersionOperation: APIOperation {
     }
 
     enum ReadPreReleaseVersionError: LocalizedError {
-        case noVersionExist
+        case noVersionExists
         case versionNotUnique
 
         var errorDescription: String? {
             switch self {
-            case .noVersionExist:
+            case .noVersionExists:
                 return "No prerelease version exists"
             case .versionNotUnique:
                 return "More than 1 prerelease version returned"
@@ -49,7 +49,7 @@ struct ReadPreReleaseVersionOperation: APIOperation {
             .tryMap { (response) throws -> Output in
                 switch response.data.count {
                 case 0:
-                    throw ReadPreReleaseVersionError.noVersionExist
+                    throw ReadPreReleaseVersionError.noVersionExists
                 case 1:
                     return Output(preReleaseVersion: response.data.first!, relationships: response.included)
                 default:

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
@@ -8,6 +8,7 @@ struct ReadPreReleaseVersionOperation: APIOperation {
 
     struct Options {
         var filterAppId: String
+        var filterVersion: String
     }
 
     enum ReadPreReleaseVersionError: LocalizedError {
@@ -37,7 +38,8 @@ struct ReadPreReleaseVersionOperation: APIOperation {
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Swift.Error> {
         var filters: [ListPrereleaseVersions.Filter] = []
-               filters += options.filterAppId.isEmpty ? [] : [.app([options.filterAppId])]
+        filters += options.filterAppId.isEmpty ? [] : [.app([options.filterAppId])]
+        filters += options.filterVersion.isEmpty ? [] : [.version([options.filterVersion])]
 
         let endpoint = APIEndpoint.prereleaseVersions(
             filter: filters,

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
@@ -1,0 +1,53 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ReadPreReleaseVersionOperation: APIOperation {
+
+    struct Options {
+        var appId: String
+    }
+
+    enum ReadPreReleaseVersionError: LocalizedError {
+        case noVersionExist
+        case versionNotUnique
+
+        var errorDescription: String? {
+            switch self {
+            case .noVersionExist:
+                return "No prerelease version exists"
+            case .versionNotUnique:
+                return "More than 1 prerelease version returned"
+            }
+        }
+    }
+
+    typealias PreReleaseVersion =  AppStoreConnect_Swift_SDK.PrereleaseVersion
+    typealias Relationships = [AppStoreConnect_Swift_SDK.PreReleaseVersionRelationship]?
+    typealias Output = (preReleaseVersion: PreReleaseVersion, relationships: Relationships)
+
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Swift.Error> {
+        let endpoint = APIEndpoint.prereleaseVersion(
+            withId: options.appId,
+            include: [.app]
+        )
+
+
+        return requestor.request(endpoint)
+            .tryMap { (prereleaseVersionResponse) throws -> Output in
+
+                return (prereleaseVersionResponse.data, prereleaseVersionResponse.included)
+
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadPreReleaseVersionOperation.swift
@@ -7,11 +7,11 @@ import Foundation
 struct ReadPreReleaseVersionOperation: APIOperation {
 
     struct Options {
-        var filterAppId: String
-        var filterVersion: String
+        let filterAppId: String
+        let filterVersion: String
     }
 
-    enum ReadPreReleaseVersionError: LocalizedError {
+    enum Error: LocalizedError {
         case noVersionExists
         case versionNotUnique
 
@@ -25,7 +25,7 @@ struct ReadPreReleaseVersionOperation: APIOperation {
         }
     }
 
-    typealias PreReleaseVersion =  AppStoreConnect_Swift_SDK.PrereleaseVersion
+    typealias PreReleaseVersion = AppStoreConnect_Swift_SDK.PrereleaseVersion
     typealias Relationships = [AppStoreConnect_Swift_SDK.PreReleaseVersionRelationship]?
     typealias Output = (preReleaseVersion: PreReleaseVersion, relationships: Relationships)
 
@@ -49,13 +49,13 @@ struct ReadPreReleaseVersionOperation: APIOperation {
             .tryMap { (response) throws -> Output in
                 switch response.data.count {
                 case 0:
-                    throw ReadPreReleaseVersionError.noVersionExists
+                    throw Error.noVersionExists
                 case 1:
                     return Output(preReleaseVersion: response.data.first!, relationships: response.included)
                 default:
-                    throw ReadPreReleaseVersionError.versionNotUnique
+                    throw Error.versionNotUnique
                 }
-        }
+            }
         .eraseToAnyPublisher()
     }
 }

--- a/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
@@ -2,25 +2,74 @@
 
 @testable import AppStoreConnectCLI
 import AppStoreConnect_Swift_SDK
-import Foundation
 import Combine
 import XCTest
 
 final class ReadPreReleaseVersionOperationTests: XCTestCase {
     typealias Operation = ReadPreReleaseVersionOperation
     typealias Options = Operation.Options
+    typealias OperationError = ReadPreReleaseVersionOperation.Error
 
-    let successRequestor = OneEndpointTestRequestor(
-        response: { _ in Future({ $0(.success(dataResponse)) }) }
+    let successResponseRequestor = OneEndpointTestRequestor(response: { _ in
+        Future({ $0(.success(onePreRealeseVersionResponse)) }) }
     )
 
-    func testReturnsOnePreReleaseVersion() throws {
+    let noResponseRequestor = OneEndpointTestRequestor(response: { _ in
+        Future{ $0(.success(noPreReleaseVersionResponse)) }}
+    )
+
+    let notUniqueRequestor = OneEndpointTestRequestor(response: { _ in
+        Future{ $0(.success(notUniqueResponse)) }}
+    )
+
+    func testOnePreReleaseVersion() throws {
         let operation = Operation(options: Options(filterAppId: "1504341572", filterVersion: "1.0"))
-        let output = try operation.execute(with: successRequestor).await()
-        XCTAssertEqual(output.preReleaseVersion.attributes?.version, "1.0")
+
+        let result = Result {
+            try operation.execute(with: successResponseRequestor).await()
+        }
+
+        switch result {
+        case .success(let output):
+            XCTAssertEqual(output.preReleaseVersion.attributes?.version, "1.0")
+        default:
+            XCTFail("Error in getting prereleaseVersion response")
+        }
     }
 
-    static let dataResponse: PreReleaseVersionsResponse = """
+    func testNoPreReleaseVersion() {
+        let operation = Operation(options: Options(filterAppId: "1504341572", filterVersion: "0.0"))
+        let expectedError = OperationError.noVersionExists
+
+        let result = Result {
+            try operation.execute(with: noResponseRequestor).await()
+        }
+
+        switch result {
+        case .failure(let error as OperationError):
+            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+        default:
+            XCTFail("Expected failed with \(expectedError) but got: \(result)")
+        }
+    }
+
+    func testNotUniquePreReleaseVersion() {
+        let operation = Operation(options: Options(filterAppId: "1504341572", filterVersion: "1.0"))
+        let expectedError = OperationError.versionNotUnique
+
+        let result = Result {
+            try operation.execute(with: notUniqueRequestor).await()
+        }
+
+        switch result {
+        case .failure(let error as OperationError):
+            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+        default:
+            XCTFail("Expected failed with \(expectedError) but got: \(result)")
+        }
+    }
+
+    static let onePreRealeseVersionResponse: PreReleaseVersionsResponse = """
         {
           "data" : [ {
             "type" : "preReleaseVersions",
@@ -60,4 +109,88 @@ final class ReadPreReleaseVersionOperationTests: XCTestCase {
         """
         .data(using: .utf8)
         .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
+
+    static let notUniqueResponse: PreReleaseVersionsResponse  = """
+    {
+      "data" : [ {
+        "type" : "preReleaseVersions",
+        "id" : "bc4bba16-2af1-4517-8de7-21790799ca72",
+        "attributes" : {
+          "version" : "1.0",
+          "platform" : "IOS"
+        },
+        "relationships" : {
+          "builds" : {
+            "links" : {
+              "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/relationships/builds",
+              "related" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/builds"
+            }
+          },
+          "app" : {
+            "links" : {
+              "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/relationships/app",
+              "related" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/app"
+            }
+          }
+        },
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72"
+        }
+      } ,
+        {
+          "type" : "preReleaseVersions",
+          "id" : "bc4bba16-2af1-4517-8de7-21790799ca72",
+          "attributes" : {
+            "version" : "1.1",
+            "platform" : "IOS"
+          },
+          "relationships" : {
+            "builds" : {
+              "links" : {
+                "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/relationships/builds",
+                "related" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/builds"
+              }
+            },
+            "app" : {
+              "links" : {
+                "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/relationships/app",
+                "related" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/app"
+              }
+            }
+          },
+          "links" : {
+            "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72"
+          }
+        } ],
+      "links" : {
+        "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bapp%5D=1504341572"
+      },
+      "meta" : {
+        "paging" : {
+          "total" : 1,
+          "limit" : 50
+        }
+      }
+    }
+    """
+    .data(using: .utf8)
+    .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
+
+
+    static let noPreReleaseVersionResponse: PreReleaseVersionsResponse = """
+    {
+      "data" : [ ],
+      "links": {
+        "self": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72"
+      },
+      "meta" : {
+        "paging" : {
+          "total" : 0,
+          "limit" : 50
+        }
+      }
+    }
+    """
+    .data(using: .utf8)
+    .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
 }

--- a/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
@@ -15,7 +15,7 @@ final class ReadPreReleaseVersionOperationTests: XCTestCase {
     )
 
     func testReturnsOnePreReleaseVersion() throws {
-        let operation = Operation(options: Options(filterAppId: "1504341572"))
+        let operation = Operation(options: Options(filterAppId: "1504341572", filterVersion: "1.0"))
         let output = try operation.execute(with: successRequestor).await()
         XCTAssertEqual(output.preReleaseVersion.attributes?.version, "1.0")
     }

--- a/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
@@ -49,7 +49,7 @@ final class ReadPreReleaseVersionOperationTests: XCTestCase {
         case .failure(let error as OperationError):
             XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
         default:
-            XCTFail("Expected failed with \(expectedError) but got: \(result)")
+            XCTFail("Expected failure with \(expectedError) but got: \(result)")
         }
     }
 
@@ -65,7 +65,7 @@ final class ReadPreReleaseVersionOperationTests: XCTestCase {
         case .failure(let error as OperationError):
             XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
         default:
-            XCTFail("Expected failed with \(expectedError) but got: \(result)")
+            XCTFail("Expected failure with \(expectedError) but got: \(result)")
         }
     }
 

--- a/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
@@ -24,48 +24,23 @@ final class ReadPreReleaseVersionOperationTests: XCTestCase {
 
     func testOnePreReleaseVersion() throws {
         let operation = Operation(options: Options(filterAppId: "1504341572", filterVersion: "1.0"))
-
-        let result = Result {
-            try operation.execute(with: successResponseRequestor).await()
-        }
-
-        switch result {
-        case .success(let output):
-            XCTAssertEqual(output.preReleaseVersion.attributes?.version, "1.0")
-        default:
-            XCTFail("Error in getting prereleaseVersion response")
-        }
+        let output = try operation.execute(with: successResponseRequestor).await()
+        XCTAssertEqual(output.preReleaseVersion.attributes?.version, "1.0")
     }
 
     func testNoPreReleaseVersion() {
         let operation = Operation(options: Options(filterAppId: "1504341572", filterVersion: "0.0"))
-        let expectedError = OperationError.noVersionExists
 
-        let result = Result {
-            try operation.execute(with: noResponseRequestor).await()
-        }
-
-        switch result {
-        case .failure(let error as OperationError):
-            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
-        default:
-            XCTFail("Expected failure with \(expectedError) but got: \(result)")
+        XCTAssertThrowsError(try operation.execute(with: noResponseRequestor).await()) { error in
+            XCTAssertEqual(error as! OperationError, OperationError.noVersionExists)
         }
     }
 
     func testNotUniquePreReleaseVersion() {
         let operation = Operation(options: Options(filterAppId: "1504341572", filterVersion: "1.0"))
-        let expectedError = OperationError.versionNotUnique
 
-        let result = Result {
-            try operation.execute(with: notUniqueRequestor).await()
-        }
-
-        switch result {
-        case .failure(let error as OperationError):
-            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
-        default:
-            XCTFail("Expected failure with \(expectedError) but got: \(result)")
+        XCTAssertThrowsError(try operation.execute(with: notUniqueRequestor).await()) { error in
+            XCTAssertEqual(error as! OperationError, OperationError.versionNotUnique)
         }
     }
 
@@ -173,8 +148,8 @@ final class ReadPreReleaseVersionOperationTests: XCTestCase {
       }
     }
     """
-    .data(using: .utf8)
-    .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
+        .data(using: .utf8)
+        .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
 
 
     static let noPreReleaseVersionResponse: PreReleaseVersionsResponse = """
@@ -191,6 +166,6 @@ final class ReadPreReleaseVersionOperationTests: XCTestCase {
       }
     }
     """
-    .data(using: .utf8)
-    .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
+        .data(using: .utf8)
+        .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
 }

--- a/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ReadPreReleaseVersionOperationTests.swift
@@ -1,0 +1,63 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+@testable import AppStoreConnectCLI
+import AppStoreConnect_Swift_SDK
+import Foundation
+import Combine
+import XCTest
+
+final class ReadPreReleaseVersionOperationTests: XCTestCase {
+    typealias Operation = ReadPreReleaseVersionOperation
+    typealias Options = Operation.Options
+
+    let successRequestor = OneEndpointTestRequestor(
+        response: { _ in Future({ $0(.success(dataResponse)) }) }
+    )
+
+    func testReturnsOnePreReleaseVersion() throws {
+        let operation = Operation(options: Options(filterAppId: "1504341572"))
+        let output = try operation.execute(with: successRequestor).await()
+        XCTAssertEqual(output.preReleaseVersion.attributes?.version, "1.0")
+    }
+
+    static let dataResponse: PreReleaseVersionsResponse = """
+        {
+          "data" : [ {
+            "type" : "preReleaseVersions",
+            "id" : "bc4bba16-2af1-4517-8de7-21790799ca72",
+            "attributes" : {
+              "version" : "1.0",
+              "platform" : "IOS"
+            },
+            "relationships" : {
+              "builds" : {
+                "links" : {
+                  "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/relationships/builds",
+                  "related" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/builds"
+                }
+              },
+              "app" : {
+                "links" : {
+                  "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/relationships/app",
+                  "related" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72/app"
+                }
+              }
+            },
+            "links" : {
+              "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/bc4bba16-2af1-4517-8de7-21790799ca72"
+            }
+          } ],
+          "links" : {
+            "self" : "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bapp%5D=1504341572"
+          },
+          "meta" : {
+            "paging" : {
+              "total" : 1,
+              "limit" : 50
+            }
+          }
+        }
+        """
+        .data(using: .utf8)
+        .map({ try! jsonDecoder.decode(PreReleaseVersionsResponse.self, from: $0) })!
+}


### PR DESCRIPTION
# 📝 Summary of Changes

closes #103 

Changes proposed in this pull request:

- Read a prerelease version information for an app id/ bundle id
## 🔨 How To Test
```
swift run asc testflight prereleaseversion read iba.test3 1.0
```
 ```
+------------+---------------+--------------+----------+---------+
| App ID     | App Bundle ID | App Name     | Platform | Version |
+------------+---------------+--------------+----------+---------+
| 1504341572 | iba.test2     | IBA Test App | IOS      | 1.0     |
+------------+---------------+--------------+----------+---------+
```
