### PR TITLE
Added default subcommand to TestFlight beta testers command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
@@ -8,15 +8,17 @@ public struct TestFlightBetaTestersCommand: ParsableCommand {
         commandName: "betatesters",
         abstract: "People who can install and test prerelease builds.",
         subcommands: [
-             InviteBetaTesterCommand.self,
-             DeleteBetaTesterCommand.self,
-             ListBetaTestersCommand.self,
-             ListBetaTesterByBuildsCommand.self,
-             ReadBetaTesterCommand.self,
-             RemoveTesterFromGroupsCommand.self,
-             AddTesterToGroupsCommand.self
-        ])
-
+            InviteBetaTesterCommand.self,
+            DeleteBetaTesterCommand.self,
+            ListBetaTestersCommand.self,
+            ListBetaTesterByBuildsCommand.self,
+            ReadBetaTesterCommand.self,
+            RemoveTesterFromGroupsCommand.self,
+            AddTesterToGroupsCommand.self
+        ],
+        defaultSubcommand: ListBetaTestersCommand.self
+    )
+    
     public init() {
     }
 }


### PR DESCRIPTION
closes #150 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Added default subcommand list to TestFlight beta testers command

## 🔨 How To Test
```swift run asc testflight betatesters```
