### PR TITLE
Added default subcommands

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CertificatesCommand.swift
@@ -12,7 +12,7 @@ struct CertificatesCommand: ParsableCommand {
             ListCertificatesCommand.self,
             ReadCertificateCommand.self,
             RevokeCertificatesCommand.self
-        ]
-        // defaultSubcommand: ListCertificatesCommand.self
+        ],
+        defaultSubcommand: ListCertificatesCommand.self
     )
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/TestFlightBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/TestFlightBuildsCommand.swift
@@ -8,13 +8,15 @@ public struct TestFlightBuildsCommand: ParsableCommand {
         commandName: "builds",
         abstract: "Information about app builds.",
         subcommands: [
-             ListBuildsCommand.self,
-             ReadBuildCommand.self,
-             ExpireBuildCommand.self,
-             RemoveBuildFromGroupsCommand.self,
-             AddGroupsToBuildCommand.self
-        ])
-
+            ListBuildsCommand.self,
+            ReadBuildCommand.self,
+            ExpireBuildCommand.self,
+            RemoveBuildFromGroupsCommand.self,
+            AddGroupsToBuildCommand.self
+        ],
+        defaultSubcommand: ListBuildsCommand.self
+    )
+    
     public init() {
     }
 }


### PR DESCRIPTION
closes #156 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Added default subcommands to the following

1. TestFlight builds command
2. Certificates command

## 🔨 How To Test

```swift run asc testflight builds```
```swift run asc certificates```
