### PR TITLE
Extract the rest of the Models to Model module

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
@@ -3,6 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Foundation
+import struct Model.BundleId
 
 struct ListBundleIdsCommand: CommonParsableCommand {
     public static var configuration = CommandConfiguration(

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
@@ -4,6 +4,7 @@ import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Combine
 import Foundation
+import struct Model.BundleId
 
 struct ModifyBundleIdCommand: CommonParsableCommand {
 

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
@@ -4,6 +4,7 @@ import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Combine
 import Foundation
+import struct Model.BundleId
 
 struct ReadBundleIdCommand: CommonParsableCommand {
     public static var configuration = CommandConfiguration(

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -3,6 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Foundation
+import struct Model.BundleId
 
 struct RegisterBundleIdCommand: CommonParsableCommand {
     public static var configuration = CommandConfiguration(

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
@@ -54,7 +54,7 @@ struct ListCertificatesCommand: CommonParsableCommand {
             .await()
 
         if let downloadPath = downloadPath {
-            try certificates.forEach { (certificate: Certificate) in
+            try certificates.forEach { certificate in
                 guard
                     let content = certificate.content,
                     let data = Data(base64Encoded: content)

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
@@ -4,6 +4,7 @@ import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Combine
 import Foundation
+import struct Model.Device
 
 struct ListDevicesCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
@@ -4,6 +4,7 @@ import ArgumentParser
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
+import struct Model.Device
 
 struct ModifyDeviceCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
@@ -4,6 +4,7 @@ import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Combine
 import Foundation
+import struct Model.Device
 import SwiftyTextTable
 import Yams
 

--- a/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
@@ -4,6 +4,7 @@ import ArgumentParser
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
+import struct Model.Device
 
 struct RegisterDeviceCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -5,6 +5,7 @@ import ArgumentParser
 import Combine
 import Foundation
 import Files
+import Model
 
 struct ListProfilesCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
@@ -95,7 +96,7 @@ struct ListProfilesCommand: CommonParsableCommand {
         )
 
         let profiles = try api.request(request)
-            .map { $0.data.map(Profile.init) }
+            .map { $0.data.map(Model.Profile.init) }
             .saveProfile(downloadPath: self.downloadPath) // FIXME: This feels like a hack.
             .await()
 
@@ -103,7 +104,7 @@ struct ListProfilesCommand: CommonParsableCommand {
     }
 }
 
-private extension Publisher where Output == [Profile], Failure == Error {
+private extension Publisher where Output == [Model.Profile], Failure == Error {
     func saveProfile(downloadPath: String?) -> AnyPublisher<Output, Failure> {
         tryMap { profiles -> Output in
             if let path = downloadPath {

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -3,6 +3,7 @@
 import ArgumentParser
 import AppStoreConnect_Swift_SDK
 import Combine
+import struct Model.BetaTester
 import Foundation
 
 struct ListBetaTesterByBuildsCommand: CommonParsableCommand {

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -5,6 +5,7 @@ import ArgumentParser
 import CodableCSV
 import Combine
 import Foundation
+import struct Model.User
 import Yams
 
 struct SyncUsersCommand: CommonParsableCommand {

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -3,32 +3,10 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
+import struct Model.BetaTester
 import SwiftyTextTable
 
-struct BetaTester: ResultRenderable {
-    let email: String?
-    let firstName: String?
-    let lastName: String?
-    let inviteType: String?
-    let betaGroups: [String]?
-    let apps: [String]?
-
-    init(
-        email: String?,
-         firstName: String?,
-         lastName: String?,
-         inviteType: BetaInviteType?,
-         betaGroups: [String]?,
-         apps: [String]?
-    ) {
-        self.email = email
-        self.firstName = firstName
-        self.lastName = lastName
-        self.inviteType = inviteType?.rawValue
-        self.betaGroups = betaGroups
-        self.apps = apps
-    }
-
+extension BetaTester {
     init(_ output: GetBetaTesterOperation.Output) {
         let attributes = output.betaTester.attributes
         let relationships = output.betaTester.relationships
@@ -46,16 +24,18 @@ struct BetaTester: ResultRenderable {
             }
             .flatMap { $0.compactMap { $0.attributes?.bundleId } }
 
-        self.init(email: attributes?.email,
-                  firstName: attributes?.firstName,
-                  lastName: attributes?.lastName,
-                  inviteType: attributes?.inviteType,
-                  betaGroups: betaGroupsNames,
-                  apps: appsBundleIds)
+        self.init(
+            email: attributes?.email,
+            firstName: attributes?.firstName,
+            lastName: attributes?.lastName,
+            inviteType: attributes?.inviteType?.rawValue,
+            betaGroups: betaGroupsNames,
+            apps: appsBundleIds
+        )
     }
 }
 
-extension BetaTester: TableInfoProvider {
+extension BetaTester: ResultRenderable, TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
        return [
             TextTableColumn(header: "Email"),

--- a/Sources/AppStoreConnectCLI/Model/Build.swift
+++ b/Sources/AppStoreConnectCLI/Model/Build.swift
@@ -2,27 +2,10 @@
 
 import AppStoreConnect_Swift_SDK
 import Foundation
-import struct Model.App
+import Model
 import SwiftyTextTable
 
-struct Build: ResultRenderable {
-    let app: App?
-    let platform: String?
-    let version: String?
-    let externalBuildState: String?
-    let internalBuildState: String?
-    let autoNotifyEnabled: String?
-    let buildNumber: String?
-    let processingState: String?
-    let minOsVersion: String?
-    let uploadedDate: String?
-    let expirationDate: String?
-    let expired: String?
-    let usesNonExemptEncryption: String?
-    let betaReviewState: String?
-}
-
-extension Build {
+extension Model.Build {
 
     init(_ build: AppStoreConnect_Swift_SDK.Build ,_ includes: [AppStoreConnect_Swift_SDK.BuildRelationship]?) {
 
@@ -61,7 +44,7 @@ extension Build {
         let buildBetaDetail = includedBuildBetaDetails?.filter { relationships?.buildBetaDetail?.data?.id == $0.id }.first
         let betaAppReviewSubmission = includedBetaAppReviewSubmissions?.filter { relationships?.betaAppReviewSubmission?.data?.id == $0.id }.first
 
-        let app = appDetails.map(App.init)
+        let app = appDetails.map(Model.App.init)
 
         self.init(
             app: app,
@@ -82,7 +65,7 @@ extension Build {
     }
 }
 
-extension Build: TableInfoProvider {
+extension Model.Build: ResultRenderable, TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
             TextTableColumn(header: "Bundle Id"),
@@ -104,7 +87,7 @@ extension Build: TableInfoProvider {
     }
 
     var tableRow: [CustomStringConvertible]  {
-        return [
+        let row = [
             app?.bundleId,
             app?.name,
             platform,
@@ -120,7 +103,8 @@ extension Build: TableInfoProvider {
             expirationDate,
             expired,
             usesNonExemptEncryption
-            ]
-            .map { $0 ?? ""}
+        ]
+
+        return row.map { $0 ?? ""}
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/BundleId.swift
+++ b/Sources/AppStoreConnectCLI/Model/BundleId.swift
@@ -3,23 +3,17 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
+import Model
 import SwiftyTextTable
-
-struct BundleId: ResultRenderable {
-    var identifier: String?
-    var name: String?
-    var platform: BundleIdPlatform?
-    var seedId: String?
-}
 
 // MARK: - API conveniences
 
-extension BundleId {
+extension Model.BundleId {
     init(_ attributes: AppStoreConnect_Swift_SDK.BundleId.Attributes) {
         self.init(
             identifier: attributes.identifier,
             name: attributes.name,
-            platform: attributes.platform,
+            platform: attributes.platform?.rawValue,
             seedId: attributes.seedId
         )
     }
@@ -35,7 +29,7 @@ extension BundleId {
 
 // MARK: - TextTable conveniences
 
-extension BundleId: TableInfoProvider {
+extension Model.BundleId: ResultRenderable, TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
             TextTableColumn(header: "Identifier"),
@@ -49,7 +43,7 @@ extension BundleId: TableInfoProvider {
         return [
             identifier ?? "",
             name ?? "",
-            platform?.rawValue ?? "",
+            platform ?? "",
             seedId ?? ""
         ]
     }

--- a/Sources/AppStoreConnectCLI/Model/Certificate.swift
+++ b/Sources/AppStoreConnectCLI/Model/Certificate.swift
@@ -2,18 +2,10 @@
 
 import AppStoreConnect_Swift_SDK
 import Foundation
+import Model
 import SwiftyTextTable
 
-struct Certificate: ResultRenderable {
-    let name: String?
-    let type: CertificateType?
-    let content: String?
-    let platform: BundleIdPlatform?
-    let expirationDate: Date?
-    let serialNumber: String?
-}
-
-extension Certificate {
+extension Model.Certificate {
     init(_ certificate: AppStoreConnect_Swift_SDK.Certificate) {
         self.init(certificate.attributes)
     }
@@ -21,16 +13,16 @@ extension Certificate {
     init(_ attributes: AppStoreConnect_Swift_SDK.Certificate.Attributes) {
         self.init(
             name: attributes.name,
-            type: attributes.certificateType,
+            type: attributes.certificateType?.rawValue,
             content: attributes.certificateContent,
-            platform: attributes.platform,
+            platform: attributes.platform?.rawValue,
             expirationDate: attributes.expirationDate,
             serialNumber: attributes.serialNumber
         )
     }
 }
 
-extension Certificate: TableInfoProvider {
+extension Model.Certificate: ResultRenderable, TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         [
             TextTableColumn(header: "SerialNumber"),
@@ -45,8 +37,8 @@ extension Certificate: TableInfoProvider {
         [
             self.serialNumber ?? "",
             self.name ?? "",
-            self.type?.rawValue ?? "",
-            self.platform?.rawValue ?? "",
+            self.type ?? "",
+            self.platform ?? "",
             self.expirationDate ?? ""
         ]
     }

--- a/Sources/AppStoreConnectCLI/Model/Device.swift
+++ b/Sources/AppStoreConnectCLI/Model/Device.swift
@@ -2,32 +2,21 @@
 
 import Foundation
 import AppStoreConnect_Swift_SDK
+import Model
 import SwiftyTextTable
-
-struct Device: ResultRenderable {
-    var udid: String?
-    var addedDate: Date?
-    var name: String?
-    var deviceClass: DeviceClass?
-    var model: String?
-    var platform: BundleIdPlatform?
-    var status: DeviceStatus?
-}
-
-// TODO: Extract these extensions somewhere that makes sense down the road
 
 // MARK: - API conveniences
 
-extension Device {
+extension Model.Device {
     init( _ attributes: AppStoreConnect_Swift_SDK.Device.Attributes) {
         self.init(
             udid: attributes.udid,
             addedDate: attributes.addedDate,
             name: attributes.name,
-            deviceClass: attributes.deviceClass,
+            deviceClass: attributes.deviceClass?.rawValue,
             model: attributes.model,
-            platform: attributes.platform,
-            status: attributes.status
+            platform: attributes.platform?.rawValue,
+            status: attributes.status?.rawValue
         )
     }
 
@@ -42,7 +31,7 @@ extension Device {
 
 // MARK: - TextTable conveniences
 
-extension Device: TableInfoProvider {
+extension Model.Device: ResultRenderable, TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
             TextTableColumn(header: "UDID"),
@@ -60,10 +49,10 @@ extension Device: TableInfoProvider {
           udid,
           name,
           addedDate?.formattedDate,
-          deviceClass?.rawValue,
+          deviceClass,
           model,
-          platform?.rawValue,
-          status?.rawValue
+          platform,
+          status,
         ].map { $0 ?? "" }
     }
 }

--- a/Sources/AppStoreConnectCLI/Model/PrereleaseVersion.swift
+++ b/Sources/AppStoreConnectCLI/Model/PrereleaseVersion.swift
@@ -2,19 +2,14 @@
 
 import AppStoreConnect_Swift_SDK
 import Foundation
-import struct Model.App
+import Model
 import SwiftyTextTable
 
-struct PreReleaseVersion: ResultRenderable {
-    var app: App?
-    var platform: String?
-    var version: String?
-    // TODO: var builds: [Build]?
-}
-
-extension PreReleaseVersion {
-    init(_ preReleaseVersion: AppStoreConnect_Swift_SDK.PrereleaseVersion, _ includes: [AppStoreConnect_Swift_SDK.PreReleaseVersionRelationship]?) {
-
+extension Model.PreReleaseVersion {
+    init(
+        _ preReleaseVersion: AppStoreConnect_Swift_SDK.PrereleaseVersion,
+        _ includes: [AppStoreConnect_Swift_SDK.PreReleaseVersionRelationship]?
+    ) {
         let relationships = preReleaseVersion.relationships
 
         let includedApps = includes?.compactMap { relationship -> AppStoreConnect_Swift_SDK.App? in
@@ -25,7 +20,7 @@ extension PreReleaseVersion {
         }
 
         let appDetails = includedApps?.first(where: { relationships?.app?.data?.id == $0.id }) 
-        let app = appDetails.map(App.init)
+        let app = appDetails.map(Model.App.init)
 
         self.init(
             app: app,
@@ -35,7 +30,7 @@ extension PreReleaseVersion {
     }
 }
 
-extension PreReleaseVersion: TableInfoProvider {
+extension Model.PreReleaseVersion: ResultRenderable, TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
             TextTableColumn(header: "App ID"),

--- a/Sources/AppStoreConnectCLI/Model/Profile.swift
+++ b/Sources/AppStoreConnectCLI/Model/Profile.swift
@@ -2,20 +2,10 @@
 
 import AppStoreConnect_Swift_SDK
 import Foundation
+import Model
 import SwiftyTextTable
 
-struct Profile: Codable {
-    var name: String?
-    var platform: BundleIdPlatform?
-    var profileContent: String?
-    var uuid: String?
-    var createdDate: Date?
-    var profileState: ProfileState?
-    var profileType: ProfileType?
-    var expirationDate: Date?
-}
-
-extension Profile {
+extension Model.Profile {
     init(_ apiProfile: AppStoreConnect_Swift_SDK.Profile) {
         self.init(apiProfile.attributes!)
     }
@@ -23,12 +13,12 @@ extension Profile {
     init(_ attributes: AppStoreConnect_Swift_SDK.Profile.Attributes) {
         self.init(
             name: attributes.name,
-            platform: attributes.platform,
+            platform: attributes.platform?.rawValue,
             profileContent: attributes.profileContent,
             uuid: attributes.uuid,
             createdDate: attributes.createdDate,
-            profileState: attributes.profileState,
-            profileType: attributes.profileType,
+            profileState: attributes.profileState?.rawValue,
+            profileType: attributes.profileType?.rawValue,
             expirationDate: attributes.expirationDate
         )
     }
@@ -38,7 +28,7 @@ extension Profile {
     }
 }
 
-extension Profile: TableInfoProvider {
+extension Model.Profile: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
             TextTableColumn(header: "UUID"),
@@ -55,9 +45,9 @@ extension Profile: TableInfoProvider {
         return [
             uuid ?? "",
             name ?? "",
-            platform?.rawValue ?? "",
-            profileState?.rawValue ?? "",
-            profileType?.rawValue ?? "",
+            platform ?? "",
+            profileState ?? "",
+            profileType ?? "",
             createdDate?.formattedDate ?? "",
             expirationDate?.formattedDate ?? ""
         ]

--- a/Sources/AppStoreConnectCLI/Model/UserInvitation.swift
+++ b/Sources/AppStoreConnectCLI/Model/UserInvitation.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import Combine
+import struct Model.User
 import SwiftyTextTable
 import AppStoreConnect_Swift_SDK
 
@@ -39,7 +40,7 @@ extension APIEndpoint where T == UserInvitationResponse {
             userWithEmail: user.username,
             firstName: user.firstName,
             lastName: user.lastName,
-            roles: user.roles,
+            roles: user.roles.compactMap(UserRole.init(rawValue:)),
             allAppsVisible: user.allAppsVisible,
             provisioningAllowed: user.provisioningAllowed,
             appsVisibleIds: user.allAppsVisible ? [] : user.visibleApps

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -6,6 +6,7 @@ import Foundation
 
 import struct Model.App
 import struct Model.BetaGroup
+import struct Model.BetaTester
 
 class AppStoreConnectService {
     private let provider: APIProvider

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -3,10 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
-
-import struct Model.App
-import struct Model.BetaGroup
-import struct Model.BetaTester
+import Model
 
 class AppStoreConnectService {
     private let provider: APIProvider
@@ -54,7 +51,7 @@ class AppStoreConnectService {
             .awaitMany()
     }
 
-    func inviteBetaTesterToGroups(with options: InviteBetaTesterOptions) throws -> BetaTester {
+    func inviteBetaTesterToGroups(with options: InviteBetaTesterOptions) throws -> Model.BetaTester {
         let id = try InviteTesterOperation(options: options)
             .execute(with: requestor)
             .await()
@@ -66,7 +63,7 @@ class AppStoreConnectService {
             .execute(with: requestor)
             .await()
 
-        return BetaTester(output)
+        return Model.BetaTester(output)
     }
 
     func addTestersToGroup(
@@ -140,7 +137,7 @@ class AppStoreConnectService {
         limitApps: Int?,
         limitBuilds: Int?,
         limitBetaGroups: Int?
-    ) throws -> BetaTester {
+    ) throws -> Model.BetaTester {
         let operation = GetBetaTesterOperation(
             options: .init(
                 identifier: .email(email),
@@ -152,7 +149,7 @@ class AppStoreConnectService {
 
         let output = try operation.execute(with: requestor).await()
 
-        return BetaTester(output)
+        return Model.BetaTester(output)
     }
 
     func deleteBetaTesters(emails: [String]) throws -> [Void] {
@@ -181,7 +178,7 @@ class AppStoreConnectService {
         sort: ListBetaTesters.Sort?,
         limit: Int?,
         relatedResourcesLimit: Int?
-    ) throws -> [BetaTester] {
+    ) throws -> [Model.BetaTester] {
 
         var appIds: [String] = appIds
         if !bundleIds.isEmpty && appIds.isEmpty {
@@ -213,7 +210,7 @@ class AppStoreConnectService {
             )
             .execute(with: requestor)
             .await()
-            .map(BetaTester.init)
+            .map(Model.BetaTester.init)
     }
 
     func removeTesterFromGroups(email: String, groupNames: [String]) throws {
@@ -258,7 +255,7 @@ class AppStoreConnectService {
         try operation.execute(with: requestor).await()
     }
 
-    func readBetaGroup(bundleId: String, groupName: String) throws -> BetaGroup {
+    func readBetaGroup(bundleId: String, groupName: String) throws -> Model.BetaGroup {
         let app = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
             .execute(with: requestor)
             .await()
@@ -268,7 +265,7 @@ class AppStoreConnectService {
             .execute(with: requestor)
             .await()
 
-        return BetaGroup(app, betaGroup)
+        return Model.BetaGroup(app, betaGroup)
     }
         
     func createBetaGroup(
@@ -276,7 +273,7 @@ class AppStoreConnectService {
         groupName: String,
         publicLinkEnabled: Bool,
         publicLinkLimit: Int?
-    ) throws -> BetaGroup {
+    ) throws -> Model.BetaGroup {
         let getAppsOperation = GetAppsOperation(options: .init(bundleIds: [appBundleId]))
         let app = try getAppsOperation.execute(with: requestor).compactMap(\.first).await()
 
@@ -290,7 +287,7 @@ class AppStoreConnectService {
         )
 
         let betaGroupResponse = createBetaGroupOperation.execute(with: requestor)
-        return try betaGroupResponse.map(BetaGroup.init).await()
+        return try betaGroupResponse.map(Model.BetaGroup.init).await()
     }
 
     func deleteBetaGroup(appBundleId: String, betaGroupName: String) throws {
@@ -309,17 +306,17 @@ class AppStoreConnectService {
             .await()
     }
 
-    func listBetaGroups(bundleIds: [String], names: [String]) throws -> [BetaGroup] {
+    func listBetaGroups(bundleIds: [String], names: [String]) throws -> [Model.BetaGroup] {
         let operation = GetAppsOperation(options: .init(bundleIds: bundleIds))
         let appIds = try operation.execute(with: requestor).await().map(\.id)
 
         return try listBetaGroups(appIds: appIds, names: names)
     }
 
-    func listBetaGroups(appIds: [String], names: [String]) throws -> [BetaGroup] {
+    func listBetaGroups(appIds: [String], names: [String]) throws -> [Model.BetaGroup] {
         let operation = ListBetaGroupsOperation(options: .init(appIds: appIds, names: names))
 
-        return try operation.execute(with: requestor).await().map(BetaGroup.init)
+        return try operation.execute(with: requestor).await().map(Model.BetaGroup.init)
     }
 
     func modifyBetaGroup(
@@ -329,7 +326,7 @@ class AppStoreConnectService {
         publicLinkEnabled: Bool?,
         publicLinkLimit: Int?,
         publicLinkLimitEnabled: Bool?
-    ) throws -> BetaGroup {
+    ) throws -> Model.BetaGroup {
         let getAppsOperation = GetAppsOperation(options: .init(bundleIds: [appBundleId]))
         let app = try getAppsOperation.execute(with: requestor).compactMap(\.first).await()
 
@@ -346,17 +343,17 @@ class AppStoreConnectService {
         let modifyBetaGroupOperation = ModifyBetaGroupOperation(options: modifyBetaGroupOptions)
         let modifiedBetaGroup = try modifyBetaGroupOperation.execute(with: requestor).await()
 
-        return BetaGroup(app, modifiedBetaGroup)
+        return Model.BetaGroup(app, modifiedBetaGroup)
     }
 
-    func readBuild(bundleId: String, buildNumber: String, preReleaseVersion: String) throws -> Build {
+    func readBuild(bundleId: String, buildNumber: String, preReleaseVersion: String) throws -> Model.Build {
         let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
         let appId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
 
         let readBuildOperation = ReadBuildOperation(options: .init(appId: appId, buildNumber: buildNumber, preReleaseVersion: preReleaseVersion))
 
         let output = try readBuildOperation.execute(with: requestor).await()
-        return Build(output.build, output.relationships)
+        return Model.Build(output.build, output.relationships)
     }
 
     func expireBuild(bundleId: String, buildNumber: String, preReleaseVersion: String) throws -> Void {
@@ -378,7 +375,7 @@ class AppStoreConnectService {
         filterProcessingStates:[ListBuilds.Filter.ProcessingState],
         filterBetaReviewStates: [String],
         limit: Int?
-    ) throws -> [Build] {
+    ) throws -> [Model.Build] {
 
         var filterAppIds: [String] = []
 
@@ -400,7 +397,7 @@ class AppStoreConnectService {
         )
 
         let output = try listBuildsOperation.execute(with: requestor).await()
-        return output.map(Build.init)
+        return output.map(Model.Build.init)
     }
 
     func removeBuildFromGroups(
@@ -439,12 +436,12 @@ class AppStoreConnectService {
             .await()
     }
 
-    func readApp(identifier: ReadAppCommand.Identifier) throws -> App {
+    func readApp(identifier: ReadAppCommand.Identifier) throws -> Model.App {
         let sdkApp = try ReadAppOperation(options: .init(identifier: identifier))
             .execute(with: requestor)
             .await()
 
-        return App(sdkApp)
+        return Model.App(sdkApp)
     }
 
     func listPreReleaseVersions(

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -14,11 +14,11 @@ class AppStoreConnectService {
         requestor = DefaultEndpointRequestor(provider: provider)
     }
 
-    func listUsers(with options: ListUsersOptions) -> AnyPublisher<[User], Error> {
+    func listUsers(with options: ListUsersOptions) -> AnyPublisher<[Model.User], Error> {
         ListUsersOperation(options: options).execute(with: requestor)
     }
 
-    func getUserInfo(with options: GetUserInfoOptions) -> AnyPublisher<User, Error> {
+    func getUserInfo(with options: GetUserInfoOptions) -> AnyPublisher<Model.User, Error> {
         GetUserInfoOperation(options: options).execute(with: requestor)
     }
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -22,19 +22,23 @@ class AppStoreConnectService {
         GetUserInfoOperation(options: options).execute(with: requestor)
     }
 
-    func listCertificates(with options: ListCertificatesOptions) -> AnyPublisher<[Certificate], Error> {
+    func listCertificates(
+        with options: ListCertificatesOptions
+    ) -> AnyPublisher<[Model.Certificate], Error> {
         ListCertificatesOperation(options: options).execute(with: requestor)
     }
 
-    func readCertificate(serial: String) throws -> Certificate {
+    func readCertificate(serial: String) throws -> Model.Certificate {
         let sdkCertificate = try ReadCertificateOperation(options: .init(serial: serial))
             .execute(with: requestor)
             .await()
 
-        return Certificate(sdkCertificate)
+        return Model.Certificate(sdkCertificate)
     }
 
-    func createCertificate(with options: CreateCertificateOptions) -> AnyPublisher<Certificate, Error> {
+    func createCertificate(
+        with options: CreateCertificateOptions
+    ) -> AnyPublisher<Model.Certificate, Error> {
         CreateCertificateOperation(options: options).execute(with: requestor)
     }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateCertificateOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateCertificateOperation.swift
@@ -3,6 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
+import struct Model.Certificate
 
 struct CreateCertificateOperation: APIOperation {
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
@@ -3,6 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
+import struct Model.User
 
 struct GetUserInfoOperation: APIOperation {
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -3,6 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
+import struct Model.Certificate
 
 struct ListCertificatesOperation: APIOperation {
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
@@ -2,6 +2,7 @@
 
 import AppStoreConnect_Swift_SDK
 import Combine
+import struct Model.User
 
 struct ListUsersOperation: APIOperation {
 

--- a/Sources/Model/BetaTester.swift
+++ b/Sources/Model/BetaTester.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct BetaTester: Codable, Equatable {
+    public let email: String?
+    public let firstName: String?
+    public let lastName: String?
+    public let inviteType: String?
+    public let betaGroups: [String]?
+    public let apps: [String]?
+
+    public init(
+        email: String?,
+        firstName: String?,
+        lastName: String?,
+        inviteType: String?,
+        betaGroups: [String]?,
+        apps: [String]?
+    ) {
+        self.email = email
+        self.firstName = firstName
+        self.lastName = lastName
+        self.inviteType = inviteType
+        self.betaGroups = betaGroups
+        self.apps = apps
+    }
+}

--- a/Sources/Model/Build.swift
+++ b/Sources/Model/Build.swift
@@ -1,0 +1,52 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct Build: Codable, Equatable {
+    public let app: App?
+    public let platform: String?
+    public let version: String?
+    public let externalBuildState: String?
+    public let internalBuildState: String?
+    public let autoNotifyEnabled: String?
+    public let buildNumber: String?
+    public let processingState: String?
+    public let minOsVersion: String?
+    public let uploadedDate: String?
+    public let expirationDate: String?
+    public let expired: String?
+    public let usesNonExemptEncryption: String?
+    public let betaReviewState: String?
+
+    public init(
+        app: App?,
+        platform: String?,
+        version: String?,
+        externalBuildState: String?,
+        internalBuildState: String?,
+        autoNotifyEnabled: String?,
+        buildNumber: String?,
+        processingState: String?,
+        minOsVersion: String?,
+        uploadedDate: String?,
+        expirationDate: String?,
+        expired: String?,
+        usesNonExemptEncryption: String?,
+        betaReviewState: String?
+    ) {
+        self.app = app
+        self.platform = platform
+        self.version = version
+        self.externalBuildState = externalBuildState
+        self.internalBuildState = internalBuildState
+        self.autoNotifyEnabled = autoNotifyEnabled
+        self.buildNumber = buildNumber
+        self.processingState = processingState
+        self.minOsVersion = minOsVersion
+        self.uploadedDate = uploadedDate
+        self.expirationDate = expirationDate
+        self.expired = expired
+        self.usesNonExemptEncryption = usesNonExemptEncryption
+        self.betaReviewState = betaReviewState
+    }
+}

--- a/Sources/Model/BundleId.swift
+++ b/Sources/Model/BundleId.swift
@@ -1,0 +1,22 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct BundleId: Codable, Equatable {
+    public let identifier: String?
+    public let name: String?
+    public let platform: String?
+    public let seedId: String?
+
+    public init(
+        identifier: String?,
+        name: String?,
+        platform: String?,
+        seedId: String?
+    ) {
+        self.identifier = identifier
+        self.name = name
+        self.platform = platform
+        self.seedId = seedId
+    }
+}

--- a/Sources/Model/Certificate.swift
+++ b/Sources/Model/Certificate.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct Certificate: Codable, Equatable {
+    public let name: String?
+    public let type: String?
+    public let content: String?
+    public let platform: String?
+    public let expirationDate: Date?
+    public let serialNumber: String?
+
+    public init(
+        name: String?,
+        type: String?,
+        content: String?,
+        platform: String?,
+        expirationDate: Date?,
+        serialNumber: String?
+    ) {
+        self.name = name
+        self.type = type
+        self.content = content
+        self.platform = platform
+        self.expirationDate = expirationDate
+        self.serialNumber = serialNumber
+    }
+}

--- a/Sources/Model/Device.swift
+++ b/Sources/Model/Device.swift
@@ -1,0 +1,31 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct Device: Codable, Equatable {
+    public let udid: String?
+    public let addedDate: Date?
+    public let name: String?
+    public let deviceClass: String?
+    public let model: String?
+    public let platform: String?
+    public let status: String?
+
+    public init(
+        udid: String?,
+        addedDate: Date?,
+        name: String?,
+        deviceClass: String?,
+        model: String?,
+        platform: String?,
+        status: String?
+    ) {
+        self.udid = udid
+        self.addedDate = addedDate
+        self.name = name
+        self.deviceClass = deviceClass
+        self.model = model
+        self.platform = platform
+        self.status = status
+    }
+}

--- a/Sources/Model/PreReleaseVersion.swift
+++ b/Sources/Model/PreReleaseVersion.swift
@@ -1,0 +1,19 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct PreReleaseVersion: Codable, Equatable {
+    public let app: App?
+    public let platform: String?
+    public let version: String?
+
+    public init(
+        app: App?,
+        platform: String?,
+        version: String?
+    ) {
+        self.app = app
+        self.platform = platform
+        self.version = version
+    }
+}

--- a/Sources/Model/Profile.swift
+++ b/Sources/Model/Profile.swift
@@ -1,0 +1,35 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct Profile: Codable, Equatable {
+    public let name: String?
+    public let platform: String?
+    public let profileContent: String?
+    public let uuid: String?
+    public let createdDate: Date?
+    public let profileState: String?
+    public let profileType: String?
+    public let expirationDate: Date?
+
+    public init(
+        name: String?,
+        platform: String?,
+        profileContent: String?,
+        uuid: String?,
+        createdDate: Date?,
+        profileState: String?,
+        profileType: String?,
+        expirationDate: Date?
+    ) {
+        self.name = name
+        self.platform = platform
+        self.profileContent = profileContent
+        self.uuid = uuid
+        self.createdDate = createdDate
+        self.profileState = profileState
+        self.profileType = profileType
+        self.expirationDate = expirationDate
+
+    }
+}

--- a/Sources/Model/User.swift
+++ b/Sources/Model/User.swift
@@ -1,0 +1,31 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct User: Codable, Equatable {
+    public let username: String
+    public let firstName: String
+    public let lastName: String
+    public let roles: [String]
+    public let provisioningAllowed: Bool
+    public let allAppsVisible: Bool
+    public let visibleApps: [String]?
+
+    public init(
+        username: String,
+        firstName: String,
+        lastName: String,
+        roles: [String],
+        provisioningAllowed: Bool,
+        allAppsVisible: Bool,
+        visibleApps: [String]?
+    ) {
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.roles = roles
+        self.provisioningAllowed = provisioningAllowed
+        self.allAppsVisible = allAppsVisible
+        self.visibleApps = visibleApps
+    }
+}

--- a/Tests/appstoreconnect-cliTests/Mockup/Certificates.swift
+++ b/Tests/appstoreconnect-cliTests/Mockup/Certificates.swift
@@ -1,6 +1,7 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 @testable import AppStoreConnectCLI
+import AppStoreConnect_Swift_SDK
 import Foundation
 
 extension Certificate {

--- a/Tests/appstoreconnect-cliTests/Operations/CreateCertificateOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/CreateCertificateOperationTests.swift
@@ -25,7 +25,7 @@ final class CreateCertificateOperationTests: XCTestCase {
         switch result {
         case .success(let certificate):
             XCTAssertEqual(certificate.name, "Mac Installer Distribution: Hello")
-            XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS)
+            XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS.rawValue)
             XCTAssertEqual(certificate.content, "MIIFpDCCBIygAwIBAgIIbgb/7NS42MgwDQ")
         default:
             XCTFail("Error happened when parsing create certificate response")

--- a/Tests/appstoreconnect-cliTests/Operations/ReadCertificateOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ReadCertificateOperationTests.swift
@@ -5,6 +5,7 @@ import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
 import XCTest
+import Model
 
 final class ReadCertificateOperationTests: XCTestCase {
 
@@ -43,9 +44,9 @@ final class ReadCertificateOperationTests: XCTestCase {
 
         switch result {
         case .success(let sdkCertificate):
-            let certificate = Certificate(sdkCertificate)
+            let certificate = Model.Certificate(sdkCertificate)
             XCTAssertEqual(certificate.name, "Mac Installer Distribution: Hello")
-            XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS)
+            XCTAssertEqual(certificate.platform, BundleIdPlatform.macOS.rawValue)
             XCTAssertEqual(certificate.content, "MIIFpDCCBIygAwIBAgIIbgb/7NS42MgwDQ")
         default:
             XCTFail("Error happened when parsing read certificate response")


### PR DESCRIPTION
Provides more separation for our domain models for moving to a more modular architecture

# 📝 Summary of Changes

Changes proposed in this pull request:

- Moves the rest of the Models in `AppStoreConnectCLI` to `Model`

# ⚠️ Items of Note

We lose the auto generated struct initialiser because it isn't public so we have to manually write it. Also I have not redefined the SDK enums so many things that were previously stored as enum are now `String` by passing their `rawValue`