### PR TITLE
Rename listByBuilds command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -7,7 +7,7 @@ import Foundation
 
 struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
-        commandName: "listByBuilds",
+        commandName: "listbybuilds",
         abstract: "List beta testers who were specifically assigned to one or more builds"
     )
 


### PR DESCRIPTION
closes #152 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Renamed command to listbybuilds

## 🔨 How To Test

```swift run asc testflight betatesters listbybuilds iba.test2```