### PR TITLE
Bug/add pagination to operations

### DIFF
--- a/Sources/AppStoreConnectCLI/Helpers/Collection+Helpers.swift
+++ b/Sources/AppStoreConnectCLI/Helpers/Collection+Helpers.swift
@@ -6,4 +6,6 @@ extension Collection {
     func nilIfEmpty() -> Self? {
         isEmpty ? nil : self
     }
+
+    var isNotEmpty: Bool { isEmpty == false }
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListAppsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListAppsOperation.swift
@@ -23,9 +23,9 @@ struct ListAppsOperation: APIOperation {
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<[App], Error> {
         var filters: [ListApps.Filter] = []
 
-        options.bundleIds.isEmpty ? () : filters.append(.bundleId(options.bundleIds))
-        options.names.isEmpty ? () : filters.append(.name(options.names))
-        options.skus.isEmpty ? () : filters.append(.sku(options.skus))
+        if options.bundleIds.isNotEmpty { filters.append(.bundleId(options.bundleIds)) }
+        if options.names.isNotEmpty { filters.append(.name(options.names)) }
+        if options.skus.isNotEmpty { filters.append(.sku(options.skus)) }
 
         let limits = options.limit.map { [ListApps.Limit.apps($0)] }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListAppsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListAppsOperation.swift
@@ -10,17 +10,6 @@ struct ListAppsOperation: APIOperation {
         let names: [String]
         let skus: [String]
         let limit: Int?
-
-        fileprivate var endpoint: APIEndpoint<AppsResponse> {
-            var filters: [ListApps.Filter] = []
-            bundleIds.isEmpty ? () : filters.append(.bundleId(bundleIds))
-            names.isEmpty ? () : filters.append(.name(names))
-            skus.isEmpty ? () : filters.append(.sku(skus))
-
-            let limits = limit.map { [ListApps.Limit.apps($0)] }
-
-            return .apps(filters: filters, limits: limits)
-        }
     }
 
     private let options: Options
@@ -32,7 +21,27 @@ struct ListAppsOperation: APIOperation {
     typealias App = AppStoreConnect_Swift_SDK.App
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<[App], Error> {
-        requestor.request(options.endpoint).map(\.data).eraseToAnyPublisher()
+        var filters: [ListApps.Filter] = []
+
+        options.bundleIds.isEmpty ? () : filters.append(.bundleId(options.bundleIds))
+        options.names.isEmpty ? () : filters.append(.name(options.names))
+        options.skus.isEmpty ? () : filters.append(.sku(options.skus))
+
+        let limits = options.limit.map { [ListApps.Limit.apps($0)] }
+
+        guard limits != nil else {
+            return requestor.requestAllPages {
+                .apps(filters: filters, next: $0)
+            }
+            .map { $0.flatMap(\.data) }
+            .eraseToAnyPublisher()
+        }
+
+        return requestor.request(.apps(filters: filters, limits: limits))
+            .map(\.data)
+            .eraseToAnyPublisher()
     }
 
 }
+
+extension AppsResponse: PaginatedResponse { }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBundleIdsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBundleIdsOperation.swift
@@ -24,10 +24,11 @@ struct ListBundleIdsOperation: APIOperation {
         let platforms = options.platforms.compactMap(Platform.init(rawValue:))
 
         var filters: [BundleIds.Filter] = []
-        filters += options.identifiers.isEmpty ? [] : [.identifier(options.identifiers)]
-        filters += options.names.isEmpty ? [] : [.name(options.names)]
-        filters += options.platforms.isEmpty ? [] : [.platform(platforms)]
-        filters += options.seedIds.isEmpty ? [] : [.seedId(options.seedIds)]
+
+        if options.identifiers.isNotEmpty { filters.append(.identifier(options.identifiers)) }
+        if options.names.isNotEmpty { filters.append(.name(options.names)) }
+        if options.platforms.isNotEmpty { filters.append(.platform(platforms)) }
+        if options.seedIds.isNotEmpty { filters.append(.seedId(options.seedIds)) }
 
         let limit = options.limit
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -9,7 +9,7 @@ struct ListCertificatesOperation: APIOperation {
 
     typealias Filter = Certificates.Filter
 
-    enum ListCertificatesError: LocalizedError {
+    enum Error: LocalizedError {
         case couldNotFindCertificate
 
         var errorDescription: String? {
@@ -19,7 +19,7 @@ struct ListCertificatesOperation: APIOperation {
             }
         }
     }
-
+    
     struct Options {
         let filterSerial: String?
         let sort: Certificates.Sort?
@@ -27,9 +27,9 @@ struct ListCertificatesOperation: APIOperation {
         let filterDisplayName: String?
         let limit: Int?
     }
-    
-    var filters: [Certificates.Filter] {
-        var filters = [Certificates.Filter]()
+
+    var filters: [Filter] {
+        var filters = [Filter]()
 
         if let filterSerial = options.filterSerial {
             filters.append(.serialNumber([filterSerial]))
@@ -52,7 +52,7 @@ struct ListCertificatesOperation: APIOperation {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) -> AnyPublisher<[Certificate], Error> {
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<[Certificate], Swift.Error> {
         let filters = self.filters
         let sort = [options.sort].compactMap { $0 }
         let limit = options.limit
@@ -68,7 +68,7 @@ struct ListCertificatesOperation: APIOperation {
         .tryMap {
             try $0.flatMap { (response: CertificatesResponse) -> [Certificate] in
                 guard !response.data.isEmpty else {
-                    throw ListCertificatesError.couldNotFindCertificate
+                    throw Error.couldNotFindCertificate
                 }
 
                 return response.data.map(Certificate.init)

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListPreReleaseVersionsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListPreReleaseVersionsOperation.swift
@@ -25,9 +25,10 @@ struct ListPreReleaseVersionsOperation: APIOperation {
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<Output, Swift.Error> {
         var filters: [ListPrereleaseVersions.Filter] = []
-        filters += options.filterAppIds.isEmpty ? [] : [.app(options.filterAppIds)]
-        filters += options.filterVersions.isEmpty ? [] : [.version(options.filterVersions)]
-        filters += options.filterPlatforms.isEmpty ? [] : [.platform(options.filterPlatforms)]
+        
+        if options.filterAppIds.isNotEmpty { filters.append(.app(options.filterAppIds)) }
+        if options.filterVersions.isNotEmpty { filters.append(.version(options.filterVersions)) }
+        if options.filterPlatforms.isNotEmpty { filters.append(.platform(options.filterPlatforms)) }
 
         let sort = [options.sort].compactMap { $0 }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
@@ -8,7 +8,8 @@ struct ListUsersOperation: APIOperation {
     
     typealias Filter = ListUsers.Filter
     typealias Limit = ListUsers.Limit
-
+    typealias Include = ListUsers.Include
+    
     struct Options {
         let limitVisibleApps: Int?
         let limitUsers: Int?
@@ -18,14 +19,14 @@ struct ListUsersOperation: APIOperation {
         let filterVisibleApps: [String]
         let includeVisibleApps: Bool
     }
-    
-    var limit: [ListUsers.Limit]? {
+
+    var limit: [Limit]? {
         [options.limitUsers.map(Limit.users), options.limitVisibleApps.map(Limit.visibleApps)]
         .compactMap { $0 }
         .nilIfEmpty()
     }
 
-    var include: [ListUsers.Include]? {
+    var include: [Include]? {
         options.includeVisibleApps ? [ListUsers.Include.visibleApps] : nil
     }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListUsersOperation.swift
@@ -5,6 +5,9 @@ import Combine
 import struct Model.User
 
 struct ListUsersOperation: APIOperation {
+    
+    typealias Filter = ListUsers.Filter
+    typealias Limit = ListUsers.Limit
 
     struct Options {
         let limitVisibleApps: Int?
@@ -15,43 +18,49 @@ struct ListUsersOperation: APIOperation {
         let filterVisibleApps: [String]
         let includeVisibleApps: Bool
     }
+    
+    var limit: [ListUsers.Limit]? {
+        [options.limitUsers.map(Limit.users), options.limitVisibleApps.map(Limit.visibleApps)]
+        .compactMap { $0 }
+        .nilIfEmpty()
+    }
 
-    private let endpoint: APIEndpoint<UsersResponse>
+    var include: [ListUsers.Include]? {
+        options.includeVisibleApps ? [ListUsers.Include.visibleApps] : nil
+    }
+
+    var filter: [Filter]? {
+        let roles = options.filterRole.map(\.rawValue).nilIfEmpty().map(Filter.roles)
+        let usernames = options.filterUsername.nilIfEmpty().map(Filter.username)
+        let visibleApps = options.filterVisibleApps.nilIfEmpty().map(Filter.visibleApps)
+
+        return [roles, usernames, visibleApps].compactMap({ $0 }).nilIfEmpty()
+    }
+
+    let options: Options
 
     init(options: Options) {
-        let include = options.includeVisibleApps ? [ListUsers.Include.visibleApps] : nil
-
-        let limit = [
-            options.limitUsers.map(ListUsers.Limit.users),
-            options.limitVisibleApps.map(ListUsers.Limit.visibleApps)]
-            .compactMap { $0 }
-            .nilIfEmpty()
-
-        let sort = options.sort.map { [$0] }
-
-        typealias Filter = ListUsers.Filter
-
-        let filter: [Filter]? = {
-            let roles = options.filterRole.map(\.rawValue).nilIfEmpty().map(Filter.roles)
-            let usernames = options.filterUsername.nilIfEmpty().map(Filter.username)
-            let visibleApps = options.filterVisibleApps.nilIfEmpty().map(Filter.visibleApps)
-
-            return [roles, usernames, visibleApps].compactMap({ $0 }).nilIfEmpty()
-        }()
-
-        endpoint = APIEndpoint.users(
-            fields: nil,
-            include: include,
-            limit: limit,
-            sort: sort,
-            filter: filter,
-            next: nil
-        )
+        self.options = options
     }
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<[User], Error> {
-        requestor.request(endpoint)
-            .map(User.fromAPIResponse)
-            .eraseToAnyPublisher()
+        let include = self.include
+        let limit = self.limit
+        let sort = options.sort.map { [$0] }
+        let filter = self.filter
+
+        return requestor.requestAllPages {
+            .users(
+                include: include,
+                limit: limit,
+                sort: sort,
+                filter: filter,
+                next: $0
+            )
+        }
+        .map { $0.flatMap(User.fromAPIResponse) }
+        .eraseToAnyPublisher()
     }
 }
+
+extension UsersResponse: PaginatedResponse { }

--- a/Tests/appstoreconnect-cliTests/Operations/ListCertificateOperations.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListCertificateOperations.swift
@@ -8,7 +8,7 @@ import XCTest
 
 final class ListCertificateOperationsTests: XCTestCase {
 
-    typealias OperationError = ListCertificatesOperation.ListCertificatesError
+    typealias OperationError = ListCertificatesOperation.Error
 
     let noCertificatesRequestor = OneEndpointTestRequestor(
         response: { _ in Future({ $0(.success(noCertificatesResponse)) }) }


### PR DESCRIPTION
Closes #92 

# 📝 Summary of Changes

Changes proposed in this pull request:

Add pagination to 

- [x] List BundleIds
- [x] List Devices (in #181)
- [x] List Certificates
- [ ] List Profiles (not support by SDK yet)
- TestFlight
  - [x] List Apps
  - [x] List Beta Groups
  - [x] List Beta Testers
  - [x] List Builds
  - [x] List PreRelease Versions
- Users
  - [x] List Invitations (in #184)
  - [ ] List Visible Apps (may not be in 0.1.0)
  - [x] List Users 


# 🧐🗒 Reviewer Notes
Please point out if there are any operations that need pagination, if there are not included in this PR :)

### Problems:
This might break command line option:`--limit`. Can do some validation for option.limit is nil or not, then determine if pagination should be done or not.

## 🔨 How To Test

`swift run asc certificates list `
`swift run asc testflight prereleaseversion list`
`swift run asc users list`

