### PR TITLE
Add sort option to betagroup list command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
@@ -1,7 +1,7 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 import ArgumentParser
-import Foundation
+import AppStoreConnect_Swift_SDK
 
 struct ListBetaGroupsCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
@@ -27,10 +27,18 @@ struct ListBetaGroupsCommand: CommonParsableCommand {
         )
     ) var filterNames: [String]
 
+    @Option(
+        parsing: .unconditional,
+        help: ArgumentHelp(
+            "Sort the results using the provided key \(ListBetaGroups.Sort.allCases).",
+            discussion: "The `-` prefix indicates descending order."
+        )
+    ) var sort: ListBetaGroups.Sort?
+
     func run() throws {
         let service = try makeService()
 
-        let betaGroups = try service.listBetaGroups(filterIdentifiers: appLookupOptions.filterIdentifiers, names: filterNames)
+        let betaGroups = try service.listBetaGroups(filterIdentifiers: appLookupOptions.filterIdentifiers, names: filterNames, sort: sort)
 
         betaGroups.render(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Model/API/ListBetaGroups.Sort+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/ListBetaGroups.Sort+ExpressibleByArgument.swift
@@ -1,0 +1,10 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+
+extension ListBetaGroups.Sort: CustomStringConvertible, ExpressibleByArgument {
+    public var description: String {
+        rawValue
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -331,7 +331,11 @@ class AppStoreConnectService {
             .await()
     }
 
-    func listBetaGroups(filterIdentifiers: [AppLookupIdentifier], names: [String]) throws -> [Model.BetaGroup] {
+    func listBetaGroups(
+        filterIdentifiers: [AppLookupIdentifier],
+        names: [String],
+        sort: ListBetaGroups.Sort?
+    ) throws -> [Model.BetaGroup] {
         var filterAppIds: [String] = []
         var filterBundleIds: [String] = []
 
@@ -349,7 +353,7 @@ class AppStoreConnectService {
             filterAppIds += try appsOperation.execute(with: requestor).await().map(\.id)
         }
 
-        let operation = ListBetaGroupsOperation(options: .init(appIds: filterAppIds, names: names))
+        let operation = ListBetaGroupsOperation(options: .init(appIds: filterAppIds, names: names, sort: sort))
         return try operation.execute(with: requestor).await().map(Model.BetaGroup.init)
     }
 
@@ -577,7 +581,7 @@ extension AppStoreConnectService {
             .await()
             .build
             .id
-        let groupIds = try ListBetaGroupsOperation(options: .init(appIds: [], names: []))
+        let groupIds = try ListBetaGroupsOperation(options: .init(appIds: [], names: [], sort: nil))
             .execute(with: requestor)
             .await()
             .filter {

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
@@ -9,6 +9,7 @@ struct ListBetaGroupsOperation: APIOperation {
     struct Options {
         let appIds: [String]
         let names: [String]
+        let sort: ListBetaGroups.Sort?
     }
 
     typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
@@ -39,7 +40,12 @@ struct ListBetaGroupsOperation: APIOperation {
         filters += options.names.isEmpty ? [] : [.name(options.names)]
 
         let response = requestor.requestAllPages {
-            APIEndpoint.betaGroups(filter: filters, include: [.app], next: $0)
+            APIEndpoint.betaGroups(
+                filter: filters,
+                include: [.app],
+                sort: [self.options.sort].compactMap { $0 },
+                next: $0
+            )
         }
 
         let output = response.tryMap { (responses: [BetaGroupsResponse]) in

--- a/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
@@ -15,7 +15,7 @@ final class ListBetaGroupsOperationTests: XCTestCase {
     )
 
     func testExecute_success() throws {
-        let operation = Operation(options: Options(appIds: [], names: []))
+        let operation = Operation(options: Options(appIds: [], names: [], sort: nil))
 
         let output = try operation.execute(with: successRequestor).await()
 
@@ -25,7 +25,7 @@ final class ListBetaGroupsOperationTests: XCTestCase {
     }
 
     func testExecute_propagatesUpstreamErrors() {
-        let operation = Operation(options: Options(appIds: [], names: []))
+        let operation = Operation(options: Options(appIds: [], names: [], sort: nil))
 
         let result = Result { try operation.execute(with: FailureTestRequestor()).await() }
 


### PR DESCRIPTION
Closes #166 
# 📝 Summary of Changes

Changes proposed in this pull request:

- Added sort option to beta group list command

## 🔨 How To Test

To sort by group name 
```swift run asc testflight betagroup list --sort +name```
```swift run asc testflight betagroup list --sort -name```

To sort by createdDate
```swift run asc testflight betagroup list --sort -createdDate```
```swift run asc testflight betagroup list --sort +createdDate```

To sort by publicLinkEnabled
```swift run asc testflight betagroup list --sort +publicLinkEnabled```
```swift run asc testflight betagroup list --sort -publicLinkEnabled```

To sort by publicLinkLimit
```swift run asc testflight betagroup list --sort +publicLinkLimit``` 
```swift run asc testflight betagroup list --sort -publicLinkLimit ```
