### PR TITLE
Add exclude internal group option to List Beta Group Command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
@@ -35,11 +35,20 @@ struct ListBetaGroupsCommand: CommonParsableCommand {
         )
     ) var sort: ListBetaGroups.Sort?
 
+    @Flag(
+        help: "Exclude apple store connect internal beta groups."
+    ) var excludeInternal: Bool
+
     func run() throws {
         let service = try makeService()
 
-        let betaGroups = try service.listBetaGroups(filterIdentifiers: appLookupOptions.filterIdentifiers, names: filterNames, sort: sort)
-
+        let betaGroups = try service.listBetaGroups(
+            filterIdentifiers: appLookupOptions.filterIdentifiers,
+            names: filterNames,
+            sort: sort,
+            excludeInternal: excludeInternal
+        )
+        
         betaGroups.render(format: common.outputFormat)
     }
 }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -360,7 +360,8 @@ class AppStoreConnectService {
     func listBetaGroups(
         filterIdentifiers: [AppLookupIdentifier],
         names: [String],
-        sort: ListBetaGroups.Sort?
+        sort: ListBetaGroups.Sort?,
+        excludeInternal: Bool
     ) throws -> [Model.BetaGroup] {
         var filterAppIds: [String] = []
         var filterBundleIds: [String] = []
@@ -379,7 +380,10 @@ class AppStoreConnectService {
             filterAppIds += try appsOperation.execute(with: requestor).await().map(\.id)
         }
 
-        let operation = ListBetaGroupsOperation(options: .init(appIds: filterAppIds, names: names, sort: sort))
+        let operation = ListBetaGroupsOperation(
+            options: .init(appIds: filterAppIds, names: names, sort: sort, excludeInternal: excludeInternal)
+        )
+
         return try operation.execute(with: requestor).await().map(Model.BetaGroup.init)
     }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
@@ -40,8 +40,8 @@ struct ListBetaGroupsOperation: APIOperation {
         filters += options.appIds.isEmpty ? [] : [.app(options.appIds)]
         filters += options.names.isEmpty ? [] : [.name(options.names)]
 
-        if let excludeInternal = options.excludeInternal {
-            filters += [.isInternalGroup(["\(excludeInternal)"])]
+        if let excludeInternal = options.excludeInternal, excludeInternal {
+            filters += [.isInternalGroup(["\(!excludeInternal)"])]
         }
 
         let response = requestor.requestAllPages {

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
@@ -10,6 +10,7 @@ struct ListBetaGroupsOperation: APIOperation {
         let appIds: [String]
         let names: [String]
         let sort: ListBetaGroups.Sort?
+        var excludeInternal: Bool?
     }
 
     typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
@@ -38,6 +39,10 @@ struct ListBetaGroupsOperation: APIOperation {
         var filters: [ListBetaGroups.Filter] = []
         filters += options.appIds.isEmpty ? [] : [.app(options.appIds)]
         filters += options.names.isEmpty ? [] : [.name(options.names)]
+
+        if let excludeInternal = options.excludeInternal {
+            filters += [.isInternalGroup(["\(excludeInternal)"])]
+        }
 
         let response = requestor.requestAllPages {
             APIEndpoint.betaGroups(


### PR DESCRIPTION
Add excludeInternal option to ListBetaGroupsCommand,
Closes #167

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add `@Flag() var excludeInternal: Bool` to ListBetaGroupsCommand
- Add `var excludeInternal?` to  ListBetaGroupsOperation options, and endpoint filters  

# 🧐🗒 Reviewer Notes

## 💁 Example

##### Usage:
`asc testflight betagroup list [--exclude-internal]`

## 🔨 How To Test

`asc testflight betagroup list --exclude-internal`
`asc testflight betagroup list`
