### PR TITLE
Filter betatesters by betagroups

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -68,12 +68,6 @@ struct ListBetaTestersCommand: CommonParsableCommand {
     @Option(help: "Number of included related resources to return.")
     var relatedResourcesLimit: Int?
 
-    func validate() throws {
-        if !appLookupOptions.filterIdentifiers.isEmpty && !filterGroupNames.isEmpty {
-            throw ValidationError("Only one of these relationship filters ('app-id/ bundle-id', 'group-name') can be applied.")
-        }
-    }
-
     func run() throws {
         let service = try makeService()
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -231,7 +231,7 @@ class AppStoreConnectService {
         var groupIds: [String] = []
         if !groupNames.isEmpty {
             groupIds = try groupNames.flatMap {
-                try ListBetaGroupsOperation(options: .init(appIds: [], names: [$0], sort: nil))
+                try ListBetaGroupsOperation(options: .init(appIds: [], names: [$0], sort: nil, include: [.app]))
                     .execute(with: requestor)
                     .await()
                     .map { $0.betaGroup.id }
@@ -295,7 +295,7 @@ class AppStoreConnectService {
             .id
 
         let groupIds = try groupNames.flatMap {
-            try ListBetaGroupsOperation(options: .init(appIds: [], names: [$0], sort: nil))
+            try ListBetaGroupsOperation(options: .init(appIds: [], names: [$0], sort: nil, include: [.app]))
                 .execute(with: requestor)
                 .await()
                 .map { $0.betaGroup.id }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -260,7 +260,6 @@ class AppStoreConnectService {
                         apps: [app.attributes?.name ?? ""]
                     )
                     modelBetaTesters.append(modelBetaTester)
-
                 }
             }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
@@ -48,9 +48,9 @@ struct ListBetaGroupsOperation: APIOperation {
 
         let response = requestor.requestAllPages {
             APIEndpoint.betaGroups(
-                filter: filters, 
-                sort: [self.options.sort].compactMap { $0 },
+                filter: filters,
                 include: self.options.include,
+                sort: [self.options.sort].compactMap { $0 },
                 next: $0
             )
         }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
@@ -16,7 +16,6 @@ struct ListBetaGroupsOperation: APIOperation {
 
     typealias BetaGroup = AppStoreConnect_Swift_SDK.BetaGroup
     typealias App = AppStoreConnect_Swift_SDK.App
-     
 
     typealias Output = [(app: App, betaGroup: BetaGroup, betaTester: [BetaTester]?)]
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
@@ -11,8 +11,8 @@ struct ListBetaTestersOperation: APIOperation {
         let firstName: String?
         let lastName: String?
         let inviteType: BetaInviteType?
-        let appIds: [String]?
-        let groupIds: [String]?
+        let appIds: [String]
+        let groupIds: [String]
         let sort: ListBetaTesters.Sort?
         let limit: Int?
         let relatedResourcesLimit: Int?
@@ -77,12 +77,12 @@ struct ListBetaTestersOperation: APIOperation {
             filters.append(.inviteType([inviteType.rawValue]))
         }
 
-        if let appIds = options.appIds, !appIds.isEmpty {
-            filters.append(.apps(appIds))
+        if !options.appIds.isEmpty && options.groupIds.isEmpty {
+            filters.append(.apps(options.appIds))
         }
 
-        if let groupIds = options.groupIds, !groupIds.isEmpty {
-            filters.append(.betaGroups(groupIds))
+        if !options.groupIds.isEmpty && options.appIds.isEmpty {
+            filters.append(.betaGroups(options.groupIds))
         }
 
         return filters

--- a/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/ListBetaGroupsOperationTests.swift
@@ -15,7 +15,7 @@ final class ListBetaGroupsOperationTests: XCTestCase {
     )
 
     func testExecute_success() throws {
-        let operation = Operation(options: Options(appIds: [], names: [], sort: nil))
+        let operation = Operation(options: Options(appIds: [], names: [], sort: nil, include: [.app]))
 
         let output = try operation.execute(with: successRequestor).await()
 
@@ -25,7 +25,7 @@ final class ListBetaGroupsOperationTests: XCTestCase {
     }
 
     func testExecute_propagatesUpstreamErrors() {
-        let operation = Operation(options: Options(appIds: [], names: [], sort: nil))
+        let operation = Operation(options: Options(appIds: [], names: [], sort: nil, include: [.app]))
 
         let result = Result { try operation.execute(with: FailureTestRequestor()).await() }
 


### PR DESCRIPTION

# 📝 Summary of Changes

Changes proposed in this pull request:

-  Filter beta testers by beta groups

# 🧐🗒 Reviewer Notes
- Betatesters API doesn't support filtering by both identifier and beta groups. When  we need to filter by both identifier and beta group names we need to use the  betagroup endpoint with included option .app and .betatesters.

## 🔨 How To Test

```swift run asc testflight betatesters list --filter-identifiers iba.test3 --filter-group-names testGrp1```
