### PR TITLE
Add betatesters listbygroup command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByGroupCommand.swift
@@ -1,9 +1,6 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 import ArgumentParser
-import AppStoreConnect_Swift_SDK
-import Combine
-import struct Model.BetaTester
 
 struct ListBetaTesterByGroupCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
@@ -19,7 +16,7 @@ struct ListBetaTesterByGroupCommand: CommonParsableCommand {
 
     @Argument(
         help: ArgumentHelp(
-            "TestFlight beta group names.",
+            "TestFlight beta group name.",
             discussion: "Please input a specific group name"
         )
     )

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByGroupCommand.swift
@@ -1,0 +1,34 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Combine
+import struct Model.BetaTester
+
+struct ListBetaTesterByGroupCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "listbygroup",
+        abstract: "List beta testers in a specific beta group for a specific app"
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @OptionGroup()
+    var appLookupArgument: AppLookupArgument
+
+    @Argument(
+        help: ArgumentHelp(
+            "TestFlight beta group names.",
+            discussion: "Please input a specific group name"
+        )
+    )
+    var groupName: String
+
+    func run() throws {
+        let service = try makeService()
+
+        let betaTesters = try service.listBetaTestersForGroup(identifier: appLookupArgument.identifier, groupName: groupName)
+        betaTesters.render(format: common.outputFormat)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/TestFlightBetaTestersCommand.swift
@@ -12,6 +12,7 @@ public struct TestFlightBetaTestersCommand: ParsableCommand {
             DeleteBetaTesterCommand.self,
             ListBetaTestersCommand.self,
             ListBetaTesterByBuildsCommand.self,
+            ListBetaTesterByGroupCommand.self,
             ReadBetaTesterCommand.self,
             RemoveTesterFromGroupsCommand.self,
             AddTesterToGroupsCommand.self

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -318,7 +318,7 @@ class AppStoreConnectService {
 
             var appId: String = ""
 
-            switch (identifier) {
+            switch identifier {
             case .appId(let id):
                 appId = id
             case .bundleId(let bundleId):

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
@@ -20,7 +20,7 @@ struct GetBetaGroupOperation: APIOperation {
             case .betaGroupNotFound(let groupName, let bundleId, let appId):
                 return "No beta group found with name: \(groupName) and bundle id: \(bundleId) and app id: \(appId)"
             case .betaGroupNotUniqueToApp(let groupName, let bundleId, let appId):
-                return "Multiple beta groups found with name: \(groupName) and app id: \(bundleId) and app id: \(appId)"
+                return "Multiple beta groups found with name: \(groupName) and bundle id: \(bundleId) and app id: \(appId)"
             }
         }
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
@@ -12,15 +12,15 @@ struct GetBetaGroupOperation: APIOperation {
     }
 
     enum Error: LocalizedError {
-        case betaGroupNotFound(groupName: String, bundleId: String)
-        case betaGroupNotUniqueToApp(groupName: String, bundleId: String)
+        case betaGroupNotFound(groupName: String, bundleId: String, appid: String)
+        case betaGroupNotUniqueToApp(groupName: String, bundleId: String, appid: String)
 
         var errorDescription: String? {
             switch self {
-            case .betaGroupNotFound(let groupName, let bundleId):
-                return "No beta group found with name: \(groupName) and bundle id: \(bundleId)"
-            case .betaGroupNotUniqueToApp(let groupName, let bundleId):
-                return "Multiple beta groups found with name: \(groupName) and app id: \(bundleId)"
+            case .betaGroupNotFound(let groupName, let bundleId, let appId):
+                return "No beta group found with name: \(groupName) and bundle id: \(bundleId) and app id: \(appId)"
+            case .betaGroupNotUniqueToApp(let groupName, let bundleId, let appId):
+                return "Multiple beta groups found with name: \(groupName) and app id: \(bundleId) and app id: \(appId)"
             }
         }
     }
@@ -37,9 +37,10 @@ struct GetBetaGroupOperation: APIOperation {
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<BetaGroup, Swift.Error> {
         let betaGroupName = options.betaGroupName
         let bundleId = options.bundleId ?? ""
+        let appId = options.appId ?? ""
 
         var filters: [ListBetaGroups.Filter] = [.name([betaGroupName])]
-        filters += options.appId != nil ? [.app([options.appId!])] : []
+        filters += appId.isEmpty ? [] : [.app([appId])]
 
         let endpoint = APIEndpoint.betaGroups(filter: filters)
 
@@ -50,9 +51,9 @@ struct GetBetaGroupOperation: APIOperation {
             case (.some(let betaGroup), 1):
                 return betaGroup
             case (.some, _):
-                throw Error.betaGroupNotUniqueToApp(groupName: betaGroupName, bundleId: bundleId)
+                throw Error.betaGroupNotUniqueToApp(groupName: betaGroupName, bundleId: bundleId, appid: appId)
             case (.none, _):
-                throw Error.betaGroupNotFound(groupName: betaGroupName, bundleId: bundleId)
+                throw Error.betaGroupNotFound(groupName: betaGroupName, bundleId: bundleId, appid: appId)
             }
         }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
@@ -12,8 +12,8 @@ struct GetBetaGroupOperation: APIOperation {
     }
 
     enum Error: LocalizedError {
-        case betaGroupNotFound(groupName: String, bundleId: String, appid: String)
-        case betaGroupNotUniqueToApp(groupName: String, bundleId: String, appid: String)
+        case betaGroupNotFound(groupName: String, bundleId: String, appId: String)
+        case betaGroupNotUniqueToApp(groupName: String, bundleId: String, appId: String)
 
         var errorDescription: String? {
             switch self {
@@ -51,9 +51,9 @@ struct GetBetaGroupOperation: APIOperation {
             case (.some(let betaGroup), 1):
                 return betaGroup
             case (.some, _):
-                throw Error.betaGroupNotUniqueToApp(groupName: betaGroupName, bundleId: bundleId, appid: appId)
+                throw Error.betaGroupNotUniqueToApp(groupName: betaGroupName, bundleId: bundleId, appId: appId)
             case (.none, _):
-                throw Error.betaGroupNotFound(groupName: betaGroupName, bundleId: bundleId, appid: appId)
+                throw Error.betaGroupNotFound(groupName: betaGroupName, bundleId: bundleId, appId: appId)
             }
         }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersByGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersByGroupOperation.swift
@@ -1,0 +1,30 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+
+struct ListBetaTestersByGroupOperation: APIOperation {
+
+    struct Options {
+        let groupId: String
+    }
+
+    private let options: Options
+
+    typealias BetaTester =  AppStoreConnect_Swift_SDK.BetaTester
+    typealias Output = [BetaTester]
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Output, Error> {
+        let endpoint = APIEndpoint.betaTesters(inBetaGroupWithId: options.groupId)
+
+        return requestor.request(endpoint)
+        .map{ response -> Output in
+            return response.data 
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
@@ -78,7 +78,7 @@ final class GetBetaGroupOperationTests: XCTestCase {
         }
 
         switch result {
-        case .failure(Operation.Error.betaGroupNotFound(groupName: "Some Group", bundleId: "com.example.test")):
+        case .failure(Operation.Error.betaGroupNotFound(groupName: "Some Group", bundleId: "com.example.test", appId: "1234567890")):
             break
         default:
             XCTFail()
@@ -120,7 +120,7 @@ final class GetBetaGroupOperationTests: XCTestCase {
         }
 
         switch result {
-        case .failure(Operation.Error.betaGroupNotFound(groupName: "Some Group", bundleId: "com.example.test")):
+        case .failure(Operation.Error.betaGroupNotFound(groupName: "Some Group", bundleId: "com.example.test", appId: "1234567890")):
             break
         default:
             XCTFail()
@@ -146,7 +146,7 @@ final class GetBetaGroupOperationTests: XCTestCase {
         }
 
         switch result {
-        case .failure(Operation.Error.betaGroupNotUniqueToApp(groupName: "Some Group", bundleId: "com.example.test")):
+        case .failure(Operation.Error.betaGroupNotUniqueToApp(groupName: "Some Group", bundleId: "com.example.test", appId: "1234567890")):
             break
         default:
             XCTFail()


### PR DESCRIPTION
closes #176 
# 📝 Summary of Changes

Changes proposed in this pull request:

- Add beta testers listbygroup command to get beta testers for a specific app and specific group name

## 🔨 How To Test

```swift run asc testflight betatesters listbygroup iba.test3 testGrp1```
```swift run asc testflight betatesters listbygroup 1511865740 testGrp1```
```swift run asc testflight betatesters listbygroup iba.test2 testGrp2 ```
