### PR TITLE
Update List Profiles Command to use Operation

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -683,6 +683,27 @@ class AppStoreConnectService {
             .map(Device.init)
     }
 
+    func listProfiles(
+        filterName: [String],
+        filterProfileState: ProfileState?,
+        filterProfileType: [ProfileType],
+        sort: Profiles.Sort?,
+        limit: Int?
+    ) throws -> [Model.Profile] {
+        try ListProfilesOperation(
+                options: .init(
+                    filterName: filterName,
+                    filterProfileState: filterProfileState,
+                    filterProfileType: filterProfileType,
+                    sort: sort,
+                    limit: limit
+                )
+            )
+            .execute(with: requestor)
+            .await()
+            .map(Model.Profile.init)
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListDevicesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListDevicesOperation.swift
@@ -24,13 +24,10 @@ struct ListDevicesOperation: APIOperation {
 
         var filters = [Devices.Filter]()
 
-        filters += options.filterName.isEmpty ? [] : [.name(options.filterName)]
-
-        filters += options.filterPlatform.isEmpty ? [] : [.platform(options.filterPlatform)]
-
-        filters += options.filterUDID.isEmpty ? [] : [.udid(options.filterUDID)]
-
-        filters += options.filterStatus != nil ? [.status([options.filterStatus!])] : []
+        if options.filterName.isNotEmpty { filters.append(.name(options.filterName)) }
+        if options.filterPlatform.isNotEmpty { filters.append(.platform(options.filterPlatform)) }
+        if options.filterUDID.isNotEmpty { filters.append(.udid(options.filterUDID)) }
+        if let filterStatus = options.filterStatus { filters.append(.status([filterStatus])) }
 
         let sort = [options.sort].compactMap { $0 }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
@@ -23,25 +23,15 @@ struct ListProfilesOperation: APIOperation {
 
         var filters = [Profiles.Filter]()
 
-        if !options.filterName.isEmpty {
-            filters.append(.name(options.filterName))
-        }
+        filters += options.filterName.isEmpty ? [] : [.name(options.filterName)]
 
-        if let filterProfileState = options.filterProfileState {
-            filters.append(.profileState([filterProfileState]))
-        }
+        filters += options.filterProfileType.isEmpty ? [] : [.profileType(options.filterProfileType)]
 
-        if !options.filterProfileType.isEmpty {
-            filters.append(.profileType(options.filterProfileType))
-        }
+        filters += options.filterProfileState != nil ? [.profileState([options.filterProfileState!])] : []
+
+        let limits: [Profiles.Limit] = options.limit != nil ? [.profiles(options.limit!)] : []
 
         let sort = [options.sort].compactMap { $0 }
-
-        var limits = [Profiles.Limit]()
-        
-        if let limit = options.limit {
-            limits.append(.profiles(limit))
-        }
 
         let endpoint = APIEndpoint.listProfiles(
             filter: filters,

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
@@ -1,0 +1,58 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+
+struct ListProfilesOperation: APIOperation {
+
+    struct Options {
+        let filterName: [String]
+        let filterProfileState: ProfileState?
+        let filterProfileType: [ProfileType]
+        let sort: Profiles.Sort?
+        let limit: Int?
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<[Profile], Error> {
+
+        var filters = [Profiles.Filter]()
+
+        if !options.filterName.isEmpty {
+            filters.append(.name(options.filterName))
+        }
+
+        if let filterProfileState = options.filterProfileState {
+            filters.append(.profileState([filterProfileState]))
+        }
+
+        if !options.filterProfileType.isEmpty {
+            filters.append(.profileType(options.filterProfileType))
+        }
+
+        let sort = [options.sort].compactMap { $0 }
+
+        var limits = [Profiles.Limit]()
+        
+        if let limit = options.limit {
+            limits.append(.profiles(limit))
+        }
+
+        let endpoint = APIEndpoint.listProfiles(
+            filter: filters,
+            include: [.bundleId, .certificates, .devices],
+            sort: sort,
+            limit: limits
+        )
+
+        return requestor
+            .request(endpoint)
+            .map(\.data)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
@@ -23,11 +23,9 @@ struct ListProfilesOperation: APIOperation {
 
         var filters = [Profiles.Filter]()
 
-        filters += options.filterName.isEmpty ? [] : [.name(options.filterName)]
-
-        filters += options.filterProfileType.isEmpty ? [] : [.profileType(options.filterProfileType)]
-
-        filters += options.filterProfileState != nil ? [.profileState([options.filterProfileState!])] : []
+        if options.filterName.isNotEmpty { filters.append(.name(options.filterName)) }
+        if options.filterProfileType.isNotEmpty { filters.append(.profileType(options.filterProfileType)) }
+        if let filterProfileState = options.filterProfileState { filters.append(.profileState([filterProfileState])) }
 
         let limits: [Profiles.Limit] = options.limit != nil ? [.profiles(options.limit!)] : []
 


### PR DESCRIPTION
Update `ListProfilesCommand` to use Operation

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `ListProfilesOperation` and service function `listProfiles`
- Update `ListProfilesCommand` to use Operation

# ⚠️ Items of Note

the SDK `APIEndpoint.listProfiles()` doesn't support paging (will start a PR to fix), so paging support is not included in this PR 

# 🧐🗒 Reviewer Notes

## 💁 Example

##### Usage
`asc profiles list [--limit <limit>] [--sort <sort>] [--filter-name <name> ...] [--filter-profile-state <state>] [--filter-profile-type <type> ...] [--download-path <path>]`

## 🔨 How To Test

`asc profiles list`
