### PR TITLE
Refactor GetBetaGroupOperation

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -215,8 +215,7 @@ class AppStoreConnectService {
         }
 
         try AddTesterToGroupOperation(
-            options: .init(addStrategy: .addTesterToGroups(testerId: testerId, groupIds: groupIds)
-            )
+            options: .init(addStrategy: .addTesterToGroups(testerId: testerId, groupIds: groupIds))
         )
         .execute(with: requestor)
         .await()
@@ -340,10 +339,12 @@ class AppStoreConnectService {
     }
 
     func removeTestersFromGroup(groupName: String, emails: [String]) throws {
-        let groupId = try GetBetaGroupOperation(options: .init(appId: nil, bundleId: nil,betaGroupName: groupName))
-            .execute(with: requestor)
-            .await()
-            .id
+        let groupId = try GetBetaGroupOperation(
+            options: .init(appId: nil, bundleId: nil, betaGroupName: groupName)
+        )
+        .execute(with: requestor)
+        .await()
+        .id
 
         let testerIds = try emails.map {
             try GetBetaTesterOperation(

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -175,7 +175,7 @@ class AppStoreConnectService {
             .await()
 
         let groupId = try GetBetaGroupOperation(
-                options: .init(app: app, betaGroupName: groupName)
+                options: .init(appId: app.id, bundleId: bundleId, betaGroupName: groupName)
             )
             .execute(with: requestor)
             .await()
@@ -207,20 +207,19 @@ class AppStoreConnectService {
 
         let groupIds = try groupNames.map {
             try GetBetaGroupOperation(
-                    options: .init(app: app, betaGroupName: $0)
-                )
-                .execute(with: requestor)
-                .await()
-                .id
-        }
-
-        try AddTesterToGroupOperation(
-                options: .init(
-                    addStrategy: .addTesterToGroups(testerId: testerId, groupIds: groupIds)
-                )
+                options: .init(appId: app.id, bundleId: bundleId, betaGroupName: $0)
             )
             .execute(with: requestor)
             .await()
+            .id
+        }
+
+        try AddTesterToGroupOperation(
+            options: .init(addStrategy: .addTesterToGroups(testerId: testerId, groupIds: groupIds)
+            )
+        )
+        .execute(with: requestor)
+        .await()
     }
 
     func getBetaTester(
@@ -341,7 +340,7 @@ class AppStoreConnectService {
     }
 
     func removeTestersFromGroup(groupName: String, emails: [String]) throws {
-        let groupId = try GetBetaGroupOperation(options: .init(app: nil, betaGroupName: groupName))
+        let groupId = try GetBetaGroupOperation(options: .init(appId: nil, bundleId: nil,betaGroupName: groupName))
             .execute(with: requestor)
             .await()
             .id
@@ -370,7 +369,7 @@ class AppStoreConnectService {
             .execute(with: requestor)
             .await()
 
-        let options = GetBetaGroupOperation.Options(app: app, betaGroupName: groupName)
+        let options = GetBetaGroupOperation.Options(appId: app.id, bundleId: bundleId, betaGroupName: groupName)
         let betaGroup = try GetBetaGroupOperation(options: options)
             .execute(with: requestor)
             .await()
@@ -401,13 +400,15 @@ class AppStoreConnectService {
     }
 
     func deleteBetaGroup(appBundleId: String, betaGroupName: String) throws {
-        let app = try GetAppsOperation(options: .init(bundleIds: [appBundleId]))
+        let appId = try GetAppsOperation(options: .init(bundleIds: [appBundleId]))
             .execute(with: requestor)
             .compactMap(\.first)
             .await()
+            .id
 
         let betaGroup = try GetBetaGroupOperation(
-            options: .init(app: app, betaGroupName: betaGroupName))
+                options: .init(appId: appId, bundleId: appBundleId, betaGroupName: betaGroupName)
+            )
             .execute(with: requestor)
             .await()
 
@@ -458,7 +459,7 @@ class AppStoreConnectService {
         let app = try getAppsOperation.execute(with: requestor).compactMap(\.first).await()
 
         let getBetaGroupOperation = GetBetaGroupOperation(
-            options: .init(app: app, betaGroupName: currentGroupName))
+            options: .init(appId: app.id, bundleId: appBundleId, betaGroupName: currentGroupName))
         let betaGroup = try getBetaGroupOperation.execute(with: requestor).await()
 
         let modifyBetaGroupOptions = ModifyBetaGroupOperation.Options(

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
@@ -6,7 +6,8 @@ import Foundation
 
 struct GetBetaGroupOperation: APIOperation {
     struct Options {
-        let app: App?
+        let appId: String? 
+        let bundleId: String?
         let betaGroupName: String
     }
 
@@ -35,14 +36,12 @@ struct GetBetaGroupOperation: APIOperation {
 
     func execute(with requestor: EndpointRequestor) -> AnyPublisher<BetaGroup, Swift.Error> {
         let betaGroupName = options.betaGroupName
-        let bundleId = options.app?.attributes?.bundleId ?? ""
+        let bundleId = options.bundleId ?? ""
 
-        var filter: [ListBetaGroups.Filter] = [.name([betaGroupName])]
-        if let app = options.app {
-            filter.append(.app([app.id]))
-        }
+        var filters: [ListBetaGroups.Filter] = [.name([betaGroupName])]
+        filters += options.appId != nil ? [.app([options.appId!])] : []
 
-        let endpoint = APIEndpoint.betaGroups(filter: filter)
+        let endpoint = APIEndpoint.betaGroups(filter: filters)
 
         let betaGroup = requestor.request(endpoint).tryMap { response -> BetaGroup in
             let betaGroups = response.data.filter { $0.attributes?.name == betaGroupName }

--- a/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetBetaGroupOperationTests.swift
@@ -14,24 +14,9 @@ final class GetBetaGroupOperationTests: XCTestCase {
 
     let testUrl = URL(fileURLWithPath: "test")
 
-    var app: App {
-        App(
-            attributes: App.Attributes(
-                bundleId: "com.example.test",
-                name: nil,
-                primaryLocale: nil,
-                sku: nil
-            ),
-            id: "1234567890",
-            relationships: nil,
-            links: ResourceLinks(self: testUrl)
-        )
-    }
-
     var options: Options {
         Options(
-            app: app,
-            betaGroupName: "Some Group"
+            appId: "1234567890", bundleId: "com.example.test", betaGroupName: "Some Group"
         )
     }
 


### PR DESCRIPTION
# 📝 Summary of Changes
Closes #180 

Changes proposed in this pull request:

- Refactored GetBetaGroupOperation to accept appId and bundleId instead of app
- Changed the following to pass app id and bundle id to GetBetaGroupOperation

1. addTestersToGroup 
2. removeTestersFromGroup
3. readBetaGroup  
4. deleteBetaGroup  
5. modifyBetaGroup  

# 🧐🗒 Reviewer Notes
This refactor is required for using it in betatesters listbygroup command


## 🔨 How To Test
```swift run asc testflight betatesters addgroup <email> iba.test3 testGrp4```
```swift run asc testflight betagroup modify iba.test3 testGrp4```
```swift run asc testflight betagroup delete iba.test3 testGrp3```
```swift run asc testflight betagroup read iba.test3 testGrp3```
```swift run asc testflight betagroup removeuser iba.test3 testGrp4 <email>```



