### PR TITLE
Update List User Invitations Command to use Operation

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -2,7 +2,6 @@
 
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
-import Foundation
 
 struct ListUserInvitationsCommand: CommonParsableCommand {
     public static var configuration = CommandConfiguration(
@@ -19,37 +18,21 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified username")
     var filterEmail: [String]
 
-    @Option(parsing: .upToNextOption, help: "Filter the results by the specified roles")
+    @Option(parsing: .upToNextOption, help: "Filter the results by the specified roles, (eg. \(UserRole.allCases.compactMap { $0.rawValue.lowercased() })")
     var filterRole: [UserRole]
 
     @Flag(help: "Include visible apps in results.")
     var includeVisibleApps: Bool
 
-    private var filters: [ListInvitedUsers.Filter]? {
-        var filters = [ListInvitedUsers.Filter]()
-
-        if filterEmail.isEmpty == false {
-            filters += [ListInvitedUsers.Filter.email(filterEmail)]
-        }
-
-        if filterRole.isEmpty == false {
-            filters += [ListInvitedUsers.Filter.roles(filterRole.map { $0.rawValue })]
-        }
-
-        return filters
-    }
-
     public func run() throws {
         let service = try makeService()
 
-        let endpoint = APIEndpoint.invitedUsers(
-            limit: limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] },
-            filter: filters
+        let invitations = try service.listUserInvitaions(
+            filterEmail: filterEmail,
+            filterRole: filterRole,
+            limitVisibleApps: limitVisibleApps,
+            includeVisibleApps: includeVisibleApps
         )
-
-        let invitations = try service.request(endpoint)
-            .map(\.data)
-            .await()
 
         invitations.render(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -704,6 +704,24 @@ class AppStoreConnectService {
             .map(Model.Profile.init)
     }
 
+    func listUserInvitaions(
+        filterEmail: [String],
+        filterRole: [UserRole],
+        limitVisibleApps: Int?,
+        includeVisibleApps: Bool
+    ) throws -> [UserInvitation] {
+        try ListUserInvitationsOperation(
+                options: .init(
+                    filterEmail: filterEmail,
+                    filterRole: filterRole,
+                    includeVisibleApps: includeVisibleApps,
+                    limitVisibleApps: limitVisibleApps
+                )
+            )
+            .execute(with: requestor)
+            .await()
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListUserInvitationsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListUserInvitationsOperation.swift
@@ -22,13 +22,8 @@ struct ListUserInvitationsOperation: APIOperation {
     func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<[UserInvitation], Error> {
         var filters = [ListInvitedUsers.Filter]()
 
-        if options.filterEmail.isEmpty == false {
-            filters += [ListInvitedUsers.Filter.email(options.filterEmail)]
-        }
-
-        if options.filterRole.isEmpty == false {
-            filters += [ListInvitedUsers.Filter.roles(options.filterRole.map { $0.rawValue })]
-        }
+        if options.filterEmail.isNotEmpty { filters.append(.email(options.filterEmail)) }
+        if options.filterRole.isNotEmpty { filters.append(.roles(options.filterRole.map { $0.rawValue })) }
 
         let limit = options.limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListUserInvitationsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListUserInvitationsOperation.swift
@@ -1,0 +1,47 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ListUserInvitationsOperation: APIOperation {
+
+    struct Options {
+        let filterEmail: [String]
+        let filterRole: [UserRole]
+        let includeVisibleApps: Bool
+        let limitVisibleApps: Int?
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<[UserInvitation], Error> {
+        var filters = [ListInvitedUsers.Filter]()
+
+        if options.filterEmail.isEmpty == false {
+            filters += [ListInvitedUsers.Filter.email(options.filterEmail)]
+        }
+
+        if options.filterRole.isEmpty == false {
+            filters += [ListInvitedUsers.Filter.roles(options.filterRole.map { $0.rawValue })]
+        }
+
+        let limit = options.limitVisibleApps.map { [ListInvitedUsers.Limit.visibleApps($0)] }
+
+        return requestor.requestAllPages {
+                .invitedUsers(
+                    limit: limit,
+                    filter: filters,
+                    next: $0
+                )
+            }
+            .map { $0.flatMap { $0.data } }
+            .eraseToAnyPublisher()
+    }
+}
+
+extension UserInvitationsResponse: PaginatedResponse { }


### PR DESCRIPTION
Update `ListUserInvitationsCommand` to use Operation

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `ListUserInvitationsOperation` and service function `listUserInvitaions`
- Add paging to Operation
- Update `ListUserInvitationsCommand` to use Operation

# 🧐🗒 Reviewer Notes

## 💁 Example

##### Usage
`asc users list-invitations [--limit-visible-apps <limit-visible-apps>] [--filter-email <filter-email> ...] [--filter-role <filter-role> ...] [--include-visible-apps]`

## 🔨 How To Test
`swift run asc users list-invitations`

