### PR TITLE
Implement Enable bundleId Capability Command

### DIFF
--- a/Sources/AppStoreConnectCLI/AppStoreConnectCLI.swift
+++ b/Sources/AppStoreConnectCLI/AppStoreConnectCLI.swift
@@ -15,6 +15,7 @@ public struct AppStoreConnectCLI: ParsableCommand {
             ReportsCommand.self,
             TestFlightCommand.self,
             UsersCommand.self,
+            CapabilityCommand.self
         ])
 
     public init() {

--- a/Sources/AppStoreConnectCLI/Commands/Capability/CapabilityCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Capability/CapabilityCommand.swift
@@ -1,0 +1,13 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+
+struct CapabilityCommand: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "capability",
+        abstract: "Manage the app capabilities for a bundle ID.",
+        subcommands: [
+            EnableBundleIdCapabilityCommand.self
+        ]
+    )
+}

--- a/Sources/AppStoreConnectCLI/Commands/Capability/EnableBundleIdCapability.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Capability/EnableBundleIdCapability.swift
@@ -1,0 +1,31 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+
+struct EnableBundleIdCapabilityCommand: CommonParsableCommand {
+
+    public static var configuration = CommandConfiguration(
+        commandName: "enable",
+        abstract: "Enable a capability for a bundle ID."
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The reverse-DNS bundle ID identifier to delete. Must be unique. (eg. com.example.app)")
+    var bundleId: String
+
+    @Argument(help: "Bundle Id capability type. \n \(CapabilityType.allCases)")
+    var capabilityType: CapabilityType
+
+    // TODO: CapabilitySetting
+
+    func run() throws {
+        let service = try makeService()
+
+        try service.enableBundleIdCapability(
+            bundleId: bundleId, capabilityType: capabilityType
+        )
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/API/CapabilityType+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/CapabilityType+ExpressibleByArgument.swift
@@ -1,0 +1,45 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+extension CapabilityType: CaseIterable, ExpressibleByArgument, CustomStringConvertible {
+    public typealias AllCases = [CapabilityType]
+
+    public static var allCases: AllCases {
+        [
+            .icloud,
+            .inAppPurchase,
+            .gameCenter,
+            .pushNotifications,
+            .wallet,
+            .interAppAudio,
+            .maps,
+            .associatedDomains,
+            .personalVpn,
+            .appGroups,
+            .healthkit,
+            .homekit,
+            .wirelessAccessoryConfiguration,
+            .applePay,
+            .dataProtection,
+            .sirikit,
+            .networkExtensions,
+            .multipath,
+            .hotSpot,
+            .nfcTagReading,
+            .classkit,
+            .autofillCredentialProvider,
+            .accessWifiInformation
+        ]
+    }
+
+    public init?(argument: String) {
+        self.init(rawValue: argument.uppercased())
+    }
+
+    public var description: String {
+        rawValue.lowercased()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -683,6 +683,24 @@ class AppStoreConnectService {
             .map(Device.init)
     }
 
+    func enableBundleIdCapability(
+        bundleId: String,
+        capabilityType: CapabilityType
+    ) throws {
+        let bundleIdResourceId = try ReadBundleIdOperation(
+                options: .init(bundleId: bundleId)
+            )
+            .execute(with: requestor)
+            .await()
+            .id
+
+        _ = try EnableBundleIdCapabilityOperation(
+                options: .init(bundleIdResourceId: bundleIdResourceId, capabilityType: capabilityType)
+            )
+            .execute(with: requestor)
+            .await()
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadBundleIdOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadBundleIdOperation.swift
@@ -17,9 +17,9 @@ struct ReadBundleIdOperation: APIOperation {
         var errorDescription: String? {
             switch self {
             case .couldNotFindBundleId(let bundleId):
-                return "Couldn't find bundleId: '\(bundleId)'."
-            case .bundleIdNotUnique(let serial):
-                return "The bundleId your provided '\(serial)' is not unique."
+                return "Couldn't find Bundle ID: '\(bundleId)'."
+            case .bundleIdNotUnique(let bundleId):
+                return "The Bundle ID you provided '\(bundleId)' is not unique."
             }
         }
     }


### PR DESCRIPTION
Relates to #93 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `ReadBundleIdOperation` and `EnableBundleIdCapabilityOperation`
- Implement `EnableBundleIdCapabilityCommand`

# ⚠️ Items of Note

This PR doesn't include printing the output of the response, if that is a requirement please comment below. :)

#### TODO 
MIssing `CapabilitySetting` options: 
`CapabilitySetting` in SDK doesn't have a `public init`(bug), so it can be left til SDK fix that problem.

# 🧐🗒 Reviewer Notes

## 💁 Example

#### Usage: 
```
asc capability enable <bundle-id> <capability-type>
```

## 🔨 How To Test

`asc capability enable com.exmaple.app push_notifications`
