### PR TITLE
Introduce File System module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,10 +45,17 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "appstoreconnect-cli", dependencies: ["AppStoreConnectCLI"]),
         .target(name: "Model"),
+        .target(name: "FileSystem",
+                dependencies: [
+                    .product(name: "CodableCSV", package: "CodableCSV"),
+                    .product(name: "Yams", package: "Yams"),
+                ]
+        ),
         .target(
             name: "AppStoreConnectCLI",
             dependencies: [
                 .target(name: "Model"),
+                .target(name: "FileSystem"),
                 .product(name: "Files", package: "Files"),
                 .product(name: "AppStoreConnect-Swift-SDK", package: "AppStoreConnect-Swift-SDK"),
                 .product(name: "Yams", package: "Yams"),

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,7 @@ let package = Package(
                 dependencies: [
                     .product(name: "CodableCSV", package: "CodableCSV"),
                     .product(name: "Yams", package: "Yams"),
+                    .product(name: "Files", package: "Files"),
                 ]
         ),
         .target(
@@ -56,7 +57,6 @@ let package = Package(
             dependencies: [
                 .target(name: "Model"),
                 .target(name: "FileSystem"),
-                .product(name: "Files", package: "Files"),
                 .product(name: "AppStoreConnect-Swift-SDK", package: "AppStoreConnect-Swift-SDK"),
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
@@ -2,9 +2,7 @@
 
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
-import Combine
-import Foundation
-import Files
+import FileSystem
 
 struct ListCertificatesCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
@@ -51,21 +49,13 @@ struct ListCertificatesCommand: CommonParsableCommand {
             )
 
         if let downloadPath = downloadPath {
-            try certificates.forEach { certificate in
-                guard
-                    let content = certificate.content,
-                    let data = Data(base64Encoded: content)
-                else {
-                    throw CertificatesError.noContent
-                }
+            let certificateProcessor = CertificateProcessor(path: .folder(path: downloadPath))
 
-                let file = try Folder(path: downloadPath)
-                    .createFile(
-                        named: "\(certificate.serialNumber ?? "serial").cer",
-                        contents: data
-                    )
+            try certificates.forEach {
 
-                print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(file.path)")
+                let file = try certificateProcessor.write($0)
+
+                print("📥 Certificate '\($0.name ?? "")' downloaded to: \(file.path)")
             }
         }
 

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
@@ -1,10 +1,7 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
-import AppStoreConnect_Swift_SDK
 import ArgumentParser
-import Combine
-import Foundation
-import Files
+import FileSystem
 
 struct ReadCertificateCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
@@ -27,20 +24,9 @@ struct ReadCertificateCommand: CommonParsableCommand {
             .readCertificate(serial: serial)
 
         if let certificateOutput = certificateOutput {
-            guard
-                let content = certificate.content,
-                let data = Data(base64Encoded: content)
-            else {
-                throw CertificatesError.noContent
-            }
+            let fileProcessor = CertificateProcessor(path: .file(path: certificateOutput))
 
-            let standardizedPath = certificateOutput as NSString
-
-            let file = try Folder(path: standardizedPath.deletingLastPathComponent)
-                .createFile(
-                    named: standardizedPath.lastPathComponent,
-                    contents: data
-                )
+            let file = try fileProcessor.write(certificate)
 
             print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(file.path)")
         }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -3,7 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Foundation
-import Files
+import FileSystem
 
 struct ListProfilesCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
@@ -56,13 +56,11 @@ struct ListProfilesCommand: CommonParsableCommand {
     @Option(help:
         ArgumentHelp(
             "If set, the provisioning profiles will be saved as files to this path.",
-            discussion: "Profiles will be saved to files with names of the pattern '<UUID>.\(profileExtension)'.",
+            discussion: "Profiles will be saved to files with names of the pattern '<UUID>.\(ProfileProcessor.profileExtension)'.",
             valueName: "path"
         )
     )
     var downloadPath: String?
-
-    static let profileExtension = "mobileprovision"
 
     func run() throws {
         let service = try makeService()
@@ -76,13 +74,11 @@ struct ListProfilesCommand: CommonParsableCommand {
         )
 
         if let path = downloadPath {
-            let folder = try Folder(path: path)
+            let processor = ProfileProcessor(path: .folder(path: path))
 
             try profiles.forEach {
-                let file = try folder.createFile(
-                    named: "\($0.uuid!).\(ListProfilesCommand.profileExtension)",
-                    contents: Data(base64Encoded: $0.profileContent!)!
-                )
+                let file = try processor.write($0)
+
                 print("📥 Profile '\($0.name!)' downloaded to: \(file.path)")
             }
         }

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -2,11 +2,10 @@
 
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
-import CodableCSV
 import Combine
 import Foundation
 import struct Model.User
-import Yams
+import FileSystem
 
 struct SyncUsersCommand: CommonParsableCommand {
     typealias UserChange = CollectionDifference<User>.Change

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Formats.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Formats.swift
@@ -2,6 +2,7 @@
 
 import ArgumentParser
 import Foundation
+import FileSystem
 
 enum OutputFormat: String, CaseIterable, Codable {
     case csv
@@ -22,20 +23,14 @@ extension OutputFormat: ExpressibleByArgument {
     }
 }
 
-enum InputFormat: String, CaseIterable, Codable {
-    case json
-    case yaml
-    case csv
-}
-
 extension InputFormat: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         self.rawValue
     }
 }
 
 extension InputFormat: ExpressibleByArgument {
-    init?(argument: String) {
+    public init?(argument: String) {
         self.init(rawValue: argument.lowercased())
     }
 }

--- a/Sources/FileSystem/Certificates/CertificateProcessor.swift
+++ b/Sources/FileSystem/Certificates/CertificateProcessor.swift
@@ -1,0 +1,53 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+import Files
+import Model
+
+public struct CertificateProcessor: ResourceWriter {
+
+    let path: ResourcePath
+
+    public init(path: ResourcePath) {
+        self.path = path
+    }
+
+    @discardableResult
+    public func write(_ certificate: Certificate) throws -> File {
+        try writeFile(certificate)
+    }
+
+    @discardableResult
+    public func write(_ certificates: [Certificate]) throws -> [File] {
+        try certificates.map { try write($0) }
+    }
+
+}
+
+extension Certificate: FileProvider {
+    private enum Error: LocalizedError {
+        case noContent
+
+        var errorDescription: String? {
+            switch self {
+            case .noContent:
+                return "The certificate in the response doesn't have a proper content."
+            }
+        }
+    }
+
+    func fileContent() throws -> Data {
+        guard
+            let content = content,
+            let data = Data(base64Encoded: content)
+            else {
+                throw Error.noContent
+        }
+
+        return data
+    }
+
+    var fileName: String {
+        "\(serialNumber ?? "serial").cer"
+    }
+}

--- a/Sources/FileSystem/Formats.swift
+++ b/Sources/FileSystem/Formats.swift
@@ -1,0 +1,9 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public enum InputFormat: String, CaseIterable, Codable {
+    case json
+    case yaml
+    case csv
+}

--- a/Sources/FileSystem/Profile/ProfileProcessor.swift
+++ b/Sources/FileSystem/Profile/ProfileProcessor.swift
@@ -1,0 +1,54 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+import Files
+import Model
+
+public struct ProfileProcessor: ResourceWriter {
+
+    public static let profileExtension = "mobileprovision"
+
+    let path: ResourcePath
+
+    public init(path: ResourcePath) {
+        self.path = path
+    }
+
+    @discardableResult
+    public func write(_ certificate: Profile) throws -> File {
+        try writeFile(certificate)
+    }
+
+    @discardableResult
+    public func write(_ certificates: [Profile]) throws -> [File] {
+        try certificates.map { try write($0) }
+    }
+
+}
+
+extension Profile: FileProvider {
+    private enum Error: LocalizedError {
+        case noContent
+
+        var errorDescription: String? {
+            switch self {
+            case .noContent:
+                return "The Profile in the response doesn't have a proper content."
+            }
+        }
+    }
+
+    func fileContent() throws -> Data {
+        guard
+            let content = profileContent,
+            let data = Data(base64Encoded: content) else {
+                throw Error.noContent
+            }
+
+        return data
+    }
+
+    var fileName: String {
+        "\(uuid!).\(ProfileProcessor.profileExtension)"
+    }
+}

--- a/Sources/FileSystem/Readers.swift
+++ b/Sources/FileSystem/Readers.swift
@@ -2,10 +2,8 @@
 
 import Foundation
 import CodableCSV
-import Combine
 import SwiftyTextTable
 import Yams
-import AppStoreConnect_Swift_SDK
 
 protocol Reader {
     associatedtype Output
@@ -13,12 +11,17 @@ protocol Reader {
     func read(filePath: String) -> Output
 }
 
-enum Readers {
+public enum Readers {
 
-    struct FileReader<T: Decodable>: Reader {
+    public struct FileReader<T: Decodable>: Reader {
+
         let format: InputFormat
 
-        func read(filePath: String) -> T {
+        public init(format: InputFormat) {
+            self.format = format
+        }
+
+        public func read(filePath: String) -> T {
             switch format {
             case .json:
                 return readJSON(from: filePath)
@@ -29,7 +32,7 @@ enum Readers {
             }
         }
 
-        private func readJSON<T: Decodable>(from filePath: String) -> T {
+        public func readJSON<T: Decodable>(from filePath: String) -> T {
             guard
                 let fileContents = try? String(contentsOfFile: filePath, encoding: .utf8),
                 let data = fileContents.data(using: .utf8),
@@ -40,7 +43,7 @@ enum Readers {
             return result
         }
 
-        private func readYAML<T: Decodable>(from filePath: String) -> T {
+        public func readYAML<T: Decodable>(from filePath: String) -> T {
             guard
                 let fileContents = try? String(contentsOfFile: filePath, encoding: .utf8),
                 let result = try? YAMLDecoder().decode(T.self, from: fileContents) else {
@@ -50,7 +53,7 @@ enum Readers {
             return result
         }
 
-        private func readCSV<T: Decodable>(from filePath: String) -> T {
+        public func readCSV<T: Decodable>(from filePath: String) -> T {
             let decoder = CSVDecoder {
                 $0.encoding = .utf8
                 $0.headerStrategy = .firstLine

--- a/Sources/FileSystem/ResourceProcessor.swift
+++ b/Sources/FileSystem/ResourceProcessor.swift
@@ -1,0 +1,69 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+import Files
+
+/// Resource processor root path
+public enum ResourcePath {
+    /// folder: The certain *path* of the folder
+    /// - path: resource processor root path will be the path of a folder, file be written inside this folder. (eg. documents/foldername/)
+    case folder(path: String)
+    /// file: path The certain *path* of the file
+    /// - path: resource processor root path will be the path of a file, file will be written to the certain path with certain name. (eg. documents/foldername/filename.txt)
+    case file(path: String)
+}
+
+protocol ResourceProcessor: ResourceReader, ResourceWriter { }
+
+protocol ResourceReader: PathProvider {
+    associatedtype T: Codable, FileProvider
+
+    func read() throws -> [T]
+}
+
+protocol ResourceWriter: PathProvider {
+    associatedtype T: Codable, FileProvider
+
+    func write(_: [T]) throws -> [File]
+
+    func write(_: T) throws -> File
+}
+
+protocol PathProvider {
+    var path: ResourcePath { get }
+}
+
+extension ResourceWriter {
+
+    func writeFile(_ resource: FileProvider) throws -> File {
+        var file: File
+
+        switch path {
+        case .file(let path):
+            let standardizedPath = path as NSString
+            file = try Folder(path: standardizedPath.deletingLastPathComponent)
+                .createFile(
+                    named: standardizedPath.lastPathComponent,
+                    contents: resource.fileContent()
+                )
+        case .folder(let folderPath):
+            file = try Folder(path: folderPath)
+                .createFile(
+                    named: resource.fileName,
+                    contents: resource.fileContent()
+                )
+        }
+
+        return file
+    }
+}
+
+protocol FileProvider: FileNameProvider, FileContentProvider { }
+
+protocol FileNameProvider {
+    var fileName: String { get }
+}
+
+protocol FileContentProvider {
+    func fileContent() throws -> Data
+}


### PR DESCRIPTION
Cover the topic in #177, create file system module and extract existing file write and read operations to it.

# 📝 Summary of Changes

Changes proposed in this pull request:
- Create module `FileSystem`
- Move `enum Reader`, `InputFormat` to `FileSystem`, with updates to commands
- Create `struct ProfileProcessor` and `struct CertificateProcessor` extends the new created `protocol ResourceProcessor` and `protocol FileProvider`. 
  
# ⚠️ Items of Note

Cover the topic of #177 

Some protocol namings may not 100% good 🤔 

Not 100% sure whether `print("📥 XXX '\($0.name ?? "")' downloaded to: \(file.path)")` should be included in `File System` or not. Didn't do this for now as mentioned in #177 that `FileSystem` should only deal with File write and read. But happy to change.

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

`swift run build`
