### PR TITLE
Implement disable bundleId capability command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Capability/CapabilityCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Capability/CapabilityCommand.swift
@@ -7,7 +7,8 @@ struct CapabilityCommand: ParsableCommand {
         commandName: "capability",
         abstract: "Manage the app capabilities for a bundle ID.",
         subcommands: [
-            EnableBundleIdCapabilityCommand.self
+            EnableBundleIdCapabilityCommand.self,
+            DisableBundleIdCapabilityCommand.self
         ]
     )
 }

--- a/Sources/AppStoreConnectCLI/Commands/Capability/DisableBundleIdCapabilityCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Capability/DisableBundleIdCapabilityCommand.swift
@@ -1,0 +1,27 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+
+struct DisableBundleIdCapabilityCommand: CommonParsableCommand {
+
+    public static var configuration = CommandConfiguration(
+        commandName: "disable",
+        abstract: "Disable a capability for a bundle ID."
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The reverse-DNS bundle ID identifier to delete. Must be unique. (eg. com.example.app)")
+    var bundleId: String
+
+    @Argument(help: "Bundle Id capability type. \n \(CapabilityType.allCases)")
+    var capabilityType: CapabilityType
+
+    func run() throws {
+        let service = try makeService()
+
+        try service.disableBundleIdCapability(bundleId: bundleId, capabilityType: capabilityType)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/Capability/DisableBundleIdCapabilityCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Capability/DisableBundleIdCapabilityCommand.swift
@@ -16,7 +16,7 @@ struct DisableBundleIdCapabilityCommand: CommonParsableCommand {
     @Argument(help: "The reverse-DNS bundle ID identifier to delete. Must be unique. (eg. com.example.app)")
     var bundleId: String
 
-    @Argument(help: "Bundle Id capability type. \n \(CapabilityType.allCases)")
+    @Argument(help: ArgumentHelp("Bundle Id capability type.", discussion: "One of \(CapabilityType.allCases)"))
     var capabilityType: CapabilityType
 
     func run() throws {

--- a/Sources/AppStoreConnectCLI/Commands/Capability/EnableBundleIdCapability.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Capability/EnableBundleIdCapability.swift
@@ -16,7 +16,7 @@ struct EnableBundleIdCapabilityCommand: CommonParsableCommand {
     @Argument(help: "The reverse-DNS bundle ID identifier to delete. Must be unique. (eg. com.example.app)")
     var bundleId: String
 
-    @Argument(help: "Bundle Id capability type. \n \(CapabilityType.allCases)")
+    @Argument(help: ArgumentHelp("Bundle Id capability type.", discussion: "One of \(CapabilityType.allCases)"))
     var capabilityType: CapabilityType
 
     // TODO: CapabilitySetting

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -740,6 +740,28 @@ class AppStoreConnectService {
             .await()
     }
 
+    func disableBundleIdCapability(bundleId: String, capabilityType: CapabilityType) throws {
+        let bundleIdResourceId = try ReadBundleIdOperation(
+                options: .init(bundleId: bundleId)
+            )
+            .execute(with: requestor)
+            .await()
+            .id
+
+        let capability = try ListCapabilitiesOperation(
+                options: .init(bundleIdResourceId: bundleIdResourceId)
+            )
+            .execute(with: requestor)
+            .await()
+            .first { $0.attributes?.capabilityType == capabilityType }
+
+        guard let id = capability?.id else { return }
+
+        try DisableCapabilityOperation(options: .init(capabilityId: id))
+            .execute(with: requestor)
+            .await()
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/Operations/DisableCapabilityOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/DisableCapabilityOperation.swift
@@ -1,0 +1,26 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+
+struct DisableCapabilityOperation: APIOperation {
+
+    struct Options {
+        let capabilityId: String
+    }
+
+    let option: Options
+
+    init(options: Options) {
+        self.option = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Void, Error> {
+        requestor
+            .request(
+                .disableCapability(id: option.capabilityId)
+            )
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCapabilitiesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCapabilitiesOperation.swift
@@ -1,0 +1,27 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+
+struct ListCapabilitiesOperation: APIOperation {
+
+    struct Options {
+        let bundleIdResourceId: String
+    }
+
+    let option: Options
+
+    init(options: Options) {
+        self.option = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<[BundleIdCapability], Error> {
+        requestor
+            .request(
+                .listAllCapabilitiesForBundleId(id: option.bundleIdResourceId)
+            )
+            .map(\.data)
+            .eraseToAnyPublisher()
+    }
+
+}


### PR DESCRIPTION
Closes #94 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create List and Disable BundleId Capability Operation
- Implement Disable Bundle Id Capability Command 

# 🧐🗒 Reviewer Notes

## 💁 Example

#### Usage
`asc capability disable <bundle-id> <capability-type>`

## 🔨 How To Test

`asc capability disable com.exmaple.foo push_notifications`
