### PR TITLE
Implement DownloadSalesAndTrendsReportsCommand

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
         "state": {
           "branch": "master",
-          "revision": "e3a5e2b820f88b8e4236257fcae03c890b6362eb",
+          "revision": "65d95d0979734597e7fb7d2d30028c659594ac53",
           "version": null
         }
       },

--- a/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
@@ -1,0 +1,57 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
+
+    typealias Filter = DownloadSalesAndTrendsReports.Filter
+
+    static var configuration = CommandConfiguration(
+        commandName: "sales",
+        abstract: "Create a new certificate using a certificate signing request.")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "Frequency of the report to download. (\(Filter.Frequency.allCases.description))")
+    var frequency: Filter.Frequency
+
+    @Argument(help: "The report date to download. The date is specified in the YYYY-MM-DD format for all report frequencies except DAILY, which does not require a specified date.")
+    var reportDate: String
+
+    @Argument(help: "The report to download.  (\(Filter.ReportType.allCases.description))")
+    var reportType: Filter.ReportType
+
+    @Argument(help: "The report sub type to download.  (\(Filter.ReportSubType.allCases.description))")
+    var reportSubType: Filter.ReportSubType
+
+    @Argument(help: "Your vendor number.")
+    var vendorNumber: String
+
+    @Argument(help: "TODO. outputFilename")
+    var outputFilename: String
+
+    @Option(help: "The version of the report.")
+    var version: [String]
+
+    func validate() throws {
+        if vendorNumber.isEmpty {
+            throw ValidationError("Your vendor number is required when downloading sales and trends report.")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        let result = try service.downloadSales(
+            frequency: [frequency],
+            reportType: [reportType],
+            reportSubType: [reportSubType],
+            vendorNumber: [vendorNumber],
+            reportDate: [reportDate],
+            version: version
+        )
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
@@ -6,32 +6,31 @@ import FileSystem
 
 struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
 
-    // swiftlint:disable identifier_name
     enum ReportFilter: String, ExpressibleByArgument, CaseIterable, CustomStringConvertible {
 
         // SALES
-        case sales_daily_summary
-        case sales_weekly_summary
-        case sales_monthly_summary
-        case sales_yearly_summary
-        case sales_weekly_opt_in
+        case salesDailySummary = "sales_daily_summary"
+        case salesWeeklySummary = "sales_weekly_summary"
+        case salesMonthlySummary = "sales_monthly_summary"
+        case salesYearlySummary = "sales_yearly_summary"
+        case salesWeeklyOptIn = "sales_weekly_opt_in"
 
         // SUBSCRIPTION
-        case subscription_daily_summary
-        case subscription_event_daily_summary
+        case subscriptionDailySummary = "subscription_daily_summary"
+        case subscriptionEventDailySummary = "subscription_event_daily_summary"
 
         // SUBSCRIBER
-        case subscriber_daily_detailed
+        case subscriberDailyDetailed = "subscriber_daily_detailed"
 
         // NEWSSTAND
-        case newsstand_daily_detailed
-        case newsstand_weekly_detailed
+        case newsstandDailyDetailed = "newsstand_daily_detailed"
+        case newsstandWeeklyDetailed = "newsstand_weekly_detailed"
 
         // PRE_ORDER
-        case pre_order_daily_summary
-        case pre_order_weekly_summary
-        case pre_order_monthly_summary
-        case pre_order_yearly_summary
+        case preOrderDailySummary = "pre_order_daily_summary"
+        case preOrderWeeklySummary = "pre_order_weekly_summary"
+        case preOrderMonthlySummary = "pre_order_monthly_summary"
+        case preOrderYearlySummary = "pre_order_yearly_summary"
 
         var description: String {
             rawValue
@@ -46,6 +45,7 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
             let version: Version
         }
 
+        // swiftlint:disable identifier_name
         enum Version: String {
             case _1_0 = "1_0"
             case _1_2 = "1_2"
@@ -53,33 +53,33 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
 
         var params: RequestParams {
             switch self {
-            case .sales_daily_summary:
+            case .salesDailySummary:
                 return .init(type: .SALES, subType: .SUMMARY, frequency: .DAILY, version: ._1_0)
-            case .sales_weekly_summary:
+            case .salesWeeklySummary:
                 return .init(type: .SALES, subType: .SUMMARY, frequency: .WEEKLY, version: ._1_0)
-            case .sales_monthly_summary:
+            case .salesMonthlySummary:
                 return .init(type: .SALES, subType: .SUMMARY, frequency: .MONTHLY, version: ._1_0)
-            case .sales_yearly_summary:
+            case .salesYearlySummary:
                 return .init(type: .SALES, subType: .SUMMARY, frequency: .YEARLY, version: ._1_0)
-            case .sales_weekly_opt_in:
+            case .salesWeeklyOptIn:
                 return .init(type: .SALES, subType: .OPT_IN, frequency: .WEEKLY, version: ._1_0)
-            case .subscription_daily_summary:
+            case .subscriptionDailySummary:
                 return .init(type: .SUBSCRIPTION, subType: .SUMMARY, frequency: .DAILY, version: ._1_2)
-            case .subscription_event_daily_summary:
+            case .subscriptionEventDailySummary:
                 return .init(type: .SUBSCRIPTION_EVENT, subType: .SUMMARY, frequency: .DAILY, version: ._1_2)
-            case .subscriber_daily_detailed:
+            case .subscriberDailyDetailed:
                 return .init(type: .SUBSCRIBER, subType: .DETAILED, frequency: .DAILY, version: ._1_2)
-            case .newsstand_daily_detailed:
+            case .newsstandDailyDetailed:
                 return .init(type: .NEWSSTAND, subType: .DETAILED, frequency: .DAILY, version: ._1_0)
-            case .newsstand_weekly_detailed:
+            case .newsstandWeeklyDetailed:
                 return .init(type: .NEWSSTAND, subType: .DETAILED, frequency: .WEEKLY, version: ._1_0)
-            case .pre_order_daily_summary:
+            case .preOrderDailySummary:
                 return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .DAILY, version: ._1_0)
-            case .pre_order_weekly_summary:
+            case .preOrderWeeklySummary:
                 return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .WEEKLY, version: ._1_0)
-            case .pre_order_monthly_summary:
+            case .preOrderMonthlySummary:
                 return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .MONTHLY, version: ._1_0)
-            case .pre_order_yearly_summary:
+            case .preOrderYearlySummary:
                 return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .YEARLY, version: ._1_0)
             }
         }

--- a/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
@@ -2,7 +2,6 @@
 
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
-import Foundation
 import FileSystem
 
 struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
@@ -11,7 +10,7 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
 
     static var configuration = CommandConfiguration(
         commandName: "sales",
-        abstract: "Create a new certificate using a certificate signing request.")
+        abstract: "Download sales and trends reports filtered by your specified criteria.")
 
     @OptionGroup()
     var common: CommonOptions
@@ -19,8 +18,12 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
     @Argument(help: "Frequency of the report to download. (\(Filter.Frequency.allCases.description))")
     var frequency: Filter.Frequency
 
-    @Argument(help: "The report date to download. The date is specified in the YYYY-MM-DD format for all report frequencies except DAILY, which does not require a specified date.")
-    var reportDate: String
+    @Argument(help:
+        ArgumentHelp(
+            "The report date to download.",
+            discussion: "The date is specified in the YYYY-MM-DD format for all report frequencies except DAILY, which does not require a specified date."
+        )
+    ) var reportDate: String
 
     @Argument(help: "The report to download.  (\(Filter.ReportType.allCases.description))")
     var reportType: Filter.ReportType
@@ -36,12 +39,6 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
 
     @Option(help: "The version of the report.")
     var version: [String]
-
-    func validate() throws {
-        if vendorNumber.isEmpty {
-            throw ValidationError("Your vendor number is required when downloading sales and trends report.")
-        }
-    }
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
@@ -3,6 +3,7 @@
 import AppStoreConnect_Swift_SDK
 import ArgumentParser
 import Foundation
+import FileSystem
 
 struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
 
@@ -30,7 +31,7 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
     @Argument(help: "Your vendor number.")
     var vendorNumber: String
 
-    @Argument(help: "TODO. outputFilename")
+    @Argument(help: "The downloaded report file name.")
     var outputFilename: String
 
     @Option(help: "The version of the report.")
@@ -53,5 +54,7 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
             reportDate: [reportDate],
             version: version
         )
+
+        try ReportProcessor(path: outputFilename).write(result)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
@@ -23,9 +23,10 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
             "The report date to download.",
             discussion: "The date is specified in the YYYY-MM-DD format for all report frequencies except DAILY, which does not require a specified date."
         )
-    ) var reportDate: String
+    )
+    var reportDate: String
 
-    @Argument(help: "The report to download.  (\(Filter.ReportType.allCases.description))")
+    @Argument(help: "The report to download.  (\(Filter.ReportType.allCases))")
     var reportType: Filter.ReportType
 
     @Argument(help: "The report sub type to download.  (\(Filter.ReportSubType.allCases.description))")

--- a/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Reports/DownloadSalesAndTrendsReportsCommand.swift
@@ -6,7 +6,84 @@ import FileSystem
 
 struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
 
-    typealias Filter = DownloadSalesAndTrendsReports.Filter
+    // swiftlint:disable identifier_name
+    enum ReportFilter: String, ExpressibleByArgument, CaseIterable, CustomStringConvertible {
+
+        // SALES
+        case sales_daily_summary
+        case sales_weekly_summary
+        case sales_monthly_summary
+        case sales_yearly_summary
+        case sales_weekly_opt_in
+
+        // SUBSCRIPTION
+        case subscription_daily_summary
+        case subscription_event_daily_summary
+
+        // SUBSCRIBER
+        case subscriber_daily_detailed
+
+        // NEWSSTAND
+        case newsstand_daily_detailed
+        case newsstand_weekly_detailed
+
+        // PRE_ORDER
+        case pre_order_daily_summary
+        case pre_order_weekly_summary
+        case pre_order_monthly_summary
+        case pre_order_yearly_summary
+
+        var description: String {
+            rawValue
+        }
+
+        typealias Filter = DownloadSalesAndTrendsReports.Filter
+
+        struct RequestParams {
+            let type: Filter.ReportType
+            let subType: Filter.ReportSubType
+            let frequency: Filter.Frequency
+            let version: Version
+        }
+
+        enum Version: String {
+            case _1_0 = "1_0"
+            case _1_2 = "1_2"
+        }
+
+        var params: RequestParams {
+            switch self {
+            case .sales_daily_summary:
+                return .init(type: .SALES, subType: .SUMMARY, frequency: .DAILY, version: ._1_0)
+            case .sales_weekly_summary:
+                return .init(type: .SALES, subType: .SUMMARY, frequency: .WEEKLY, version: ._1_0)
+            case .sales_monthly_summary:
+                return .init(type: .SALES, subType: .SUMMARY, frequency: .MONTHLY, version: ._1_0)
+            case .sales_yearly_summary:
+                return .init(type: .SALES, subType: .SUMMARY, frequency: .YEARLY, version: ._1_0)
+            case .sales_weekly_opt_in:
+                return .init(type: .SALES, subType: .OPT_IN, frequency: .WEEKLY, version: ._1_0)
+            case .subscription_daily_summary:
+                return .init(type: .SUBSCRIPTION, subType: .SUMMARY, frequency: .DAILY, version: ._1_2)
+            case .subscription_event_daily_summary:
+                return .init(type: .SUBSCRIPTION_EVENT, subType: .SUMMARY, frequency: .DAILY, version: ._1_2)
+            case .subscriber_daily_detailed:
+                return .init(type: .SUBSCRIBER, subType: .DETAILED, frequency: .DAILY, version: ._1_2)
+            case .newsstand_daily_detailed:
+                return .init(type: .NEWSSTAND, subType: .DETAILED, frequency: .DAILY, version: ._1_0)
+            case .newsstand_weekly_detailed:
+                return .init(type: .NEWSSTAND, subType: .DETAILED, frequency: .WEEKLY, version: ._1_0)
+            case .pre_order_daily_summary:
+                return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .DAILY, version: ._1_0)
+            case .pre_order_weekly_summary:
+                return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .WEEKLY, version: ._1_0)
+            case .pre_order_monthly_summary:
+                return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .MONTHLY, version: ._1_0)
+            case .pre_order_yearly_summary:
+                return .init(type: .PRE_ORDER, subType: .SUMMARY, frequency: .YEARLY, version: ._1_0)
+            }
+        }
+    }
 
     static var configuration = CommandConfiguration(
         commandName: "sales",
@@ -15,8 +92,13 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Argument(help: "Frequency of the report to download. (\(Filter.Frequency.allCases.description))")
-    var frequency: Filter.Frequency
+    @Argument(
+        help: ArgumentHelp(
+            "Sales and trends report filters.",
+            discussion: "Possibable values: \(ReportFilter.allCases)"
+        )
+    )
+    var filter: ReportFilter
 
     @Argument(help:
         ArgumentHelp(
@@ -26,31 +108,24 @@ struct DownloadSalesAndTrendsReportsCommand: CommonParsableCommand {
     )
     var reportDate: String
 
-    @Argument(help: "The report to download.  (\(Filter.ReportType.allCases))")
-    var reportType: Filter.ReportType
-
-    @Argument(help: "The report sub type to download.  (\(Filter.ReportSubType.allCases.description))")
-    var reportSubType: Filter.ReportSubType
-
     @Argument(help: "Your vendor number.")
     var vendorNumber: String
 
     @Argument(help: "The downloaded report file name.")
     var outputFilename: String
 
-    @Option(help: "The version of the report.")
-    var version: [String]
-
     func run() throws {
         let service = try makeService()
 
+        let requestFilters = filter.params
+
         let result = try service.downloadSales(
-            frequency: [frequency],
-            reportType: [reportType],
-            reportSubType: [reportSubType],
+            frequency: [requestFilters.frequency],
+            reportType: [requestFilters.type],
+            reportSubType: [requestFilters.subType],
             vendorNumber: [vendorNumber],
             reportDate: [reportDate],
-            version: version
+            version: [requestFilters.version.rawValue]
         )
 
         try ReportProcessor(path: outputFilename).write(result)

--- a/Sources/AppStoreConnectCLI/Commands/Reports/ReportsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Reports/ReportsCommand.swift
@@ -8,7 +8,7 @@ struct ReportsCommand: ParsableCommand {
         commandName: "reports",
         abstract: "Download your sales and financial reports.",
         subcommands: [
-            /* TODO */
+             DownloadSalesAndTrendsReportsCommand.self,
         ]
     )
 }

--- a/Sources/AppStoreConnectCLI/Model/API/Sales.Filter+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/Sales.Filter+ExpressibleByArgument.swift
@@ -1,0 +1,55 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+private typealias Filter = DownloadSalesAndTrendsReports.Filter
+
+extension Filter.Frequency: ExpressibleByArgument, CustomStringConvertible {
+    private typealias AllCases = [Filter.Frequency]
+
+    public static var allCases: AllCases {
+        [.DAILY, .MONTHLY, .WEEKLY, .YEARLY]
+    }
+
+    public init?(argument: String) {
+        self.init(rawValue: argument.uppercased())
+    }
+
+    public var description: String {
+        rawValue.lowercased()
+    }
+}
+
+extension Filter.ReportType: ExpressibleByArgument, CustomStringConvertible {
+    private typealias AllCases = [Filter.ReportType]
+
+    public static var allCases: AllCases {
+        [.SALES, .PRE_ORDER, .NEWSSTAND, .SUBSCRIPTION, .SUBSCRIPTION_EVENT, .SUBSCRIBER]
+    }
+
+    public init?(argument: String) {
+        self.init(rawValue: argument.uppercased())
+    }
+
+    public var description: String {
+        rawValue.lowercased()
+    }
+}
+
+extension Filter.ReportSubType: ExpressibleByArgument, CustomStringConvertible {
+    private typealias AllCases = [Filter.ReportSubType]
+
+    public static var allCases: AllCases {
+        [.SUMMARY, .DETAILED, .OPT_IN]
+    }
+
+    public init?(argument: String) {
+        self.init(rawValue: argument.uppercased())
+    }
+
+    public var description: String {
+        rawValue.lowercased()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -769,8 +769,8 @@ class AppStoreConnectService {
         vendorNumber: [String],
         reportDate: [String],
         version: [String]
-    ) throws {
-        return try DownloadSalesOperation(options: .init(
+    ) throws -> Data {
+        try DownloadSalesOperation(options: .init(
                 frequency: frequency,
                 reportType: reportType,
                 reportSubType: reportSubType,

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -762,6 +762,26 @@ class AppStoreConnectService {
             .await()
     }
 
+    func downloadSales(
+        frequency: [DownloadSalesAndTrendsReports.Filter.Frequency],
+        reportType: [DownloadSalesAndTrendsReports.Filter.ReportType],
+        reportSubType: [DownloadSalesAndTrendsReports.Filter.ReportSubType],
+        vendorNumber: [String],
+        reportDate: [String],
+        version: [String]
+    ) throws {
+        return try DownloadSalesOperation(options: .init(
+                frequency: frequency,
+                reportType: reportType,
+                reportSubType: reportSubType,
+                vendorNumber: vendorNumber,
+                reportDate: reportDate,
+                version: version)
+            )
+            .execute(with: requestor)
+            .await()
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
@@ -24,10 +24,12 @@ struct DownloadSalesOperation: APIOperation {
     }
 
     func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Data, Error> {
-        var filter: [Filter] = [.frequency(options.frequency),
-                                .reportDate(options.reportDate),
-                                .reportSubType(options.reportSubType),
-                                .vendorNumber(options.vendorNumber)]
+        var filter: [Filter] = [
+            .frequency(options.frequency),
+            .reportDate(options.reportDate),
+            .reportSubType(options.reportSubType),
+            .vendorNumber(options.vendorNumber),
+        ]
 
         !options.reportDate.isEmpty ? filter += [.reportType(options.reportType)] : nil
         !options.version.isEmpty ? filter += [.version(options.version)] : nil

--- a/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
@@ -31,8 +31,8 @@ struct DownloadSalesOperation: APIOperation {
             .vendorNumber(options.vendorNumber),
         ]
 
-        !options.reportDate.isEmpty ? filter += [.reportType(options.reportType)] : nil
-        !options.version.isEmpty ? filter += [.version(options.version)] : nil
+        if options.reportDate.isNotEmpty { filter.append(.reportType(options.reportType)) }
+        if options.version.isNotEmpty { filter.append(.version(options.version)) }
 
         return requestor
             .request(.downloadSalesAndTrendsReports(filter: filter))

--- a/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
@@ -1,0 +1,39 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct DownloadSalesOperation: APIOperation {
+
+    typealias Filter = DownloadSalesAndTrendsReports.Filter
+
+    struct Options {
+       let frequency: [Filter.Frequency]
+       let reportType: [Filter.ReportType]
+       let reportSubType: [Filter.ReportSubType]
+       let vendorNumber: [String]
+       let reportDate: [String]
+       let version: [String]
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Void, Error> {
+        var filter: [Filter] = [.frequency(options.frequency),
+                                .reportDate(options.reportDate),
+                                .reportSubType(options.reportSubType),
+                                .vendorNumber(options.vendorNumber)]
+
+        !options.reportDate.isEmpty ? filter += [.reportType(options.reportType)] : nil
+        !options.version.isEmpty ? filter += [.version(options.version)] : nil
+
+        return requestor
+            .request(.downloadSalesAndTrendsReports(filter: filter))
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/DownloadSalesOperation.swift
@@ -23,7 +23,7 @@ struct DownloadSalesOperation: APIOperation {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Void, Error> {
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Data, Error> {
         var filter: [Filter] = [.frequency(options.frequency),
                                 .reportDate(options.reportDate),
                                 .reportSubType(options.reportSubType),

--- a/Sources/FileSystem/Reports/ReportProcessor.swift
+++ b/Sources/FileSystem/Reports/ReportProcessor.swift
@@ -1,0 +1,26 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+import Files
+
+public struct ReportProcessor {
+
+    public typealias Report = Data
+
+    let path: String
+
+    public init(path: String) {
+        self.path = path
+    }
+
+    @discardableResult
+    public func write(_ report: Report) throws -> File {
+        let standardizedPath = path as NSString
+        return try Folder(path: standardizedPath.deletingLastPathComponent)
+            .createFile(
+                named: "\(standardizedPath.lastPathComponent).txt.gz",
+                contents: report
+            )
+    }
+
+}


### PR DESCRIPTION
Closes #91 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `DownloadSalesAndTrendsReportsCommand`
- Report Filter + `ExpressibleByArgument`
- Add service function `downloadSales`

# ⚠️ Items of Note

The downloaded report suffix is `.gz`

# 🧐🗒 Reviewer Notes

## 💁 Example

```
USAGE: asc reports sales <options>

ARGUMENTS:
  <frequency>             Frequency of the report to download. ([daily, monthly, weekly, yearly]) 
  <report-date>           The report date to download. The date is specified in the YYYY-MM-DD format for all report frequencies except DAILY, which
                          does not require a specified date. 
  <report-type>           The report to download.  ([sales, pre_order, newsstand, subscription, subscription_event, subscriber]) 
  <report-sub-type>       The report sub type to download.  ([summary, detailed, opt_in]) 
  <vendor-number>         Your vendor number. 
  <output-filename>       The downloaded report file name. 
```

## 🔨 How To Test

```
swift run asc reports sales weekly 2020-05-24 sales summary 12345678 ./../report
```