### PR TITLE
Add paging support to ListProfilesCommand

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/appstoreconnect-cli.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/appstoreconnect-cli.xcscheme
@@ -62,6 +62,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FileSystem"
+               BuildableName = "FileSystem"
+               BlueprintName = "FileSystem"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
         "state": {
           "branch": "master",
-          "revision": "e3a5e2b820f88b8e4236257fcae03c890b6362eb",
+          "revision": "65d95d0979734597e7fb7d2d30028c659594ac53",
           "version": null
         }
       },

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
@@ -31,16 +31,19 @@ struct ListProfilesOperation: APIOperation {
 
         let sort = [options.sort].compactMap { $0 }
 
-        let endpoint = APIEndpoint.listProfiles(
-            filter: filters,
-            include: [.bundleId, .certificates, .devices],
-            sort: sort,
-            limit: limits
-        )
-
         return requestor
-            .request(endpoint)
-            .map(\.data)
+            .requestAllPages {
+                .listProfiles(
+                    filter: filters,
+                    include: [.bundleId, .certificates, .devices],
+                    sort: sort,
+                    limit: limits,
+                    next: $0
+                )
+            }
+            .map { $0.flatMap(\.data) }
             .eraseToAnyPublisher()
     }
 }
+
+extension ProfilesResponse: PaginatedResponse { }


### PR DESCRIPTION
Closes #185 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add paging support to `ListBuildsOperation`

# 🧐🗒 Reviewer Notes

## 💁 Example
```
asc profiles list [--limit <limit>] [--sort <sort>] [--filter-name <name> ...] [--filter-profile-state <state>] [--filter-profile-type <type> ...] [--download-path <path>]
```

## 🔨 How To Test

`swift run asc profiles list`
