### PR TITLE
Enable limit in list bundle ids operation

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBundleIdsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBundleIdsOperation.swift
@@ -30,14 +30,18 @@ struct ListBundleIdsOperation: APIOperation {
         if options.platforms.isNotEmpty { filters.append(.platform(platforms)) }
         if options.seedIds.isNotEmpty { filters.append(.seedId(options.seedIds)) }
 
-        let limit = options.limit
+        guard let limit = options.limit else {
+            return requestor.requestAllPages {
+                    .listBundleIds(filter: filters, next: $0)
+                }
+                .map { $0.flatMap(\.data) }
+                .eraseToAnyPublisher()
+        }
 
-        return requestor.requestAllPages {
-                .listBundleIds(filter: filters, limit: limit, next: $0)
-            }
-            .map {
-                $0.flatMap(\.data)
-            }
+        return requestor.request(
+                .listBundleIds(filter: filters, limit: limit)
+            )
+            .map(\.data)
             .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
In the previous PR for addressing paging, `--limit` in `ListBundleIdCommand` was accidentally ignored when requesting, this PR is to add limit back.

# 📝 Summary of Changes

- Reenable `--limit` when list bundle-ids

# 🧐🗒 Reviewer Notes

## 💁 Example

`asc bundle-ids list [--limit <limit>]`

## 🔨 How To Test
`asc bundle-ids list`
