### PR TITLE
Fixed CreateProfileCommand to use "create" instead of "delete"

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
@@ -6,7 +6,7 @@ import Foundation
 
 struct CreateProfileCommand: CommonParsableCommand {
     static var configuration = CommandConfiguration(
-        commandName: "delete",
+        commandName: "create",
         abstract: "Create a new provisioning profile.")
 
     @OptionGroup()


### PR DESCRIPTION

- 🏷 Remember to label your pull request appropriately and select appropriate code reviewers.

When using the profiles command, it contains two delete subcommands. 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Changes the first `delete` subcommand to `create`

# 🧐🗒 Reviewer Notes

## 💁 Example

Theses new changes would be used as follows: `asc profiles create <string> <profile-type> <bundle-id>`

## 🔨 How To Test

The issue can be reproduced with the following command `asc help profiles` which outputs the following for subcommands:

```bash
SUBCOMMANDS:
  list                    Find and list provisioning profiles and download their data.
  delete                  Create a new provisioning profile.
  delete                  Delete a provisioning profile that is used for app development or distribution.
```
