### PR TITLE
Reorder subcommands of TestFlightBetaGroupCommand

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/BetaGroupCommand.swift
@@ -11,13 +11,13 @@ struct TestFlightBetaGroupCommand: ParsableCommand {
         one or more builds.
         """,
         subcommands: [
+            AddTestersToGroupCommand.self,
             CreateBetaGroupCommand.self,
             DeleteBetaGroupCommand.self,
             ListBetaGroupsCommand.self,
             ModifyBetaGroupCommand.self,
             ReadBetaGroupCommand.self,
             RemoveTestersFromGroupCommand.self,
-            AddTestersToGroupCommand.self,
         ],
         defaultSubcommand: ListBetaGroupsCommand.self
     )


### PR DESCRIPTION
Closes #202 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Reorder subcommands of `TestFlightBetaGroupCommand`

# 🧐🗒 Reviewer Notes

## 💁 Example

```
SUBCOMMANDS:
  adduser                 Add testers to beta group
  create                  Create a new beta group
  delete                  Delete a beta group
  list                    List beta groups
  modify                  Modify a beta group, only the specified options are modified
  read                    Read a beta group
  removeuser              Remove beta testers from a beta group
```

## 🔨 How To Test

`asc testflight betagroup -h`
