### PR TITLE
Reorder subcommands of AppStoreConnectCLI Command

### DIFF
--- a/Sources/AppStoreConnectCLI/AppStoreConnectCLI.swift
+++ b/Sources/AppStoreConnectCLI/AppStoreConnectCLI.swift
@@ -9,13 +9,13 @@ public struct AppStoreConnectCLI: ParsableCommand {
         abstract: "A utility for interacting with the AppStore Connect API.",
         subcommands: [
             BundleIdsCommand.self,
+            CapabilityCommand.self,
             CertificatesCommand.self,
             DevicesCommand.self,
             ProfilesCommand.self,
             ReportsCommand.self,
             TestFlightCommand.self,
             UsersCommand.self,
-            CapabilityCommand.self,
         ])
 
     public init() {


### PR DESCRIPTION
Closes #201 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Reorder subcommand of CLI top-level command

# 🧐🗒 Reviewer Notes

## 💁 Example

```
SUBCOMMANDS:
  bundle-ids              Manage the bundle IDs that uniquely identify your apps.
  capability              Manage the app capabilities for a bundle ID.
  certificates            Create, download, and revoke signing certificates for app development and distribution.
  devices                 Register devices for development and testing.
  profiles                Create, delete, and download provisioning profiles that enable app installations for development and
                          distribution.
  reports                 Download your sales and financial reports.
  testflight              Manage your beta testing program, including beta testers and groups, apps, and builds.
  users                   Manage users on your App Store Connect team.

```

## 🔨 How To Test

`asc -h`
