### PR TITLE
Implement create profile command 

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
@@ -24,12 +24,22 @@ struct CreateProfileCommand: CommonParsableCommand {
 
     @Option(
         parsing: .upToNextOption,
-        help: "The resource ids of Certificates."
+        help: "The serial numbers of Certificates. (eg. 1A2B3C4D5E6FD798)"
     )
-    var certificates: [String]
+    var certificatesSerialNumbers: [String]
 
-    @Option(help: "The resource ids of Devices.")
-    var devices: [String]
+    @Option(help: "The UDIDs of Devices.")
+    var devicesUdids: [String]
+
+    func validate() throws {
+        if certificatesSerialNumbers.isEmpty {
+            throw ValidationError("Expected at least one certificate serial number.")
+        }
+
+        if devicesUdids.isEmpty {
+            throw ValidationError("Expected at least one device udid.")
+        }
+    }
 
     func run() throws {
         let service = try makeService()
@@ -38,8 +48,8 @@ struct CreateProfileCommand: CommonParsableCommand {
             name: name,
             bundleId: bundleId,
             profileType: profileType,
-            certificateIds: certificates,
-            deviceIds: devices
+            certificateSerialNumbers: certificatesSerialNumbers,
+            deviceUDIDs: devicesUdids
         )
 
         [profile].render(format: common.outputFormat)

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
@@ -5,6 +5,7 @@ import ArgumentParser
 import Foundation
 
 struct CreateProfileCommand: CommonParsableCommand {
+
     static var configuration = CommandConfiguration(
         commandName: "create",
         abstract: "Create a new provisioning profile.")
@@ -13,21 +14,35 @@ struct CreateProfileCommand: CommonParsableCommand {
     var common: CommonOptions
 
     @Argument(help: "The name of the provisioning profile to create.")
-    var string: String
+    var name: String
 
-    @Argument(help: "The type of profile to create \(ProfileType.allCases)")
+    @Argument(help: "The type of profile to create \(ProfileType.allCases).")
     var profileType: ProfileType
 
     @Argument(help: "The reverse-DNS bundle ID identifier to associate with this profile (must already exist).")
     var bundleId: String
 
-    @Argument(help: "Certificates") // TODO
+    @Option(
+        parsing: .upToNextOption,
+        help: "The resource ids of Certificates."
+    )
     var certificates: [String]
 
-    @Option(help: "Devices") // TODO
+    @Option(help: "The resource ids of Devices.")
     var devices: [String]
 
     func run() throws {
-        fatalError("Not implementedf")
+        let service = try makeService()
+
+        let profile = try service.createProfile(
+            name: name,
+            bundleId: bundleId,
+            profileType: profileType,
+            certificateIds: certificates,
+            deviceIds: devices
+        )
+
+        [profile].render(format: common.outputFormat)
     }
+
 }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
@@ -28,7 +28,10 @@ struct CreateProfileCommand: CommonParsableCommand {
     )
     var certificatesSerialNumbers: [String]
 
-    @Option(help: "The UDIDs of Devices.")
+    @Option(
+        parsing: .upToNextOption,
+        help: "The UDIDs of Devices."
+    )
     var devicesUdids: [String]
 
     func validate() throws {

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
@@ -8,9 +8,9 @@ struct ProfilesCommand: ParsableCommand {
         commandName: "profiles",
         abstract: "Create, delete, and download provisioning profiles that enable app installations for development and distribution.",
         subcommands: [
-            ListProfilesCommand.self,
             CreateProfileCommand.self,
             DeleteProfileCommand.self,
+            ListProfilesCommand.self,
         ],
         defaultSubcommand: ListProfilesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -719,22 +719,19 @@ class AppStoreConnectService {
         .await()
         .id
 
-        let deviceIds = try deviceUDIDs.compactMap {
-            try ListDevicesOperation(
-                options: .init(
-                    filterName: [],
-                    filterPlatform: [],
-                    filterUDID: [$0],
-                    filterStatus: nil,
-                    sort: nil,
-                    limit: nil
-                )
+        let deviceIds = try ListDevicesOperation(
+            options: .init(
+                filterName: [],
+                filterPlatform: [],
+                filterUDID: deviceUDIDs,
+                filterStatus: nil,
+                sort: nil,
+                limit: nil
             )
-            .execute(with: requestor)
-            .await()
-            .first?
-            .id
-        }
+        )
+        .execute(with: requestor)
+        .await()
+        .map { $0.id }
 
         let certificateIds = try certificateSerialNumbers.compactMap {
             try ListCertificatesOperation(

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -704,6 +704,32 @@ class AppStoreConnectService {
             .map(Model.Profile.init)
     }
 
+    func createProfile(
+        name: String,
+        bundleId: String,
+        profileType: ProfileType,
+        certificateIds: [String],
+        deviceIds: [String]
+    ) throws -> Model.Profile {
+        let appId = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
+            .execute(with: requestor)
+            .await()
+            .id
+
+        return try CreateProfileOperation(
+            options: .init(
+                name: name,
+                bundleId: appId,
+                profileType: profileType,
+                certificateIds: certificateIds,
+                deviceIds: deviceIds
+            )
+        )
+        .execute(with: requestor)
+        .map(Model.Profile.init)
+        .await()
+    }
+
     func listUserInvitaions(
         filterEmail: [String],
         filterRole: [UserRole],

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
@@ -1,0 +1,36 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct CreateProfileOperation: APIOperation {
+
+    struct Options {
+        let name: String
+        let bundleId: String
+        let profileType: ProfileType
+        let certificateIds: [String]
+        let deviceIds: [String]
+    }
+
+    private let endpoint: APIEndpoint<ProfileResponse>
+
+    init(options: Options) {
+        endpoint = APIEndpoint.create(
+            profileWithId: options.bundleId,
+            name: options.name,
+            profileType: options.profileType,
+            certificateIds: options.certificateIds,
+            deviceIds: options.deviceIds
+        )
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Profile, Error> {
+        requestor
+            .request(endpoint)
+            .map { $0.data }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListCertificatesOpertaion.swift
@@ -3,7 +3,6 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
-import struct Model.Certificate
 
 struct ListCertificatesOperation: APIOperation {
 
@@ -71,7 +70,7 @@ struct ListCertificatesOperation: APIOperation {
                     throw Error.couldNotFindCertificate
                 }
 
-                return response.data.map(Certificate.init)
+                return response.data
             }
         }
         .eraseToAnyPublisher()


### PR DESCRIPTION
Closes #200 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `CreateProfileOperation` 
- Implement `CreateProfileCommand`

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage
```
asc profiles create <name> <profile-type> <bundle-id> [--certificates <certificates> ...] [--devices <devices> ...]
```

## 🔨 How To Test

```
asc profiles create fooname ios_app_development com.example.foo 1234abcd 1234abcd
```
