### PR TITLE
Update SDK to use the newest version, for fixing paging bug

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
         "state": {
           "branch": "master",
-          "revision": "65d95d0979734597e7fb7d2d30028c659594ac53",
+          "revision": "b00cde9b192c501014a5822af37d54857ede2611",
           "version": null
         }
       },


### PR DESCRIPTION
As SDK gets updated this PR is to make the CLI tool point to the newest SDK version
Hopefully, this will closes #193 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Update SDK to the newest version 

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

Before updates:
`swift run asc devices`
if you have 20+ devices this command will be running forever

after updates 
`swift run asc devices`
can get the result
