### PR TITLE
Fix list profile command paging bug

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
@@ -94,7 +94,7 @@ struct ListBetaTestersOperation: APIOperation {
 
     func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<Output, Swift.Error> {
         let filters = self.filters
-        let limits = self.limits
+        let limits = self.limits.nilIfEmpty()
         let sorts = self.sorts
         let includes: [ListBetaTesters.Include] = [.apps, .betaGroups]
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
@@ -27,7 +27,7 @@ struct ListProfilesOperation: APIOperation {
         if options.filterProfileType.isNotEmpty { filters.append(.profileType(options.filterProfileType)) }
         if let filterProfileState = options.filterProfileState { filters.append(.profileState([filterProfileState])) }
 
-        let limits: [Profiles.Limit] = options.limit != nil ? [.profiles(options.limit!)] : []
+        let limits: [Profiles.Limit]? = options.limit != nil ? [.profiles(options.limit!)] : nil
 
         let sort = [options.sort].compactMap { $0 }
 


### PR DESCRIPTION
Closes #209 
The add params logic in SDK like this 
```
if let limit = limit
```
so it will add [] to params when limit == [], then the limit from links will not be respected,
 this PR is to change `limit: nil` when limit array is empty.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Resolves issue #209 by change limit [] to nil

# 🧐🗒 Reviewer Notes

## 💁 Example

```
swift run asc profiles list   
```

## 🔨 How To Test

```
swift run asc profiles list   
```
