### PR TITLE
Remove validation in CreateProfileCommand

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
@@ -34,6 +34,12 @@ struct CreateProfileCommand: CommonParsableCommand {
     )
     var devicesUdids: [String]
 
+    func validate() throws {
+        if certificatesSerialNumbers.isEmpty {
+            throw ValidationError("Expected at least one certificate serial number.")
+        }
+    }
+
     func run() throws {
         let service = try makeService()
 

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
@@ -34,16 +34,6 @@ struct CreateProfileCommand: CommonParsableCommand {
     )
     var devicesUdids: [String]
 
-    func validate() throws {
-        if certificatesSerialNumbers.isEmpty {
-            throw ValidationError("Expected at least one certificate serial number.")
-        }
-
-        if devicesUdids.isEmpty {
-            throw ValidationError("Expected at least one device udid.")
-        }
-    }
-
     func run() throws {
         let service = try makeService()
 


### PR DESCRIPTION
Closes #210 
As serverside also provides validation so frontend validation can be removed for correction

# 📝 Summary of Changes

Changes proposed in this pull request:

- Resolves issue #210 by removing validation in create profile command

# 🧐🗒 Reviewer Notes

## 💁 Example

USAGE: 
```
asc profiles create <name> <profile-type> <bundle-id> [--certificates-serial-numbers <certificates-serial-numbers> ...] [--devices-udids <devices-udids> ...]
```

## 🔨 How To Test

```
swift run asc profiles create example-name ios_app_development com.example.foo --certificates-serial-numbers 12345678ABCDE --devices-udids 00001234-0000094A3A7123AB
```
