### PR TITLE
Use AppLookupIdentifier in ListUsersCommand for accepting app | bundleId

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -42,10 +42,15 @@ public struct ListUsersCommand: CommonParsableCommand {
 
     @Option(
         parsing: .upToNextOption,
-        help: ArgumentHelp(stringLiteral: "Filter the results by the app(s) visible to each user.\nUsers with access to all apps will always be included."),
-        transform: { $0.lowercased() }
+        help: ArgumentHelp(discussion:
+            """
+            Filter the results by the app(s) resources ids or bundle ids visible to each user.
+            Users with access to all apps will always be included.
+            """
+        ),
+        transform: AppLookupIdentifier.init
     )
-    var filterVisibleApps: [String]
+    var filterVisibleApps: [AppLookupIdentifier]
 
     @Flag(help: "Include visible apps in results.")
     var includeVisibleApps: Bool


### PR DESCRIPTION
Closes #212 


# 📝 Summary of Changes

Changes proposed in this pull request:

- Resolves issue #212 by using `AppLookupIdentifier` for `filterVisibleApps` in `ListUsersCommand`

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage:
```
asc users list <options>
```

## 🔨 How To Test

```
swift run asc users list --include-visible-apps --filter-visible-apps iba.test2
```

