### PR TITLE
Implement ReadProfileCommand, also add filter profile by ID feature to ListProfilesCommand

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -13,9 +13,6 @@ struct ListProfilesCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Argument(help: "The resource id of the profile.")
-    var id: String?
-
     @Option(help: "Limit the number of profiles to return (maximum 200).")
     var limit: Int?
 
@@ -28,7 +25,11 @@ struct ListProfilesCommand: CommonParsableCommand {
     )
     var sort: Profiles.Sort?
 
-    // TODO?: filter[id]
+    @Option(
+        parsing: .upToNextOption,
+        help: "The resource id of the profile."
+    )
+    var filterId: [String]
 
     @Option(
         parsing: .upToNextOption,
@@ -69,7 +70,7 @@ struct ListProfilesCommand: CommonParsableCommand {
         let service = try makeService()
 
         let profiles = try service.listProfiles(
-            id: id,
+            ids: filterId,
             filterName: filterName,
             filterProfileState: filterProfileState,
             filterProfileType: filterProfileType,

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -13,6 +13,9 @@ struct ListProfilesCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
+    @Argument(help: "The resource id of the profile.")
+    var id: String?
+
     @Option(help: "Limit the number of profiles to return (maximum 200).")
     var limit: Int?
 
@@ -66,6 +69,7 @@ struct ListProfilesCommand: CommonParsableCommand {
         let service = try makeService()
 
         let profiles = try service.listProfiles(
+            id: id,
             filterName: filterName,
             filterProfileState: filterProfileState,
             filterProfileType: filterProfileType,

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
@@ -11,7 +11,7 @@ struct ProfilesCommand: ParsableCommand {
             CreateProfileCommand.self,
             DeleteProfileCommand.self,
             ListProfilesCommand.self,
-            ReadProfileCommand.self
+            ReadProfileCommand.self,
         ],
         defaultSubcommand: ListProfilesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
@@ -11,6 +11,7 @@ struct ProfilesCommand: ParsableCommand {
             CreateProfileCommand.self,
             DeleteProfileCommand.self,
             ListProfilesCommand.self,
+            ReadProfileCommand.self
         ],
         defaultSubcommand: ListProfilesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ReadProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ReadProfileCommand.swift
@@ -1,0 +1,40 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import FileSystem
+
+struct ReadProfileCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "read",
+        abstract: "Find and read a provisioning profile and download it data.")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The resource id of the provisioning profile to read.")
+    var id: String
+
+    @Option(
+        help: ArgumentHelp(
+            "If set, the provisioning profiles will be saved as files to this path.",
+            discussion: "Profiles will be saved to files with names of the pattern '<UUID>.\(ProfileProcessor.profileExtension)'.",
+            valueName: "path"
+        )
+    )
+    var downloadPath: String?
+
+    func run() throws {
+        let service = try makeService()
+
+        let profile = try service.readProfile(id: id)
+
+        if let path = downloadPath {
+            let processor = ProfileProcessor(path: .folder(path: path))
+            let file = try processor.write(profile)
+
+            print("📥 Profile '\(profile.name!)' downloaded to: \(file.path)")
+        }
+
+        [profile].render(format: common.outputFormat)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Model/Profile.swift
+++ b/Sources/AppStoreConnectCLI/Model/Profile.swift
@@ -7,11 +7,10 @@ import SwiftyTextTable
 
 extension Model.Profile {
     init(_ apiProfile: AppStoreConnect_Swift_SDK.Profile) {
-        self.init(apiProfile.attributes!)
-    }
+        let attributes = apiProfile.attributes!
 
-    init(_ attributes: AppStoreConnect_Swift_SDK.Profile.Attributes) {
         self.init(
+            id: apiProfile.id,
             name: attributes.name,
             platform: attributes.platform?.rawValue,
             profileContent: attributes.profileContent,
@@ -31,6 +30,7 @@ extension Model.Profile {
 extension Model.Profile: TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
         return [
+            TextTableColumn(header: "ID"),
             TextTableColumn(header: "UUID"),
             TextTableColumn(header: "Name"),
             TextTableColumn(header: "Platform"),
@@ -43,6 +43,7 @@ extension Model.Profile: TableInfoProvider {
 
     var tableRow: [CustomStringConvertible] {
         return [
+            id ?? "",
             uuid ?? "",
             name ?? "",
             platform ?? "",

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -704,7 +704,7 @@ class AppStoreConnectService {
     }
 
     func listProfiles(
-        id: String?,
+        ids: [String],
         filterName: [String],
         filterProfileState: ProfileState?,
         filterProfileType: [ProfileType],
@@ -713,7 +713,7 @@ class AppStoreConnectService {
     ) throws -> [Model.Profile] {
         try ListProfilesOperation(
             options: .init(
-                id: id,
+                ids: ids,
                 filterName: filterName,
                 filterProfileState: filterProfileState,
                 filterProfileType: filterProfileType,

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -697,6 +697,7 @@ class AppStoreConnectService {
     }
 
     func listProfiles(
+        id: String?,
         filterName: [String],
         filterProfileState: ProfileState?,
         filterProfileType: [ProfileType],
@@ -704,17 +705,18 @@ class AppStoreConnectService {
         limit: Int?
     ) throws -> [Model.Profile] {
         try ListProfilesOperation(
-                options: .init(
-                    filterName: filterName,
-                    filterProfileState: filterProfileState,
-                    filterProfileType: filterProfileType,
-                    sort: sort,
-                    limit: limit
-                )
+            options: .init(
+                id: id,
+                filterName: filterName,
+                filterProfileState: filterProfileState,
+                filterProfileType: filterProfileType,
+                sort: sort,
+                limit: limit
             )
-            .execute(with: requestor)
-            .await()
-            .map(Model.Profile.init)
+        )
+        .execute(with: requestor)
+        .await()
+        .map(Model.Profile.init)
     }
 
     func createProfile(

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -703,6 +703,14 @@ class AppStoreConnectService {
             .map(Device.init)
     }
 
+    func readProfile(id: String) throws -> Model.Profile {
+        Model.Profile(
+            try ReadProfileOperation(options: .init(id: id))
+                .execute(with: requestor)
+                .await()
+        )
+    }
+
     func listProfiles(
         ids: [String],
         filterName: [String],

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
@@ -6,7 +6,7 @@ import Combine
 struct ListProfilesOperation: APIOperation {
 
     struct Options {
-        let id: String?
+        let ids: [String]
         let filterName: [String]
         let filterProfileState: ProfileState?
         let filterProfileType: [ProfileType]
@@ -27,7 +27,7 @@ struct ListProfilesOperation: APIOperation {
         if options.filterName.isNotEmpty { filters.append(.name(options.filterName)) }
         if options.filterProfileType.isNotEmpty { filters.append(.profileType(options.filterProfileType)) }
         if let filterProfileState = options.filterProfileState { filters.append(.profileState([filterProfileState])) }
-        if let id = options.id { filters.append(.id([id])) }
+        if options.ids.isNotEmpty { filters.append(.id(options.ids)) }
 
         let limits: [Profiles.Limit]? = options.limit != nil ? [.profiles(options.limit!)] : nil
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesOperation.swift
@@ -6,6 +6,7 @@ import Combine
 struct ListProfilesOperation: APIOperation {
 
     struct Options {
+        let id: String?
         let filterName: [String]
         let filterProfileState: ProfileState?
         let filterProfileType: [ProfileType]
@@ -26,6 +27,7 @@ struct ListProfilesOperation: APIOperation {
         if options.filterName.isNotEmpty { filters.append(.name(options.filterName)) }
         if options.filterProfileType.isNotEmpty { filters.append(.profileType(options.filterProfileType)) }
         if let filterProfileState = options.filterProfileState { filters.append(.profileState([filterProfileState])) }
+        if let id = options.id { filters.append(.id([id])) }
 
         let limits: [Profiles.Limit]? = options.limit != nil ? [.profiles(options.limit!)] : nil
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadProfileOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadProfileOperation.swift
@@ -1,0 +1,26 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+
+struct ReadProfileOperation: APIOperation {
+
+    struct Options {
+        let id: String
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<Profile, Swift.Error> {
+        requestor.request(
+            .readProfileInformation(id: options.id)
+        )
+        .map(\.data)
+        .eraseToAnyPublisher()
+    }
+
+}

--- a/Sources/Model/Profile.swift
+++ b/Sources/Model/Profile.swift
@@ -3,6 +3,7 @@
 import Foundation
 
 public struct Profile: Codable, Equatable {
+    public let id: String?
     public let name: String?
     public let platform: String?
     public let profileContent: String?
@@ -13,6 +14,7 @@ public struct Profile: Codable, Equatable {
     public let expirationDate: Date?
 
     public init(
+        id: String?,
         name: String?,
         platform: String?,
         profileContent: String?,
@@ -22,6 +24,7 @@ public struct Profile: Codable, Equatable {
         profileType: String?,
         expirationDate: Date?
     ) {
+        self.id = id
         self.name = name
         self.platform = platform
         self.profileContent = profileContent
@@ -30,6 +33,5 @@ public struct Profile: Codable, Equatable {
         self.profileState = profileState
         self.profileType = profileType
         self.expirationDate = expirationDate
-
     }
 }


### PR DESCRIPTION
Closing #211 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add `Id` as attributes to `Profile` 
- Closes #211 by Implement `ReadProfileCommand`
- Add `--filter` option to `ListProfilesCommand`

# ⚠️ Items of Note

This PR will expose the internal Id to user

# 🧐🗒 Reviewer Notes

## 💁 Example
ID will be shown in this command:
```
asc profiles list
+------------+--------------------------------------+---------------------+----------+--------+---------------------+----------------------+----------------------+
| ID         | UUID                                 | Name                | Platform | State  | Type                | Created Date         | Expiration Date      |
+------------+--------------------------------------+---------------------+----------+--------+---------------------+----------------------+----------------------+
```

The id can be accepted as filter in `ListProfilesCommand`:

``` 
swift run asc profiles list --filter-id <filter-id>
```

Also implemented `ReadProfileCommand`
```
asc profiles read <id> [--download-path <path>]
```

## 🔨 How To Test

```
swift run asc profiles list 1N2Z3LUSP8 --download-path ./../
```
```
swift run asc profiles read 1N2Z3LUSP8 --download-path ../../
```
