### PR TITLE
Add a ListProfilesByBundleId command

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
@@ -1,0 +1,49 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+import FileSystem
+
+struct ListProfilesByBundleIdCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "list-by-bundle",
+        abstract: "Find and list provisioning profiles by bundle identifier and download their data.",
+        discussion: "Xcode managed profiles can be fetched with this command. Xcode managed profiles do not show up in the default profiles list.")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The bundle ID of an application. (eg. com.example.app)")
+    var bundleId: String
+
+    @Option(default: 200, help: "Limit the number of profiles to return (maximum 200).")
+    var limit: Int?
+
+    @Option(help:
+        ArgumentHelp(
+            "If set, the provisioning profiles will be saved as files to this path.",
+            discussion: "Profiles will be saved to files with names of the pattern '<UUID>.\(ProfileProcessor.profileExtension)'.",
+            valueName: "path"
+        )
+    )
+    var downloadPath: String?
+
+    func run() throws {
+        let service = try makeService()
+
+        let profiles = try service.listProfilesByBundleId(bundleId, limit: limit)
+
+        if let path = downloadPath {
+            let processor = ProfileProcessor(path: .folder(path: path))
+
+            try profiles.forEach {
+                let file = try processor.write($0)
+
+                print("📥 Profile '\($0.name!)' downloaded to: \(file.path)")
+            }
+        }
+
+        profiles.render(format: common.outputFormat)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ProfilesCommand.swift
@@ -11,6 +11,7 @@ struct ProfilesCommand: ParsableCommand {
             CreateProfileCommand.self,
             DeleteProfileCommand.self,
             ListProfilesCommand.self,
+            ListProfilesByBundleIdCommand.self,
         ],
         defaultSubcommand: ListProfilesCommand.self
     )

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -696,6 +696,22 @@ class AppStoreConnectService {
             .map(Device.init)
     }
 
+    func listProfilesByBundleId(_ bundleId: String, limit: Int?) throws -> [Model.Profile] {
+        let bundleIdResourceId = try ReadBundleIdOperation(
+            options: .init(bundleId: bundleId)
+        )
+            .execute(with: requestor)
+            .await()
+            .id
+
+        return try ListProfilesByBundleIdOperation(
+            options: .init(bundleId: bundleIdResourceId, limit: limit)
+        )
+            .execute(with: requestor)
+            .await()
+            .map(Model.Profile.init)
+    }
+
     func listProfiles(
         filterName: [String],
         filterProfileState: ProfileState?,

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -712,7 +712,7 @@ class AppStoreConnectService {
             .id
 
         return try ListProfilesByBundleIdOperation(
-            options: .init(bundleId: bundleIdResourceId, limit: limit)
+            options: .init(bundleIdResourceId: bundleIdResourceId, limit: limit)
         )
             .execute(with: requestor)
             .await()

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesByBundleIdOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesByBundleIdOperation.swift
@@ -1,0 +1,31 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+
+struct ListProfilesByBundleIdOperation: APIOperation {
+
+    struct Options {
+        let bundleId: String
+        let limit: Int?
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<[Profile], Error> {
+
+        let endpoint: APIEndpoint<ProfilesResponse> = .listAllProfilesForBundleId(
+            id: options.bundleId,
+            limit: options.limit
+        )
+
+        return requestor
+            .request(endpoint)
+            .map(\.data)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesByBundleIdOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListProfilesByBundleIdOperation.swift
@@ -6,7 +6,7 @@ import Combine
 struct ListProfilesByBundleIdOperation: APIOperation {
 
     struct Options {
-        let bundleId: String
+        let bundleIdResourceId: String
         let limit: Int?
     }
 
@@ -19,7 +19,7 @@ struct ListProfilesByBundleIdOperation: APIOperation {
     func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<[Profile], Error> {
 
         let endpoint: APIEndpoint<ProfilesResponse> = .listAllProfilesForBundleId(
-            id: options.bundleId,
+            id: options.bundleIdResourceId,
             limit: options.limit
         )
 


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- List the provisioning profiles for a specific bundle id.
- Xcode managed Team profiles can be fetched with this command.

# 🧐🗒 Reviewer Notes

## 💁 Example

```
swift run asc profiles list-by-bundle com.example.app           
```

## 🔨 How To Test

This command is very similar to the `profiles list` command but has no filtering features and only fetches the profiles for a single app.

However this command can fetch Xcode Managed Profiles.