### PR TITLE
Add includeVisibleApps to GetUserInfoCommand and Operations

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
@@ -15,10 +15,16 @@ struct GetUserInfoCommand: CommonParsableCommand {
     @Argument(help: "The email of the user to find.")
     var email: String
 
+    @Flag(help: "Include visible apps in results.")
+    var includeVisibleApps: Bool
+
     func run() throws {
         let service = try makeService()
 
-        let user = try service.getUserInfo(with: email)
+        let user = try service.getUserInfo(
+            with: email,
+            includeVisibleApps: includeVisibleApps
+        )
 
         user.render(format: common.outputFormat)
     }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -85,8 +85,15 @@ class AppStoreConnectService {
         .await()
     }
 
-    func getUserInfo(with email: String) throws -> Model.User {
-        try GetUserInfoOperation(options: .init(email: email)).execute(with: requestor).await()
+    func getUserInfo(with email: String, includeVisibleApps: Bool) throws -> Model.User {
+        try GetUserInfoOperation(
+            options: .init(
+                email: email,
+                includeVisibleApps: includeVisibleApps
+            )
+        )
+        .execute(with: requestor)
+        .await()
     }
 
     func listCertificates(

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
@@ -20,6 +20,7 @@ struct GetUserInfoOperation: APIOperation {
 
     struct Options {
         let email: String
+        let includeVisibleApps: Bool
     }
 
     let options: Options
@@ -28,7 +29,10 @@ struct GetUserInfoOperation: APIOperation {
 
     init(options: Options) {
         let filters: [ListUsers.Filter] = [.username([options.email])]
-        endpoint = APIEndpoint.users(filter: filters)
+        let include = options.includeVisibleApps ? [ListUsers.Include.visibleApps] : []
+
+        endpoint = APIEndpoint.users(include: include, filter: filters)
+
         self.options = options
     }
 

--- a/Tests/appstoreconnect-cliTests/Operations/GetUserInfoOperationTests.swift
+++ b/Tests/appstoreconnect-cliTests/Operations/GetUserInfoOperationTests.swift
@@ -17,7 +17,7 @@ final class GetUserInfoOperationTests: XCTestCase {
 
     func testCouldNotFindUserError() {
         let email = "bob@bob.com"
-        let options = Options(email: email)
+        let options = Options(email: email, includeVisibleApps: false)
         let operation = GetUserInfoOperation(options: options)
 
         let result = Result {


### PR DESCRIPTION
Closes #218 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add flag `includeVisibleApps` to GetUserInfoCommand

# 🧐🗒 Reviewer Notes

## 💁 Example
Usage:
```
asc users info <email> [--include-visible-apps]
```

## 🔨 How To Test

```
asc users info foo@gmail.com --include-visible-apps
```
