### PR TITLE
Adding a verbose flag for displaying more messages in terminal

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
@@ -55,8 +55,8 @@ struct ListCertificatesCommand: CommonParsableCommand {
 
                 let file = try certificateProcessor.write($0)
 
-                // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
-                if common.verbose || common.outputFormat == .table {
+                // Only print if the `PrintLevel` is set to verbose.
+                if common.printLevel == .verbose {
                     print("📥 Certificate '\($0.name ?? "")' downloaded to: \(file.path)")
                 }
             }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
@@ -55,7 +55,8 @@ struct ListCertificatesCommand: CommonParsableCommand {
 
                 let file = try certificateProcessor.write($0)
 
-                if common.quiet == false {
+                // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
+                if common.verbose || common.outputFormat == .table {
                     print("📥 Certificate '\($0.name ?? "")' downloaded to: \(file.path)")
                 }
             }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
@@ -55,7 +55,9 @@ struct ListCertificatesCommand: CommonParsableCommand {
 
                 let file = try certificateProcessor.write($0)
 
-                print("📥 Certificate '\($0.name ?? "")' downloaded to: \(file.path)")
+                if common.quiet == false {
+                    print("📥 Certificate '\($0.name ?? "")' downloaded to: \(file.path)")
+                }
             }
         }
 

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
@@ -28,8 +28,8 @@ struct ReadCertificateCommand: CommonParsableCommand {
 
             let file = try fileProcessor.write(certificate)
 
-            // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
-            if common.verbose || common.outputFormat == .table {
+            // Only print if the `PrintLevel` is set to verbose.
+            if common.printLevel == .verbose {
                 print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(file.path)")
             }
         }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
@@ -28,7 +28,9 @@ struct ReadCertificateCommand: CommonParsableCommand {
 
             let file = try fileProcessor.write(certificate)
 
-            print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(file.path)")
+            if common.quiet == false {
+                print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(file.path)")
+            }
         }
 
         certificate.render(format: common.outputFormat)

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
@@ -28,7 +28,8 @@ struct ReadCertificateCommand: CommonParsableCommand {
 
             let file = try fileProcessor.write(certificate)
 
-            if common.quiet == false {
+            // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
+            if common.verbose || common.outputFormat == .table {
                 print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(file.path)")
             }
         }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
@@ -25,8 +25,8 @@ struct RevokeCertificatesCommand: CommonParsableCommand {
         let service = try makeService()
         _ = try service.revokeCertificates(serials: serials)
 
-        // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
-        if common.verbose || common.outputFormat == .table {
+        // Only print if the `PrintLevel` is set to verbose.
+        if common.printLevel == .verbose {
             serials.forEach {
                 print("🚮 Certificate `\($0)` revoked.")
             }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
@@ -25,7 +25,8 @@ struct RevokeCertificatesCommand: CommonParsableCommand {
         let service = try makeService()
         _ = try service.revokeCertificates(serials: serials)
 
-        if common.quiet == false {
+        // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
+        if common.verbose || common.outputFormat == .table {
             serials.forEach {
                 print("🚮 Certificate `\($0)` revoked.")
             }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
@@ -25,8 +25,10 @@ struct RevokeCertificatesCommand: CommonParsableCommand {
         let service = try makeService()
         _ = try service.revokeCertificates(serials: serials)
 
-        serials.forEach {
-            print("🚮 Certificate `\($0)` revoked.")
+        if common.quiet == false {
+            serials.forEach {
+                print("🚮 Certificate `\($0)` revoked.")
+            }
         }
     }
 

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -22,4 +22,7 @@ struct CommonOptions: ParsableArguments {
 
     @Flag(default: .table, help: "Display results in specified format.")
     var outputFormat: OutputFormat
+
+    @Flag(name: .shortAndLong, help: "Show less messages in stdout")
+    var quiet: Bool
 }

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -10,7 +10,7 @@ protocol CommonParsableCommand: ParsableCommand {
     func makeService() throws -> AppStoreConnectService
 }
 
-/// A level representing the verbosity of command.
+/// A level representing the verbosity of a command.
 enum PrintLevel {
     // Withholds displaying normal status messages
     case quiet

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -23,6 +23,6 @@ struct CommonOptions: ParsableArguments {
     @Flag(default: .table, help: "Display results in specified format.")
     var outputFormat: OutputFormat
 
-    @Flag(name: .shortAndLong, help: "Show less messages in stdout")
+    @Flag(name: .shortAndLong, help: "Display less messaging in standard output.")
     var quiet: Bool
 }

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -10,6 +10,14 @@ protocol CommonParsableCommand: ParsableCommand {
     func makeService() throws -> AppStoreConnectService
 }
 
+/// A level representing the verbosity of command.
+enum PrintLevel {
+    // Withholds displaying normal status messages
+    case quiet
+    // Displays all status messages
+    case verbose
+}
+
 extension CommonParsableCommand {
     func makeService() throws -> AppStoreConnectService {
         AppStoreConnectService(configuration: try APIConfiguration(common.authOptions))
@@ -23,7 +31,20 @@ struct CommonOptions: ParsableArguments {
     @Flag(default: .table, help: "Display results in specified format.")
     var outputFormat: OutputFormat
 
-    /// Used to print status messages. Defaults to `false`, except for `--table`, so all commands are parsable by default.
+    /// The verbosity of the executed command.
+    var printLevel: PrintLevel {
+        // Commands are parsable by default except for `--table` which is intended to be interactive.
+        switch (verbose, outputFormat == .table) {
+            // if `--verbose` or `--table`is used then return a verbose print level
+            case (true, _), (_, true):
+                return .verbose
+            // if both `--verbose` and `--table` are not used, then return a quiet print level
+            case (false, false):
+                return .quiet
+        }
+    }
+
+    /// Used to define the command's `PrintLevel`. Defaults to `false`.
     @Flag(name: .shortAndLong, help: "Display extra messages as command is running.")
     var verbose: Bool
 }

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -23,6 +23,7 @@ struct CommonOptions: ParsableArguments {
     @Flag(default: .table, help: "Display results in specified format.")
     var outputFormat: OutputFormat
 
-    @Flag(name: .shortAndLong, help: "Display less messaging in standard output.")
-    var quiet: Bool
+    /// Used to print status messages. Defaults to `false`, except for `--table`, so all commands are parsable by default.
+    @Flag(name: .shortAndLong, help: "Display extra messages as command is running.")
+    var verbose: Bool
 }

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -35,12 +35,12 @@ struct CommonOptions: ParsableArguments {
     var printLevel: PrintLevel {
         // Commands are parsable by default except for `--table` which is intended to be interactive.
         switch (verbose, outputFormat == .table) {
-            // if `--verbose` or `--table`is used then return a verbose print level
-            case (true, _), (_, true):
-                return .verbose
-            // if both `--verbose` and `--table` are not used, then return a quiet print level
-            case (false, false):
-                return .quiet
+        // if `--verbose` or `--table`is used then return a verbose print level
+        case (true, _), (_, true):
+            return .verbose
+        // if both `--verbose` and `--table` are not used, then return a quiet print level
+        case (false, false):
+            return .quiet
         }
     }
 

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -79,7 +79,8 @@ struct ListProfilesCommand: CommonParsableCommand {
             try profiles.forEach {
                 let file = try processor.write($0)
 
-                if common.quiet == false {
+                // Command output is parsable by default. Only print if verbosity is enabled or output is a `.table`
+                if common.verbose || common.outputFormat == .table {
                     print("📥 Profile '\($0.name!)' downloaded to: \(file.path)")
                 }
             }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -79,8 +79,8 @@ struct ListProfilesCommand: CommonParsableCommand {
             try profiles.forEach {
                 let file = try processor.write($0)
 
-                // Command output is parsable by default. Only print if verbosity is enabled or output is a `.table`
-                if common.verbose || common.outputFormat == .table {
+                // Only print if the `PrintLevel` is set to verbose.
+                if common.printLevel == .verbose {
                     print("📥 Profile '\($0.name!)' downloaded to: \(file.path)")
                 }
             }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -79,7 +79,9 @@ struct ListProfilesCommand: CommonParsableCommand {
             try profiles.forEach {
                 let file = try processor.write($0)
 
-                print("📥 Profile '\($0.name!)' downloaded to: \(file.path)")
+                if common.quiet == false {
+                    print("📥 Profile '\($0.name!)' downloaded to: \(file.path)")
+                }
             }
         }
 

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -31,7 +31,8 @@ struct SyncUsersCommand: CommonParsableCommand {
     var dryRun: Bool
 
     func run() throws {
-        if dryRun, common.quiet == false {
+        // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
+        if dryRun, common.verbose || common.outputFormat == .table {
             print("## Dry run ##")
         }
 

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -31,8 +31,8 @@ struct SyncUsersCommand: CommonParsableCommand {
     var dryRun: Bool
 
     func run() throws {
-        // Command output is parsable by default. Only print if user is enabling verbosity or output is a `.table`
-        if dryRun, common.verbose || common.outputFormat == .table {
+        // Only print if the `PrintLevel` is set to verbose.
+        if common.printLevel == .verbose {
             print("## Dry run ##")
         }
 

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -31,7 +31,7 @@ struct SyncUsersCommand: CommonParsableCommand {
     var dryRun: Bool
 
     func run() throws {
-        if dryRun {
+        if dryRun, common.quiet == false {
             print("## Dry run ##")
         }
 

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -55,7 +55,9 @@ protocol ResultRenderable: Codable {
 extension ResultRenderable {
     func renderAsJSON() -> String {
         let jsonEncoder = JSONEncoder()
-        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        // Withholding `.prettyPrinted` to maintain output that is parsable by default.
+        // Consider adding the option `--pretty` if needed https://github.com/ittybittyapps/appstoreconnect-cli/issues/221
+        jsonEncoder.outputFormatting = [.sortedKeys]
         let json = try! jsonEncoder.encode(self) // swiftlint:disable:this force_try
         return String(data: json, encoding: .utf8)!
     }


### PR DESCRIPTION
# 🤔 Objective and Motivation

The objective of these changes are to purpose adding an optional flag `-v/--verbose` to display more output in terminal. My motivation for this flag is to remove overhead when using `asc` with ansible. I'm using the following command in my ansible playbook:

```shell
asc profiles list --json --filter-name "App Store {{ app_name }}" --download-path .
```
...and I get the following output:
```
"stdout": "📥 Profile 'App Store Test001010002' downloaded to: ./aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.mobileprovision\n[{\"createdDate\":619333688,\"expirationDate\":620178602,\"name\":\"App Store Test001010002\",\"platform\":\"IOS\",\"profileContent\":\"MdMIIdqAAYJKoZIhvcNAQQcCoIIdmTCCHZCUCAQExCzACJB........
```

The `"stdout"` is now malformed json and requires additional parsing to work correctly by filtering out the `"📥 Profile 'App Store Test001010002' downloaded to: ./aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.mobileprovision\n"`. With the `--verbose` flag added, the command now looks like this:
```shell
asc profiles list --verbose --json --filter-name "App Store {{ app_name }}" --download-path .
```
...and I get the following output:
```
"stdout": "📥 Profile 'App Store Test001010002' downloaded to: ./aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.mobileprovision\n[{\"createdDate\":619333688,\"expirationDate\":620178602,\"name\":\"App Store Test001010002\",\"platform\":\"IOS\",\"profileContent\":\"MdMIIdqAAYJKoZIhvcNAQQcCoIIdmTCCHZCUCAQExCzACJB........
```

...and the default command and output looks like this: 

```shell
asc profiles list --json --filter-name "App Store {{ app_name }}" --download-path .
```
...and the json returned to stdout is no longer malformed so now I get the following output:
```
"stdout": "[{\"createdDate\":619333688,\"expirationDate\":620178602,\"name\":\"App Store Test001010002\",\"platform\":\"IOS\",\"profileContent\":\"MdMIIdqAAYJKoZIhvcNAQQcCoIIdmTCCHZCUCAQExCzACJB........
```
# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds the optional flag `-v/--verbose` to display more in terminal.
- Changed output of all commands to be parsable by default
- Removed `.prettyPrinted` and created https://github.com/ittybittyapps/appstoreconnect-cli/issues/221

# ⚠️ Items of Note

_Document anything here that you think the reviewer(s) of this PR may need to know, or would be of specific interest._

The `--verbose` only changes the output of a `CommonParsableCommand` that has not been commented with a `TODO`.

# 🧐🗒 Reviewer Notes

## 💁 Example

```
swift run asc profiles list --verbose --json --filter-name "Cool App" --download-path ~/Documents/Cool\ App
```

## 🔨 How To Test

Run these command and notice the messaging in terminal:

```
swift run asc profiles list --json --filter-name "Cool App" --download-path ~/Documents/Cool\ App
swift run asc users sync ~/Documents/fake.json --dry-run
swift run asc certificates list
swift run asc certificates read "M109UYTGSF007" --certificate-output distribution.cer
swift run asc certificates revoke "M109UYTGSF007"
```

Run the same commands with `-v/--verbose` added and notice more messaging in terminal:

```
swift run asc profiles list --verbose --json --filter-name "Cool App" --download-path ~/Documents/Cool\ App
swift run asc users sync -v ~/Documents/fake.json --dry-run
swift run asc certificates list -v
swift run asc certificates read --verbose "M109UYTGSF007" --certificate-output distribution.cer
swift run asc certificates revoke --verbose "M109UYTGSF007"
```
