### PR TITLE
Add sync pull command entry point

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/CommandError.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommandError.swift
@@ -1,0 +1,14 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+enum CommandError: LocalizedError {
+    case unimplemented
+
+    var errorDescription: String? {
+        switch self {
+        case .unimplemented:
+            return "This command has not been implemented"
+        }
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -8,18 +8,20 @@ struct TestFlightPullCommand: CommonParsableCommand {
 
     static var configuration = CommandConfiguration(
         commandName: "pull",
-        abstract: "Pull down existing TestFlight configuration, refreshing local configuration files."
+        abstract: "Pull TestFlight configuration, overwriting local configuration files."
     )
 
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(parsing: .upToNextOption, help: "Filter the app configurations by the specified bundle IDs")
-    var filterBundleIds: [String]
+    @Option(
+        parsing: .upToNextOption,
+        help: "Filter by only including apps with the specified bundleIds in the configuration"
+    ) var filterBundleIds: [String]
 
     @Option(
         default: "./config/apps",
-        help: "Path to the folder containing the TestFlight configuration."
+        help: "Path to output/write the TestFlight configuration."
     ) var outputPath: String
 
     func run() throws {

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -25,7 +25,7 @@ struct TestFlightPullCommand: CommonParsableCommand {
     ) var outputPath: String
 
     func run() throws {
-        fatalError("Unimplemented command")
+        throw CommandError.unimplemented
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -1,0 +1,29 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import Foundation
+import FileSystem
+
+struct TestFlightPullCommand: CommonParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        commandName: "pull",
+        abstract: "Pull down existing TestFlight configuration, refreshing local configuration files."
+    )
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Option(parsing: .upToNextOption, help: "Filter the app configurations by the specified bundle IDs")
+    var filterBundleIds: [String]
+
+    @Option(
+        default: "./config/apps",
+        help: "Path to the folder containing the TestFlight configuration."
+    ) var outputPath: String
+
+    func run() throws {
+        fatalError("Unimplemented command")
+    }
+
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightSyncCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightSyncCommand.swift
@@ -5,7 +5,7 @@ import ArgumentParser
 struct TestFlightSyncCommand: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "sync",
-        abstract: "Synchronize with Testflight via configuration files.",
+        abstract: "Synchronize with TestFlight using configuration files.",
         subcommands: [
             TestFlightPullCommand.self,
         ]

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightSyncCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightSyncCommand.swift
@@ -1,0 +1,13 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+
+struct TestFlightSyncCommand: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "sync",
+        abstract: "Synchronize with Testflight via configuration files.",
+        subcommands: [
+            TestFlightPullCommand.self,
+        ]
+    )
+}

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/TestFlightCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/TestFlightCommand.swift
@@ -13,6 +13,7 @@ public struct TestFlightCommand: ParsableCommand {
             TestFlightBetaTestersCommand.self,
             TestFlightBuildsCommand.self,
             TestFlightPreReleaseVersionCommand.self,
+            TestFlightSyncCommand.self,
         ])
 
     public init() {


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds `TestFlightSyncCommand`
- Adds `TestFlightPullCommand`
- Adds options to `TestFlightPullCommand`

# ⚠️ Items of Note

Causes `fatalError` when attempting to run pull when it is unimplemented

Unsure if we want to merge unimplemented commands or if this should be a draft

# 🧐🗒 Reviewer Notes

## 💁 Example


### Unimplemented Usage
```
$ swift run asc testflight sync pull

Fatal error: Unimplemented command: file /Users/adam/Developer/appstoreconnect-cli/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift, line 26
```

### Generated Help
```
$ swift run asc testflight sync pull --help

OVERVIEW: Pull down existing TestFlight configuration, refreshing local configuration files.

USAGE: asc testflight sync pull [--api-issuer <uuid>] [--api-key-id <keyid>] [--csv] [--json] [--table] [--yaml] [--verbose] [--filter-bundle-ids <filter-bundle-ids> ...] [--output-path <output-path>]

OPTIONS:
  --api-issuer <uuid>     An AppStore Connect API Key issuer ID. (default: @env:APPSTORE_CONNECT_ISSUER_ID)
        The value for this option can be obtained from the AppStore Connect portal and takes the form of a
        UUID.

        If not specified on the command line this value will be read from the environment variable
        APPSTORE_CONNECT_ISSUER_ID.
  --api-key-id <keyid>    An AppStoreConnect API Key ID. (default: @env:APPSTORE_CONNECT_API_KEY_ID)
        The value for this option can be obtained from the AppStore Connect portal and takes the form of
        an 10 character alpha-numeric identifier, eg. 7MM5YSX5LS

        If not specified on the command line the value of this option will be read from the environment
        variable APPSTORE_CONNECT_API_KEY_ID.

        The environment will be searched for key with the name of APPSTORE_CONNECT_API_KEY. The contents
        of this environment key are expected to be a PKCS 8 (.p8) formatted private key associated with
        this Key ID.

        If the APPSTORE_CONNECT_API_KEY environment variable is empty, in the incorrect format, or not
        found then the following directories will be searched in sequence for a private key file with the
        name of 'AuthKey_<keyid>.p8': ./private_keys, ~/private_keys, ~/.private_keys and
        ~/.appstoreconnect/private_keys.
  --csv/--json/--table/--yaml
                          Display results in specified format. (default: table)
  -v, --verbose           Display extra messages as command is running.
  --filter-bundle-ids <filter-bundle-ids>
                          Filter the app configurations by the specified bundle IDs
  --output-path <output-path>
                          Path to the folder containing the TestFlight configuration. (default:
                          ./config/apps)
  -h, --help              Show help information.
```

## 🔨 How To Test

As the command is unimplemented there is not much to test yet.
