### PR TITLE
Pull testflight models and pass them to the configuration processor

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -3,6 +3,7 @@
 import ArgumentParser
 import Foundation
 import FileSystem
+import Model
 
 struct TestFlightPullCommand: CommonParsableCommand {
 
@@ -25,7 +26,13 @@ struct TestFlightPullCommand: CommonParsableCommand {
     ) var outputPath: String
 
     func run() throws {
-        throw CommandError.unimplemented
+        let service = try makeService()
+
+        // TODO: A new service function should be created to efficiently gather these models
+        let apps = try service.listApps(bundleIds: filterBundleIds)
+        let identifiers = apps.map { app in AppLookupIdentifier.appId(app.id) }
+        let testers = try service.listBetaTesters(filterIdentifiers: identifiers)
+        let groups = try service.listBetaGroups(filterIdentifiers: identifiers)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -36,6 +36,9 @@ struct TestFlightPullCommand: CommonParsableCommand {
 
         let processor = TestflightConfigurationProcessor(path: .folder(path: outputPath))
         processor.writeConfiguration(apps: apps, testers: testers, groups: groups)
+
+        // TODO: Remove when the pull is completed
+        throw CommandError.unimplemented
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -33,6 +33,9 @@ struct TestFlightPullCommand: CommonParsableCommand {
         let identifiers = apps.map { app in AppLookupIdentifier.appId(app.id) }
         let testers = try service.listBetaTesters(filterIdentifiers: identifiers)
         let groups = try service.listBetaGroups(filterIdentifiers: identifiers)
+
+        let processor = TestflightConfigurationProcessor(path: .folder(path: outputPath))
+        processor.writeConfiguration(apps: apps, testers: testers, groups: groups)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -46,6 +46,7 @@ extension BetaGroup {
         _ apiBetaGroup: AppStoreConnect_Swift_SDK.BetaGroup
     ) {
         self.init(
+            id: apiBetaGroup.id,
             app: App(apiApp),
             groupName: apiBetaGroup.attributes?.name,
             isInternal: apiBetaGroup.attributes?.isInternalGroup,

--- a/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaGroup.swift
@@ -3,11 +3,10 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
-import struct Model.App
-import struct Model.BetaGroup
+import Model
 import SwiftyTextTable
 
-extension BetaGroup: TableInfoProvider, ResultRenderable {
+extension Model.BetaGroup: TableInfoProvider, ResultRenderable {
 
     static func tableColumns() -> [TextTableColumn] {
         [
@@ -26,9 +25,9 @@ extension BetaGroup: TableInfoProvider, ResultRenderable {
 
     var tableRow: [CustomStringConvertible] {
         [
-            app.id,
-            app.bundleId ?? "",
-            app.name ?? "",
+            app?.id ?? "",
+            app?.bundleId ?? "",
+            app?.name ?? "",
             groupName ?? "",
             isInternal ?? "",
             publicLink ?? "",
@@ -40,14 +39,14 @@ extension BetaGroup: TableInfoProvider, ResultRenderable {
     }
 }
 
-extension BetaGroup {
+extension Model.BetaGroup {
     init(
-        _ apiApp: AppStoreConnect_Swift_SDK.App,
+        _ apiApp: AppStoreConnect_Swift_SDK.App?,
         _ apiBetaGroup: AppStoreConnect_Swift_SDK.BetaGroup
     ) {
         self.init(
             id: apiBetaGroup.id,
-            app: App(apiApp),
+            app: apiApp.map(Model.App.init),
             groupName: apiBetaGroup.attributes?.name,
             isInternal: apiBetaGroup.attributes?.isInternalGroup,
             publicLink: apiBetaGroup.attributes?.publicLink,

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -26,7 +26,7 @@ extension Model.BetaTester {
             firstName: betaTester.attributes?.firstName,
             lastName: betaTester.attributes?.lastName,
             inviteType: betaTester.attributes?.inviteType?.rawValue,
-            betaGroups: betaGroups.compactMap(\.attributes?.name),
+            betaGroups: betaGroups.map { Model.BetaGroup(nil, $0) },
             apps: apps.map(Model.App.init)
         )
     }
@@ -51,7 +51,7 @@ extension Model.BetaTester: ResultRenderable, TableInfoProvider {
             firstName ?? "",
             lastName ?? "",
             inviteType ?? "",
-            betaGroups?.joined(separator: ", ") ?? [],
+            betaGroups?.compactMap(\.groupName).joined(separator: ", ") ?? [],
             apps?.compactMap(\.bundleId).joined(separator: ", ") ?? [],
         ]
     }

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -7,32 +7,30 @@ import struct Model.BetaTester
 import SwiftyTextTable
 
 extension BetaTester {
+
     init(_ output: GetBetaTesterOperation.Output) {
-        let attributes = output.betaTester.attributes
-        let relationships = output.betaTester.relationships
+        let betaTester = output.betaTester
+        let appRelationships = (betaTester.relationships?.apps?.data) ?? []
+        let betaGroupRelationships = (betaTester.relationships?.betaGroups?.data) ?? []
 
-        // Find tester related beta groups and apps in included data
-        let betaGroupsNames = relationships?.betaGroups?.data?
-            .compactMap { group -> [AppStoreConnect_Swift_SDK.BetaGroup]? in
-                output.betaGroups?.filter { $0.id == group.id }
-            }
-            .flatMap { $0.compactMap { $0.attributes?.name } }
+        let apps = appRelationships.compactMap { relationship -> App? in
+            output.apps?.first { app in relationship.id == app.id }
+        }
 
-        let appsBundleIds = relationships?.apps?.data?
-            .compactMap { app -> [AppStoreConnect_Swift_SDK.App]? in
-                output.apps?.filter { app.id == $0.id }
-            }
-            .flatMap { $0.compactMap { $0.attributes?.bundleId } }
+        let betaGroups = betaGroupRelationships.compactMap { relationship -> BetaGroup? in
+            output.betaGroups?.first { betaGroup in relationship.id == betaGroup.id }
+        }
 
         self.init(
-            email: attributes?.email,
-            firstName: attributes?.firstName,
-            lastName: attributes?.lastName,
-            inviteType: attributes?.inviteType?.rawValue,
-            betaGroups: betaGroupsNames,
-            apps: appsBundleIds
+            email: betaTester.attributes?.email,
+            firstName: betaTester.attributes?.firstName,
+            lastName: betaTester.attributes?.lastName,
+            inviteType: betaTester.attributes?.inviteType?.rawValue,
+            betaGroups: betaGroups.compactMap(\.attributes?.name),
+            apps: apps.compactMap(\.attributes?.bundleId)
         )
     }
+
 }
 
 extension BetaTester: ResultRenderable, TableInfoProvider {

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -3,21 +3,21 @@
 import AppStoreConnect_Swift_SDK
 import Combine
 import Foundation
-import struct Model.BetaTester
+import Model
 import SwiftyTextTable
 
-extension BetaTester {
+extension Model.BetaTester {
 
     init(_ output: GetBetaTesterOperation.Output) {
         let betaTester = output.betaTester
         let appRelationships = (betaTester.relationships?.apps?.data) ?? []
         let betaGroupRelationships = (betaTester.relationships?.betaGroups?.data) ?? []
 
-        let apps = appRelationships.compactMap { relationship -> App? in
+        let apps = appRelationships.compactMap { relationship -> AppStoreConnect_Swift_SDK.App? in
             output.apps?.first { app in relationship.id == app.id }
         }
 
-        let betaGroups = betaGroupRelationships.compactMap { relationship -> BetaGroup? in
+        let betaGroups = betaGroupRelationships.compactMap { relationship -> AppStoreConnect_Swift_SDK.BetaGroup? in
             output.betaGroups?.first { betaGroup in relationship.id == betaGroup.id }
         }
 
@@ -27,13 +27,13 @@ extension BetaTester {
             lastName: betaTester.attributes?.lastName,
             inviteType: betaTester.attributes?.inviteType?.rawValue,
             betaGroups: betaGroups.compactMap(\.attributes?.name),
-            apps: apps.compactMap(\.attributes?.bundleId)
+            apps: apps.map(Model.App.init)
         )
     }
 
 }
 
-extension BetaTester: ResultRenderable, TableInfoProvider {
+extension Model.BetaTester: ResultRenderable, TableInfoProvider {
     static func tableColumns() -> [TextTableColumn] {
        return [
             TextTableColumn(header: "Email"),
@@ -52,7 +52,7 @@ extension BetaTester: ResultRenderable, TableInfoProvider {
             lastName ?? "",
             inviteType ?? "",
             betaGroups?.joined(separator: ", ") ?? [],
-            apps?.joined(separator: ", ") ?? [],
+            apps?.compactMap(\.bundleId).joined(separator: ", ") ?? [],
         ]
     }
 }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -15,10 +15,10 @@ class AppStoreConnectService {
     }
 
     func listApps(
-        bundleIds: [String],
-        names: [String],
-        skus: [String],
-        limit: Int?
+        bundleIds: [String] = [],
+        names: [String] = [],
+        skus: [String] = [],
+        limit: Int? = nil
     ) throws -> [Model.App] {
         let operation = ListAppsOperation(
             options: .init(bundleIds: bundleIds, names: names, skus: skus, limit: limit)
@@ -277,15 +277,15 @@ class AppStoreConnectService {
     }
 
     func listBetaTesters(
-        email: String?,
-        firstName: String?,
-        lastName: String?,
-        inviteType: BetaInviteType?,
-        filterIdentifiers: [AppLookupIdentifier],
-        groupNames: [String],
-        sort: ListBetaTesters.Sort?,
-        limit: Int?,
-        relatedResourcesLimit: Int?
+        email: String? = nil,
+        firstName: String? = nil,
+        lastName: String? = nil,
+        inviteType: BetaInviteType? = nil,
+        filterIdentifiers: [AppLookupIdentifier] = [],
+        groupNames: [String] = [],
+        sort: ListBetaTesters.Sort? = nil,
+        limit: Int? = nil,
+        relatedResourcesLimit: Int? = nil
     ) throws -> [Model.BetaTester] {
 
         var filterAppIds: [String] = []
@@ -474,10 +474,10 @@ class AppStoreConnectService {
     }
 
     func listBetaGroups(
-        filterIdentifiers: [AppLookupIdentifier],
-        names: [String],
-        sort: ListBetaGroups.Sort?,
-        excludeInternal: Bool
+        filterIdentifiers: [AppLookupIdentifier] = [],
+        names: [String] = [],
+        sort: ListBetaGroups.Sort? = nil,
+        excludeInternal: Bool = false
     ) throws -> [Model.BetaGroup] {
         var filterAppIds: [String] = []
         var filterBundleIds: [String] = []

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -333,39 +333,33 @@ class AppStoreConnectService {
         .map(Model.BetaTester.init)
     }
 
-    func listBetaTestersForGroup(identifier: AppLookupIdentifier, groupName: String)
-        throws -> [Model.BetaTester] {
+    func listBetaTestersForGroup(
+        identifier: AppLookupIdentifier,
+        groupName: String
+    ) throws -> [Model.BetaTester] {
+        let readAppOperation = ReadAppOperation(options: .init(identifier: identifier))
+        let app = try readAppOperation.execute(with: requestor).await()
 
-            var appId: String = ""
+        let groupId = try GetBetaGroupOperation(
+            options: .init(appId: app.id, bundleId: nil, betaGroupName: groupName)
+        )
+        .execute(with: requestor)
+        .await()
+        .id
 
-            switch identifier {
-            case .appId(let id):
-                appId = id
-            case .bundleId(let bundleId):
-                let appsOperation = GetAppsOperation(options: .init(bundleIds: [bundleId]))
-                appId = try appsOperation.execute(with: requestor).compactMap(\.first).await().id
-            }
+        let operation = ListBetaTestersByGroupOperation(options: .init(groupId: groupId))
+        let output = try operation.execute(with: requestor).await()
 
-            let groupId = try GetBetaGroupOperation(
-                options: .init(appId: appId, bundleId: nil, betaGroupName: groupName)
+        return output.map { apiBetaTester -> Model.BetaTester in
+            Model.BetaTester(
+                email: apiBetaTester.attributes?.email,
+                firstName: apiBetaTester.attributes?.firstName,
+                lastName: apiBetaTester.attributes?.lastName,
+                inviteType: (apiBetaTester.attributes?.inviteType).map { $0.rawValue },
+                betaGroups: [groupName],
+                apps: [Model.App(app)]
             )
-            .execute(with: requestor)
-            .await()
-            .id
-
-            let operation = ListBetaTestersByGroupOperation(options: .init(groupId: groupId))
-            let output = try operation.execute(with: requestor).await()
-
-            return output.map { (betatester: AppStoreConnect_Swift_SDK.BetaTester) -> Model.BetaTester in
-                Model.BetaTester(
-                    email: betatester.attributes?.email,
-                    firstName: betatester.attributes?.firstName,
-                    lastName: betatester.attributes?.lastName,
-                    inviteType: (betatester.attributes?.inviteType).map { $0.rawValue },
-                    betaGroups: [groupName],
-                    apps: [appId]
-                )
-            }
+        }
     }
 
     func removeTesterFromGroups(email: String, groupNames: [String]) throws {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -340,14 +340,12 @@ class AppStoreConnectService {
         let readAppOperation = ReadAppOperation(options: .init(identifier: identifier))
         let app = try readAppOperation.execute(with: requestor).await()
 
-        let groupId = try GetBetaGroupOperation(
+        let getBetaGroupOperation = GetBetaGroupOperation(
             options: .init(appId: app.id, bundleId: nil, betaGroupName: groupName)
         )
-        .execute(with: requestor)
-        .await()
-        .id
+        let betaGroup = try getBetaGroupOperation.execute(with: requestor).await()
 
-        let operation = ListBetaTestersByGroupOperation(options: .init(groupId: groupId))
+        let operation = ListBetaTestersByGroupOperation(options: .init(groupId: betaGroup.id))
         let output = try operation.execute(with: requestor).await()
 
         return output.map { apiBetaTester -> Model.BetaTester in
@@ -356,7 +354,7 @@ class AppStoreConnectService {
                 firstName: apiBetaTester.attributes?.firstName,
                 lastName: apiBetaTester.attributes?.lastName,
                 inviteType: (apiBetaTester.attributes?.inviteType).map { $0.rawValue },
-                betaGroups: [groupName],
+                betaGroups: [Model.BetaGroup(app, betaGroup)],
                 apps: [Model.App(app)]
             )
         }

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetBetaGroupOperation.swift
@@ -5,6 +5,7 @@ import Combine
 import Foundation
 
 struct GetBetaGroupOperation: APIOperation {
+
     struct Options {
         let appId: String?
         let bundleId: String?
@@ -59,4 +60,5 @@ struct GetBetaGroupOperation: APIOperation {
 
         return betaGroup.eraseToAnyPublisher()
     }
+
 }

--- a/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
+++ b/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
@@ -1,6 +1,7 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 import Foundation
+import Model
 
 public struct TestflightConfigurationProcessor: ResourceWriter {
 
@@ -8,6 +9,14 @@ public struct TestflightConfigurationProcessor: ResourceWriter {
 
     public init(path: ResourcePath) {
         self.path = path
+    }
+
+    public func writeConfiguration(
+        apps: [Model.App],
+        testers: [Model.BetaTester],
+        groups: [Model.BetaGroup]
+    ) {
+        // TODO: Convert models to a TestflightConfiguration and write it to disk
     }
 
 }

--- a/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
+++ b/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
@@ -1,0 +1,13 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+public struct TestflightConfigurationProcessor: ResourceWriter {
+
+    let path: ResourcePath
+
+    public init(path: ResourcePath) {
+        self.path = path
+    }
+
+}

--- a/Sources/FileSystem/Model/BetaGroup.swift
+++ b/Sources/FileSystem/Model/BetaGroup.swift
@@ -2,39 +2,18 @@
 
 import Foundation
 
-public struct BetaGroup: Codable, Equatable {
+struct BetaGroup: Codable, Equatable {
 
-    public typealias EmailAddress = String
+    typealias EmailAddress = String
 
-    public var id: String?
-    public var groupName: String
-    public var isInternal: Bool?
-    public var publicLink: String?
-    public var publicLinkEnabled: Bool?
-    public var publicLinkLimit: Int?
-    public var publicLinkLimitEnabled: Bool?
-    public var creationDate: String?
-    public var testers: [EmailAddress]
+    var id: String?
+    var groupName: String
+    var isInternal: Bool?
+    var publicLink: String?
+    var publicLinkEnabled: Bool?
+    var publicLinkLimit: Int?
+    var publicLinkLimitEnabled: Bool?
+    var creationDate: String?
+    var testers: [EmailAddress]
 
-    public init(
-        id: String?,
-        groupName: String,
-        isInternal: Bool?,
-        publicLink: String?,
-        publicLinkEnabled: Bool?,
-        publicLinkLimit: Int?,
-        publicLinkLimitEnabled: Bool?,
-        creationDate: String?,
-        testers: [String] = []
-    ) {
-        self.id = id
-        self.groupName = groupName
-        self.isInternal = isInternal
-        self.publicLink = publicLink
-        self.publicLinkEnabled = publicLinkEnabled
-        self.publicLinkLimit = publicLinkLimit
-        self.publicLinkLimitEnabled = publicLinkLimitEnabled
-        self.creationDate = creationDate
-        self.testers = testers
-    }
 }

--- a/Sources/FileSystem/Model/BetaTester.swift
+++ b/Sources/FileSystem/Model/BetaTester.swift
@@ -2,12 +2,13 @@
 
 import Foundation
 
-public struct BetaTester: Codable, Hashable {
-    public var email: String
-    public var firstName: String
-    public var lastName: String
+struct BetaTester: Codable, Hashable {
 
-    public init(
+    var email: String
+    var firstName: String
+    var lastName: String
+
+    init(
         email: String,
         firstName: String?,
         lastName: String?
@@ -16,4 +17,5 @@ public struct BetaTester: Codable, Hashable {
         self.firstName = firstName ?? ""
         self.lastName = lastName ?? ""
     }
+
 }

--- a/Sources/FileSystem/Model/TestFlightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestFlightConfiguration.swift
@@ -1,0 +1,3 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation

--- a/Sources/FileSystem/Model/TestFlightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestFlightConfiguration.swift
@@ -1,3 +1,0 @@
-// Copyright 2020 Itty Bitty Apps Pty Ltd
-
-import Foundation

--- a/Sources/FileSystem/Model/TestflightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestflightConfiguration.swift
@@ -8,7 +8,7 @@ struct TestflightConfiguration {
     var appConfigurations: [AppConfiguration]
 
     struct AppConfiguration {
-        var app:  Model.App
+        var app: Model.App
         var testers: [BetaTester]
         var betagroups: [BetaGroup]
     }

--- a/Sources/FileSystem/Model/TestflightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestflightConfiguration.swift
@@ -1,0 +1,15 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+import Model
+
+struct TestflightConfiguration {
+
+    var appConfigurations: [AppConfiguration]
+
+    struct AppConfiguration {
+        var app:  Model.App
+        var testers: [BetaTester]
+        var betagroups: [BetaGroup]
+    }
+}

--- a/Sources/FileSystem/ResourceProcessor.swift
+++ b/Sources/FileSystem/ResourceProcessor.swift
@@ -21,13 +21,7 @@ protocol ResourceReader: PathProvider {
     func read() throws -> [T]
 }
 
-protocol ResourceWriter: PathProvider {
-    associatedtype T: Codable, FileProvider
-
-    func write(_: [T]) throws -> [File]
-
-    func write(_: T) throws -> File
-}
+protocol ResourceWriter: PathProvider { }
 
 protocol PathProvider {
     var path: ResourcePath { get }

--- a/Sources/Model/BetaGroup.swift
+++ b/Sources/Model/BetaGroup.swift
@@ -3,6 +3,8 @@
 import Foundation
 
 public struct BetaGroup: Codable, Equatable {
+
+    public let id: String
     public let app: App
     public let groupName: String?
     public let isInternal: Bool?
@@ -13,6 +15,7 @@ public struct BetaGroup: Codable, Equatable {
     public let creationDate: String?
 
     public init(
+        id: String,
         app: App,
         groupName: String?,
         isInternal: Bool?,
@@ -22,6 +25,7 @@ public struct BetaGroup: Codable, Equatable {
         publicLinkLimitEnabled: Bool?,
         creationDate: String?
     ) {
+        self.id = id
         self.app = app
         self.groupName = groupName
         self.isInternal = isInternal
@@ -31,4 +35,5 @@ public struct BetaGroup: Codable, Equatable {
         self.publicLinkLimitEnabled = publicLinkLimitEnabled
         self.creationDate = creationDate
     }
+
 }

--- a/Sources/Model/BetaGroup.swift
+++ b/Sources/Model/BetaGroup.swift
@@ -5,7 +5,7 @@ import Foundation
 public struct BetaGroup: Codable, Equatable {
 
     public let id: String
-    public let app: App
+    public let app: App?
     public let groupName: String?
     public let isInternal: Bool?
     public let publicLink: String?
@@ -16,7 +16,7 @@ public struct BetaGroup: Codable, Equatable {
 
     public init(
         id: String,
-        app: App,
+        app: App?,
         groupName: String?,
         isInternal: Bool?,
         publicLink: String?,

--- a/Sources/Model/BetaTester.swift
+++ b/Sources/Model/BetaTester.swift
@@ -7,7 +7,7 @@ public struct BetaTester: Codable, Equatable {
     public let firstName: String?
     public let lastName: String?
     public let inviteType: String?
-    public let betaGroups: [String]?
+    public let betaGroups: [BetaGroup]?
     public let apps: [App]?
 
     public init(
@@ -15,7 +15,7 @@ public struct BetaTester: Codable, Equatable {
         firstName: String?,
         lastName: String?,
         inviteType: String?,
-        betaGroups: [String]?,
+        betaGroups: [BetaGroup]?,
         apps: [App]?
     ) {
         self.email = email

--- a/Sources/Model/BetaTester.swift
+++ b/Sources/Model/BetaTester.swift
@@ -8,7 +8,7 @@ public struct BetaTester: Codable, Equatable {
     public let lastName: String?
     public let inviteType: String?
     public let betaGroups: [String]?
-    public let apps: [String]?
+    public let apps: [App]?
 
     public init(
         email: String?,
@@ -16,7 +16,7 @@ public struct BetaTester: Codable, Equatable {
         lastName: String?,
         inviteType: String?,
         betaGroups: [String]?,
-        apps: [String]?
+        apps: [App]?
     ) {
         self.email = email
         self.firstName = firstName


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Add `TestflightConfigurationProcessor`
- Fetch Apps, Testflight testers and groups
- Feeds models into the configuration processor
- Removes protocol requirements from `ResourceWriter`

# ⚠️ Items of Note

- This is an intentionally naive implementation that calls out the room for optimisation in future PRs
- The Command has still not been fully implemented and will still throw an error

# 🧐🗒 Reviewer Notes

## 💁 Example

```
$ asc testflight sync pull

Error: This command has not been implemented
```
