### PR TITLE
Write out testflight config (sync pull)

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -34,8 +34,8 @@ struct TestFlightPullCommand: CommonParsableCommand {
         let testers = try service.listBetaTesters(filterIdentifiers: identifiers)
         let groups = try service.listBetaGroups(filterIdentifiers: identifiers)
 
-        let processor = TestflightConfigurationProcessor(path: .folder(path: outputPath))
-        processor.writeConfiguration(apps: apps, testers: testers, groups: groups)
+        let processor = TestflightConfigurationProcessor(appsFolderPath: outputPath)
+        try processor.writeConfiguration(apps: apps, testers: testers, groups: groups)
 
         // TODO: Remove when the pull is completed
         throw CommandError.unimplemented

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -31,7 +31,7 @@ struct TestFlightPullCommand: CommonParsableCommand {
         // TODO: A new service function should be created to efficiently gather these models
         let apps = try service.listApps(bundleIds: filterBundleIds)
         let identifiers = apps.map { app in AppLookupIdentifier.appId(app.id) }
-        let testers = try service.listBetaTesters(filterIdentifiers: identifiers)
+        let testers = try service.listBetaTesters(filterIdentifiers: identifiers, limit: 200)
         let groups = try service.listBetaGroups(filterIdentifiers: identifiers)
 
         let processor = TestflightConfigurationProcessor(appsFolderPath: outputPath)

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -36,9 +36,6 @@ struct TestFlightPullCommand: CommonParsableCommand {
 
         let processor = TestflightConfigurationProcessor(appsFolderPath: outputPath)
         try processor.writeConfiguration(apps: apps, testers: testers, groups: groups)
-
-        // TODO: Remove when the pull is completed
-        throw CommandError.unimplemented
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Model/BetaTester.swift
+++ b/Sources/AppStoreConnectCLI/Model/BetaTester.swift
@@ -51,8 +51,8 @@ extension Model.BetaTester: ResultRenderable, TableInfoProvider {
             firstName ?? "",
             lastName ?? "",
             inviteType ?? "",
-            betaGroups?.compactMap(\.groupName).joined(separator: ", ") ?? [],
-            apps?.compactMap(\.bundleId).joined(separator: ", ") ?? [],
+            betaGroups.compactMap(\.groupName).joined(separator: ", "),
+            apps.compactMap(\.bundleId).joined(separator: ", "),
         ]
     }
 }

--- a/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
+++ b/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
@@ -11,12 +11,35 @@ public struct TestflightConfigurationProcessor: ResourceWriter {
         self.path = path
     }
 
+    private typealias AppConfiguration = TestflightConfiguration.AppConfiguration
+
     public func writeConfiguration(
         apps: [Model.App],
         testers: [Model.BetaTester],
         groups: [Model.BetaGroup]
     ) {
-        // TODO: Convert models to a TestflightConfiguration and write it to disk
+        var appConfigurations: [AppConfiguration] = []
+
+        let groupsByApp = Dictionary(grouping: groups, by: \.app?.id)
+
+        for app in apps {
+            var appConfiguration = AppConfiguration(app: app)
+
+            appConfiguration.betaTesters = testers
+                .filter { tester in (tester.apps).map(\.id).contains(app.id) }
+                .compactMap(FileSystem.BetaTester.init)
+
+            appConfiguration.betaGroups = (groupsByApp[app.id] ?? []).map { betaGroup in
+                FileSystem.BetaGroup(
+                    betaGroup: betaGroup,
+                    betaTesters: testers.filter { ($0.betaGroups).map(\.id).contains(betaGroup.id) }
+                )
+            }
+
+            appConfigurations += [appConfiguration]
+        }
+
+        let configuration = TestflightConfiguration(appConfigurations: appConfigurations)
     }
 
 }

--- a/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
+++ b/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
@@ -49,6 +49,13 @@ public struct TestflightConfigurationProcessor {
             return headers + rows
         }
 
+        let filenameForBetaGroup: (BetaGroup) -> String = { betaGroup in
+            return betaGroup.groupName
+                .components(separatedBy: CharacterSet(charactersIn: " *?:/\\."))
+                .joined(separator: "_")
+                + ".yml"
+        }
+
         try configurations.forEach { config in
             // TODO: We can require a bundle id in our file system app model
             let appFolder = try appsFolder.createSubfolder(named: config.app.bundleId!)
@@ -64,7 +71,7 @@ public struct TestflightConfigurationProcessor {
 
             let groupFolder = try appFolder.createSubfolder(named: "betagroups")
             let groupFiles: [(fileName: String, yamlData: String)] = try config.betaGroups.map {
-                ("\($0.groupName.filenameSafe()).yml", try YAMLEncoder().encode($0))
+                (filenameForBetaGroup($0), try YAMLEncoder().encode($0))
             }
 
             try groupFiles.forEach { file in
@@ -73,11 +80,4 @@ public struct TestflightConfigurationProcessor {
         }
     }
 
-}
-
-private extension String {
-  func filenameSafe() -> String {
-    let unsafeFilenameCharacters = CharacterSet(charactersIn: " *?:/\\.")
-    return self.components(separatedBy: unsafeFilenameCharacters).joined(separator: "_")
-  }
 }

--- a/Sources/FileSystem/Model/BetaGroup.swift
+++ b/Sources/FileSystem/Model/BetaGroup.swift
@@ -1,6 +1,7 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 import Foundation
+import Model
 
 struct BetaGroup: Codable, Equatable {
 
@@ -8,12 +9,12 @@ struct BetaGroup: Codable, Equatable {
 
     var id: String?
     var groupName: String
-    var isInternal: Bool?
-    var publicLink: String?
-    var publicLinkEnabled: Bool?
-    var publicLinkLimit: Int?
-    var publicLinkLimitEnabled: Bool?
-    var creationDate: String?
     var testers: [EmailAddress]
+
+    init(betaGroup: Model.BetaGroup, betaTesters: [Model.BetaTester]) {
+        id = betaGroup.id
+        groupName = betaGroup.groupName ?? ""
+        testers = betaTesters.compactMap(\.email)
+    }
 
 }

--- a/Sources/FileSystem/Model/BetaTester.swift
+++ b/Sources/FileSystem/Model/BetaTester.swift
@@ -1,6 +1,7 @@
 // Copyright 2020 Itty Bitty Apps Pty Ltd
 
 import Foundation
+import Model
 
 struct BetaTester: Codable, Hashable {
 
@@ -8,14 +9,14 @@ struct BetaTester: Codable, Hashable {
     var firstName: String
     var lastName: String
 
-    init(
-        email: String,
-        firstName: String?,
-        lastName: String?
-    ) {
+    init?(betaTester: Model.BetaTester) {
+        guard let email = betaTester.email else {
+            return nil
+        }
+
         self.email = email
-        self.firstName = firstName ?? ""
-        self.lastName = lastName ?? ""
+        self.firstName = betaTester.firstName ?? ""
+        self.lastName = betaTester.lastName ?? ""
     }
 
 }

--- a/Sources/FileSystem/Model/BetaTester.swift
+++ b/Sources/FileSystem/Model/BetaTester.swift
@@ -9,6 +9,12 @@ struct BetaTester: Codable, Hashable {
     var firstName: String
     var lastName: String
 
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case email = "Email"
+        case firstName = "First Name"
+        case lastName = "Last Name"
+    }
+
     init?(betaTester: Model.BetaTester) {
         guard let email = betaTester.email else {
             return nil

--- a/Sources/FileSystem/Model/TestflightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestflightConfiguration.swift
@@ -9,7 +9,7 @@ struct TestflightConfiguration {
 
     struct AppConfiguration {
         var app: Model.App
-        var testers: [BetaTester]
-        var betagroups: [BetaGroup]
+        var betaTesters: [BetaTester] = []
+        var betaGroups: [BetaGroup] = []
     }
 }

--- a/Sources/FileSystem/Model/TestflightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestflightConfiguration.swift
@@ -5,11 +5,8 @@ import Model
 
 struct TestflightConfiguration {
 
-    var appConfigurations: [AppConfiguration]
+    var app: Model.App
+    var betaTesters: [BetaTester] = []
+    var betaGroups: [BetaGroup] = []
 
-    struct AppConfiguration {
-        var app: Model.App
-        var betaTesters: [BetaTester] = []
-        var betaGroups: [BetaGroup] = []
-    }
 }

--- a/Sources/Model/BetaTester.swift
+++ b/Sources/Model/BetaTester.swift
@@ -3,12 +3,13 @@
 import Foundation
 
 public struct BetaTester: Codable, Equatable {
+
     public let email: String?
     public let firstName: String?
     public let lastName: String?
     public let inviteType: String?
-    public let betaGroups: [BetaGroup]?
-    public let apps: [App]?
+    public let betaGroups: [BetaGroup]
+    public let apps: [App]
 
     public init(
         email: String?,
@@ -22,7 +23,8 @@ public struct BetaTester: Codable, Equatable {
         self.firstName = firstName
         self.lastName = lastName
         self.inviteType = inviteType
-        self.betaGroups = betaGroups
-        self.apps = apps
+        self.betaGroups = betaGroups ?? []
+        self.apps = apps ?? []
     }
+
 }


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Implements `TestflightConfigurationProcessor` `writeConfiguration`
- Makes `BetaTester` arrays non optional
- Completes `testflight sync pull`

# ⚠️ Items of Note

If we use our own FileSystem app model we can get rid of an unnecessary `!` in a subsequent PR and ensure we only write out what we care about

# 🧐🗒 Reviewer Notes

## 💁 Example

`asc testflight sync pull`

`asc testflight sync pull --path "./appConfig"`

`asc testflgith sync pull --filter-bundle-ids com.example.app`

## 🔨 How To Test

Run `testflight sync pull` with various options and ensure that it writes out the expected config
