### PR TITLE
Create FileSystem App model and throw if an app is missing a bundleId

### DIFF
--- a/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
+++ b/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
@@ -22,8 +22,8 @@ public struct TestflightConfigurationProcessor {
         // Generate configuration
         let groupsByApp = Dictionary(grouping: groups, by: \.app?.id)
 
-        let configurations: [TestflightConfiguration] = apps.map { app in
-            var config = TestflightConfiguration(app: app)
+        let configurations: [TestflightConfiguration] = try apps.map { app in
+            var config = try TestflightConfiguration(app: FileSystem.App(model: app))
 
             config.betaTesters = testers
                 .filter { tester in tester.apps.map(\.id).contains(app.id) }
@@ -57,8 +57,7 @@ public struct TestflightConfigurationProcessor {
         }
 
         try configurations.forEach { config in
-            // TODO: We can require a bundle id in our file system app model
-            let appFolder = try appsFolder.createSubfolder(named: config.app.bundleId!)
+            let appFolder = try appsFolder.createSubfolder(named: config.app.bundleId)
 
             let appFile = try appFolder.createFile(named: "app.yml")
             let appYAML = try YAMLEncoder().encode(config.app)

--- a/Sources/FileSystem/Model/App.swift
+++ b/Sources/FileSystem/Model/App.swift
@@ -1,0 +1,26 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+import Model
+
+struct App: Codable {
+
+    var id: String
+    var bundleId: String
+    var name: String?
+    var primaryLocale: String?
+    var sku: String?
+
+    init(model: Model.App) throws {
+        guard let bundleId = model.bundleId else {
+            throw ModelError.missingBundleId(appId: model.id)
+        }
+
+        self.id = model.id
+        self.bundleId = bundleId
+        self.name = model.name
+        self.primaryLocale = model.primaryLocale
+        self.sku = model.sku
+    }
+
+}

--- a/Sources/FileSystem/Model/ModelError.swift
+++ b/Sources/FileSystem/Model/ModelError.swift
@@ -1,0 +1,16 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+
+enum ModelError: LocalizedError {
+
+    case missingBundleId(appId: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingBundleId(let appId):
+            return "App with id: \(appId) is missing bundleId data"
+        }
+    }
+
+}

--- a/Sources/FileSystem/Model/TestflightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestflightConfiguration.swift
@@ -5,7 +5,7 @@ import Model
 
 struct TestflightConfiguration {
 
-    var app: Model.App
+    var app: App
     var betaTesters: [BetaTester] = []
     var betaGroups: [BetaGroup] = []
 


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds FileSystem.App
- Removes a force unwrap
- Adds `ModelError` for when we need to throw errors from `FileSystem` related to malformed model data

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

Sync pull should remain unchanged
