### PR TITLE
Separate out configuration generation and writing

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -34,8 +34,7 @@ struct TestFlightPullCommand: CommonParsableCommand {
         let testers = try service.listBetaTesters(filterIdentifiers: identifiers, limit: 200)
         let groups = try service.listBetaGroups(filterIdentifiers: identifiers)
 
-        let processor = TestflightConfigurationProcessor(appsFolderPath: outputPath)
-        try processor.writeConfiguration(apps: apps, testers: testers, groups: groups)
+        try writeConfiguration(apps: apps, testers: testers, groups: groups, to: outputPath)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -34,7 +34,7 @@ struct TestFlightPullCommand: CommonParsableCommand {
         let testers = try service.listBetaTesters(filterIdentifiers: identifiers, limit: 200)
         let groups = try service.listBetaGroups(filterIdentifiers: identifiers)
 
-        try writeConfiguration(apps: apps, testers: testers, groups: groups, to: outputPath)
+        try FileSystem.writeConfiguration(apps: apps, testers: testers, groups: groups, to: outputPath)
     }
 
 }

--- a/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
+++ b/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
@@ -14,7 +14,7 @@ struct TestflightConfigurationProcessor {
         self.appsFolderPath = appsFolderPath
     }
 
-    func writeConfiguration(configurations: [TestflightConfiguration]) throws {
+    func writeConfiguration(_ configuration: TestflightConfiguration) throws {
         let appsFolder = try Folder(path: appsFolderPath)
         try appsFolder.delete()
 
@@ -31,7 +31,7 @@ struct TestflightConfigurationProcessor {
                 + ".yml"
         }
 
-        try configurations.forEach { config in
+        try configuration.appConfigurations.forEach { config in
             let appFolder = try appsFolder.createSubfolder(named: config.app.bundleId)
 
             let appFile = try appFolder.createFile(named: "app.yml")

--- a/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
+++ b/Sources/FileSystem/Configuration/TestflightConfigurationProcessor.swift
@@ -6,40 +6,15 @@ import Model
 import Files
 import Yams
 
-public struct TestflightConfigurationProcessor {
+struct TestflightConfigurationProcessor {
 
     let appsFolderPath: String
 
-    public init(appsFolderPath: String) {
+    init(appsFolderPath: String) {
         self.appsFolderPath = appsFolderPath
     }
 
-    public func writeConfiguration(
-        apps: [Model.App],
-        testers: [Model.BetaTester],
-        groups: [Model.BetaGroup]
-    ) throws {
-        // Generate configuration
-        let groupsByApp = Dictionary(grouping: groups, by: \.app?.id)
-
-        let configurations: [TestflightConfiguration] = try apps.map { app in
-            var config = try TestflightConfiguration(app: FileSystem.App(model: app))
-
-            config.betaTesters = testers
-                .filter { tester in tester.apps.map(\.id).contains(app.id) }
-                .compactMap(FileSystem.BetaTester.init)
-
-            config.betaGroups = (groupsByApp[app.id] ?? []).map { betaGroup in
-                FileSystem.BetaGroup(
-                    betaGroup: betaGroup,
-                    betaTesters: testers.filter { $0.betaGroups.map(\.id).contains(betaGroup.id) }
-                )
-            }
-
-            return config
-        }
-
-        // Write out the configuration
+    func writeConfiguration(configurations: [TestflightConfiguration]) throws {
         let appsFolder = try Folder(path: appsFolderPath)
         try appsFolder.delete()
 

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -9,25 +9,8 @@ public func writeConfiguration(
     groups: [Model.BetaGroup],
     to appsFolderPath: String
 ) throws {
-    let groupsByApp = Dictionary(grouping: groups, by: \.app?.id)
-
-    let configurations: [AppConfiguration] = try apps.map { app in
-        var config = try AppConfiguration(app: App(model: app))
-
-        config.betaTesters = testers
-            .filter { tester in tester.apps.map(\.id).contains(app.id) }
-            .compactMap(FileSystem.BetaTester.init)
-
-        config.betaGroups = (groupsByApp[app.id] ?? []).map { betaGroup in
-            FileSystem.BetaGroup(
-                betaGroup: betaGroup,
-                betaTesters: testers.filter { $0.betaGroups.map(\.id).contains(betaGroup.id) }
-            )
-        }
-
-        return config
-    }
+    let configuration = try TestflightConfiguration(apps: apps, testers: testers, groups: groups)
 
     let processor = TestflightConfigurationProcessor(appsFolderPath: appsFolderPath)
-    try processor.writeConfiguration(TestflightConfiguration(appConfigurations: configurations))
+    try processor.writeConfiguration(configuration)
 }

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -1,0 +1,33 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import Foundation
+import Model
+
+public func writeConfiguration(
+    apps: [Model.App],
+    testers: [Model.BetaTester],
+    groups: [Model.BetaGroup],
+    to appsFolderPath: String
+) throws {
+    let groupsByApp = Dictionary(grouping: groups, by: \.app?.id)
+
+    let configurations: [TestflightConfiguration] = try apps.map { app in
+        var config = try TestflightConfiguration(app: App(model: app))
+
+        config.betaTesters = testers
+            .filter { tester in tester.apps.map(\.id).contains(app.id) }
+            .compactMap(FileSystem.BetaTester.init)
+
+        config.betaGroups = (groupsByApp[app.id] ?? []).map { betaGroup in
+            FileSystem.BetaGroup(
+                betaGroup: betaGroup,
+                betaTesters: testers.filter { $0.betaGroups.map(\.id).contains(betaGroup.id) }
+            )
+        }
+
+        return config
+    }
+
+    let processor = TestflightConfigurationProcessor(appsFolderPath: appsFolderPath)
+    try processor.writeConfiguration(configurations: configurations)
+}

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -11,8 +11,8 @@ public func writeConfiguration(
 ) throws {
     let groupsByApp = Dictionary(grouping: groups, by: \.app?.id)
 
-    let configurations: [TestflightConfiguration] = try apps.map { app in
-        var config = try TestflightConfiguration(app: App(model: app))
+    let configurations: [AppConfiguration] = try apps.map { app in
+        var config = try AppConfiguration(app: App(model: app))
 
         config.betaTesters = testers
             .filter { tester in tester.apps.map(\.id).contains(app.id) }
@@ -29,5 +29,5 @@ public func writeConfiguration(
     }
 
     let processor = TestflightConfigurationProcessor(appsFolderPath: appsFolderPath)
-    try processor.writeConfiguration(configurations: configurations)
+    try processor.writeConfiguration(TestflightConfiguration(appConfigurations: configurations))
 }

--- a/Sources/FileSystem/Model/TestflightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestflightConfiguration.swift
@@ -7,12 +7,37 @@ struct TestflightConfiguration {
 
     var appConfigurations: [AppConfiguration]
 
-}
+    init(
+        apps: [Model.App],
+        testers: [Model.BetaTester],
+        groups: [Model.BetaGroup]
+    ) throws {
+        let groupsByApp = Dictionary(grouping: groups, by: \.app?.id)
 
-struct AppConfiguration {
+        appConfigurations = try apps.map { app in
+            var config = try AppConfiguration(app: App(model: app))
 
-    var app: App
-    var betaTesters: [BetaTester] = []
-    var betaGroups: [BetaGroup] = []
+            config.betaTesters = testers
+                .filter { tester in tester.apps.map(\.id).contains(app.id) }
+                .compactMap(FileSystem.BetaTester.init)
+
+            config.betaGroups = (groupsByApp[app.id] ?? []).map { betaGroup in
+                FileSystem.BetaGroup(
+                    betaGroup: betaGroup,
+                    betaTesters: testers.filter { $0.betaGroups.map(\.id).contains(betaGroup.id) }
+                )
+            }
+
+            return config
+        }
+    }
+
+    struct AppConfiguration {
+
+        var app: App
+        var betaTesters: [BetaTester] = []
+        var betaGroups: [BetaGroup] = []
+
+    }
 
 }

--- a/Sources/FileSystem/Model/TestflightConfiguration.swift
+++ b/Sources/FileSystem/Model/TestflightConfiguration.swift
@@ -5,6 +5,12 @@ import Model
 
 struct TestflightConfiguration {
 
+    var appConfigurations: [AppConfiguration]
+
+}
+
+struct AppConfiguration {
+
     var app: App
     var betaTesters: [BetaTester] = []
     var betaGroups: [BetaGroup] = []


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Move testflight configuration generation into `TestflightConfiguration.init`
- Expose a `FileSystem` fuction to write the configuration
- Make `TestflightConfigurationProcessor` take a `TestflightConfiguration`

 🧐🗒 Reviewer Notes

## 🔨 How To Test

Usage / results should remain unchanged
