### PR TITLE
Create efficient service for retrieving testflight program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Temporary Items
 /*.xcodeproj
 xcuserdata/
 config/auth.yml
+config/apps

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -28,13 +28,8 @@ struct TestFlightPullCommand: CommonParsableCommand {
     func run() throws {
         let service = try makeService()
 
-        // TODO: A new service function should be created to efficiently gather these models
-        let apps = try service.listApps(bundleIds: filterBundleIds)
-        let identifiers = apps.map { app in AppLookupIdentifier.appId(app.id) }
-        let testers = try service.listBetaTesters(filterIdentifiers: identifiers, limit: 200)
-        let groups = try service.listBetaGroups(filterIdentifiers: identifiers)
+        let testflightProgram = try service.getTestFlightProgram()
 
-        let testflightProgram = TestFlightProgram(apps: apps, testers: testers, groups: groups)
         try FileSystem.writeTestFlightConfiguration(program: testflightProgram, to: outputPath)
     }
 

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -28,7 +28,7 @@ struct TestFlightPullCommand: CommonParsableCommand {
     func run() throws {
         let service = try makeService()
 
-        let testflightProgram = try service.getTestFlightProgram()
+        let testflightProgram = try service.getTestFlightProgram(bundleIds: filterBundleIds)
 
         try FileSystem.writeTestFlightConfiguration(program: testflightProgram, to: outputPath)
     }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPushCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPushCommand.swift
@@ -21,9 +21,12 @@ struct TestFlightPushCommand: CommonParsableCommand {
     ) var inputPath: String
 
     func run() throws {
-        let service = try makeService()
+        let localTestFlightProgram = try FileSystem.readTestFlightConfiguration(from: inputPath)
 
-        let testFlightProgram = try FileSystem.readTestFlightConfiguration(from: inputPath)
+        let service = try makeService()
+        let remoteTestFlightProgram = try service.getTestFlightProgram()
+
+        // TODO: Compare local and remote Program
 
         // TODO: Push the testflight program to the API
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -913,6 +913,15 @@ class AppStoreConnectService {
             .await()
     }
 
+    func getTestFlightProgram(filterBundleIds: [String] = []) throws -> TestFlightProgram {
+        let apps = try listApps(bundleIds: filterBundleIds)
+        let identifiers = apps.map { app in AppLookupIdentifier.appId(app.id) }
+        let testers = try listBetaTesters(filterIdentifiers: identifiers, limit: 200)
+        let groups = try listBetaGroups(filterIdentifiers: identifiers)
+
+        return TestFlightProgram(apps: apps, testers: testers, groups: groups)
+    }
+
     /// Make a request for something `Decodable`.
     ///
     /// - Parameters:

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -913,8 +913,9 @@ class AppStoreConnectService {
             .await()
     }
 
-    func getTestFlightProgram(filterBundleIds: [String] = []) throws -> TestFlightProgram {
-        let apps = try listApps(bundleIds: filterBundleIds)
+    func getTestFlightProgram(bundleIds: [String] = []) throws -> TestFlightProgram {
+        let appsOperation = ListAppsOperation(options: .init(bundleIds: bundleIds))
+        let apps = try appsOperation.execute(with: requestor).await()
         let appIds = apps.map(\.id)
 
         // Passing appIds can cause undefined API behaviour for list beta testers so we retrieve all
@@ -927,7 +928,7 @@ class AppStoreConnectService {
             .await()
 
         return TestFlightProgram(
-            apps: apps,
+            apps: apps.map(Model.App.init),
             testers: testers.map(Model.BetaTester.init),
             groups: groups.map(Model.BetaGroup.init)
         )

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListAppsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListAppsOperation.swift
@@ -6,10 +6,10 @@ import Combine
 struct ListAppsOperation: APIOperation {
 
     struct Options {
-        let bundleIds: [String]
-        let names: [String]
-        let skus: [String]
-        let limit: Int?
+        var bundleIds: [String] = []
+        var names: [String] = []
+        var skus: [String] = []
+        var limit: Int?
     }
 
     private let options: Options

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaGroupsOperation.swift
@@ -7,9 +7,9 @@ import Foundation
 struct ListBetaGroupsOperation: APIOperation {
 
     struct Options {
-        let appIds: [String]
-        let names: [String]
-        let sort: ListBetaGroups.Sort?
+        var appIds: [String] = []
+        var names: [String] = []
+        var sort: ListBetaGroups.Sort?
         var excludeInternal: Bool?
     }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListBetaTestersOperation.swift
@@ -7,15 +7,15 @@ import Foundation
 struct ListBetaTestersOperation: APIOperation {
 
     struct Options {
-        let email: String?
-        let firstName: String?
-        let lastName: String?
-        let inviteType: BetaInviteType?
-        let appIds: [String]?
-        let groupIds: [String]?
-        let sort: ListBetaTesters.Sort?
-        let limit: Int?
-        let relatedResourcesLimit: Int?
+        var email: String?
+        var firstName: String?
+        var lastName: String?
+        var inviteType: BetaInviteType?
+        var appIds: [String]?
+        var groupIds: [String]?
+        var sort: ListBetaTesters.Sort?
+        var limit: Int?
+        var relatedResourcesLimit: Int?
     }
 
     enum Error: LocalizedError {

--- a/config/apps/codes.orj.app1/betaGroups.yml
+++ b/config/apps/codes.orj.app1/betaGroups.yml
@@ -1,2 +1,0 @@
-- name: Test Group
-  publicLinkEnabled: false


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `getTestFlightProgram` service function

# 🧐🗒 Reviewer Notes

## 💁 Example

Functionality for `sync pull` remains unchanges

## 🔨 How To Test
Test that `sync pull` remains unchanged
