### PR TITLE
Change ListProfilesByBundleIdCommand to use fuzzy search

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
         "state": {
           "branch": "master",
-          "revision": "b00cde9b192c501014a5822af37d54857ede2611",
+          "revision": "c7ab261425c2cee73602b162047f603c87d346b5",
           "version": null
         }
       },

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
@@ -14,7 +14,12 @@ struct ListProfilesByBundleIdCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Argument(help: "The bundle ID of an application. (eg. com.example.app)")
+    @Argument(
+        help: ArgumentHelp(
+            "The bundle ID of an application. (eg. com.example.app)",
+            discussion: "Note that all provisioning profiles for bundle identifiers beginning with this string will be fetched."
+        )
+    )
     var bundleId: String
 
     @Option(default: 200, help: "Limit the number of profiles to return (maximum 200).")

--- a/Sources/AppStoreConnectCLI/Model/API/Sales.Filter+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/Sales.Filter+ExpressibleByArgument.swift
@@ -4,12 +4,12 @@ import ArgumentParser
 import AppStoreConnect_Swift_SDK
 import Foundation
 
-private typealias Filter = DownloadSalesAndTrendsReports.Filter
+public typealias Filter = DownloadSalesAndTrendsReports.Filter
 
 extension Filter.Frequency: ExpressibleByArgument, CustomStringConvertible {
-    private typealias AllCases = [Filter.Frequency]
+    public typealias AllCases = [Filter.Frequency]
 
-    private static var allCases: AllCases {
+    public static var allCases: AllCases {
         [.DAILY, .MONTHLY, .WEEKLY, .YEARLY]
     }
 
@@ -23,9 +23,9 @@ extension Filter.Frequency: ExpressibleByArgument, CustomStringConvertible {
 }
 
 extension Filter.ReportType: ExpressibleByArgument, CustomStringConvertible {
-    private typealias AllCases = [Filter.ReportType]
+    public typealias AllCases = [Filter.ReportType]
 
-    private static var allCases: AllCases {
+    public static var allCases: AllCases {
         [.SALES, .PRE_ORDER, .NEWSSTAND, .SUBSCRIPTION, .SUBSCRIPTION_EVENT, .SUBSCRIBER]
     }
 
@@ -39,9 +39,9 @@ extension Filter.ReportType: ExpressibleByArgument, CustomStringConvertible {
 }
 
 extension Filter.ReportSubType: ExpressibleByArgument, CustomStringConvertible {
-    private typealias AllCases = [Filter.ReportSubType]
+    public typealias AllCases = [Filter.ReportSubType]
 
-    private static var allCases: AllCases {
+    public static var allCases: AllCases {
         [.SUMMARY, .DETAILED, .OPT_IN]
     }
 

--- a/Sources/AppStoreConnectCLI/Model/API/Sales.Filter+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/Sales.Filter+ExpressibleByArgument.swift
@@ -9,7 +9,7 @@ private typealias Filter = DownloadSalesAndTrendsReports.Filter
 extension Filter.Frequency: ExpressibleByArgument, CustomStringConvertible {
     private typealias AllCases = [Filter.Frequency]
 
-    public static var allCases: AllCases {
+    private static var allCases: AllCases {
         [.DAILY, .MONTHLY, .WEEKLY, .YEARLY]
     }
 
@@ -25,7 +25,7 @@ extension Filter.Frequency: ExpressibleByArgument, CustomStringConvertible {
 extension Filter.ReportType: ExpressibleByArgument, CustomStringConvertible {
     private typealias AllCases = [Filter.ReportType]
 
-    public static var allCases: AllCases {
+    private static var allCases: AllCases {
         [.SALES, .PRE_ORDER, .NEWSSTAND, .SUBSCRIPTION, .SUBSCRIPTION_EVENT, .SUBSCRIBER]
     }
 
@@ -41,7 +41,7 @@ extension Filter.ReportType: ExpressibleByArgument, CustomStringConvertible {
 extension Filter.ReportSubType: ExpressibleByArgument, CustomStringConvertible {
     private typealias AllCases = [Filter.ReportSubType]
 
-    public static var allCases: AllCases {
+    private static var allCases: AllCases {
         [.SUMMARY, .DETAILED, .OPT_IN]
     }
 

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -708,6 +708,7 @@ class AppStoreConnectService {
         )
         .execute(with: requestor)
         .await()
+        .filter { ($0.attributes?.identifier?.starts(with: bundleId) ?? false) }
         .map(\.id)
 
         return try bundleIdResourceIds.map {

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -703,19 +703,22 @@ class AppStoreConnectService {
     }
 
     func listProfilesByBundleId(_ bundleId: String, limit: Int?) throws -> [Model.Profile] {
-        let bundleIdResourceId = try ReadBundleIdOperation(
-            options: .init(bundleId: bundleId)
+        let bundleIdResourceIds = try ListBundleIdsOperation(
+            options: .init(identifiers: [bundleId], names: [], platforms: [], seedIds: [], limit: nil)
         )
-            .execute(with: requestor)
-            .await()
-            .id
+        .execute(with: requestor)
+        .await()
+        .map(\.id)
 
-        return try ListProfilesByBundleIdOperation(
-            options: .init(bundleIdResourceId: bundleIdResourceId, limit: limit)
-        )
+        return try bundleIdResourceIds.map {
+            try ListProfilesByBundleIdOperation(
+                options: .init(bundleIdResourceId: $0, limit: limit)
+            )
             .execute(with: requestor)
             .await()
-            .map(Model.Profile.init)
+        }
+        .flatMap { $0 }
+        .map(Model.Profile.init)
     }
 
     func readProfile(id: String) throws -> Model.Profile {


### PR DESCRIPTION
Remove bundle id must be unique validation for `ListProfilesByBundleIdCommand`.
Input first part of the bundle ID will result in all the matched cases.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Removed bundle id `must be unique validation` for `ListProfilesByBundleIdCommand`.
- Return all the matched profiles for input bundle Id

# ⚠️ Items of Note

Inputted bundle Id string must be the first part of the bundle Id.

# 🧐🗒 Reviewer Notes

## 💁 Example

USAGE: 
```
asc profiles list-by-bundle [--api-issuer <uuid>] [--api-key-id <keyid>] [--csv] [--json] [--table] [--yaml] [--verbose] <bundle-id> [--limit <limit>] [--download-path <path>]
```

## 🔨 How To Test

```
swift run asc profiles list-by-bundle com --download-path ../../
```