### PR TITLE
Pin swift-argument-parser version number to 0.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "9f04d1ff1afbccd02279338a2c91e5f27c45e93a",
-          "version": "0.0.5"
+          "revision": "35b76bf577d3cc74820f8991894ce3bcdf024ddc",
+          "version": "0.0.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",
-            from: "0.0.2"
+            .exact("0.0.2")
         ),
         .package(
             url: "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",


### PR DESCRIPTION
Swift argument parser produces breaking changes in its new version. 
As there is no plan for adopting the new version currently, a lock might be needed.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Lock swift-argument-parser version to 0.0.2
