### PR TITLE
Don't send deviceIds when provision type is AppStore

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
@@ -32,8 +32,6 @@ struct CreateProfileOperation: APIOperation {
             .map { $0.data }
             .eraseToAnyPublisher()
     }
-    
-    
 
 }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
@@ -17,12 +17,15 @@ struct CreateProfileOperation: APIOperation {
     private let endpoint: APIEndpoint<ProfileResponse>
 
     init(options: Options) {
+        let shouldOmitDeviceIds = [.macAppStore, .iOSAppStore, .tvOSAppStore]
+            .contains(options.profileType)
+        
         endpoint = APIEndpoint.create(
             profileWithId: options.bundleId,
             name: options.name,
             profileType: options.profileType,
             certificateIds: options.certificateIds,
-            deviceIds: options.profileType.areDeviceIdsRequired ? options.deviceIds : []
+            deviceIds: shouldOmitDeviceIds ? [] : options.deviceIds
         )
     }
 
@@ -33,10 +36,4 @@ struct CreateProfileOperation: APIOperation {
             .eraseToAnyPublisher()
     }
 
-}
-
-fileprivate extension ProfileType {
-    var areDeviceIdsRequired: Bool {
-        return !self.rawValue.contains("_APP_STORE")
-    }
 }

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
@@ -19,7 +19,7 @@ struct CreateProfileOperation: APIOperation {
     init(options: Options) {
         let shouldOmitDeviceIds = [.macAppStore, .iOSAppStore, .tvOSAppStore]
             .contains(options.profileType)
-        
+
         endpoint = APIEndpoint.create(
             profileWithId: options.bundleId,
             name: options.name,

--- a/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/CreateProfileOperation.swift
@@ -22,7 +22,7 @@ struct CreateProfileOperation: APIOperation {
             name: options.name,
             profileType: options.profileType,
             certificateIds: options.certificateIds,
-            deviceIds: options.deviceIds
+            deviceIds: options.profileType.areDeviceIdsRequired ? options.deviceIds : []
         )
     }
 
@@ -32,5 +32,13 @@ struct CreateProfileOperation: APIOperation {
             .map { $0.data }
             .eraseToAnyPublisher()
     }
+    
+    
 
+}
+
+fileprivate extension ProfileType {
+    var areDeviceIdsRequired: Bool {
+        return !self.rawValue.contains("_APP_STORE")
+    }
 }


### PR DESCRIPTION
# 📝 Summary of Changes

When you create a AppStore provisioning profile, you don't need to send deviceIds. 