### PR TITLE
Handle situation where you have nested bundle id

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadBundleIdOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadBundleIdOperation.swift
@@ -37,11 +37,12 @@ struct ReadBundleIdOperation: APIOperation {
             )
         )
         .tryMap {
-            switch $0.data.count {
+            let data = $0.data.filter { $0.attributes?.identifier == self.options.bundleId }
+            switch data.count {
             case 0:
                 throw Error.couldNotFindBundleId(self.options.bundleId)
             case 1:
-                return $0.data.first!
+                return data.first!
             default:
                 throw Error.bundleIdNotUnique(self.options.bundleId)
             }


### PR DESCRIPTION
# 📝 Summary of Changes

Imagine, If you have an app `com.mycompany.myapp` and say a share extension with the `com.mycompany.myapp.share` bundle id you will get a `bundleIdNotUnique` exception. 
This change fixes that.