### PR TITLE
Add pretty flag to CommonOptions

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
@@ -41,6 +41,6 @@ struct ListBundleIdsCommand: CommonParsableCommand {
             limit: limit
         )
 
-        bundleIds.render(format: common.outputFormat)
+        bundleIds.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ModifyBundleIdCommand.swift
@@ -28,6 +28,6 @@ struct ModifyBundleIdCommand: CommonParsableCommand {
         let bundleId = try service
             .modifyBundleIdInformation(bundleId: identifier, name: name)
 
-        bundleId.render(format: common.outputFormat)
+        bundleId.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ReadBundleIdCommand.swift
@@ -23,6 +23,6 @@ struct ReadBundleIdCommand: CommonParsableCommand {
 
         let bundleId = try service.readBundleIdInformation(bundleId: identifier)
 
-        bundleId.render(format: common.outputFormat)
+        bundleId.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -35,6 +35,6 @@ struct RegisterBundleIdCommand: CommonParsableCommand {
             .map(BundleId.init)
             .await()
 
-        bundleId.render(format: common.outputFormat)
+        bundleId.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/CreateCertificateCommand.swift
@@ -29,6 +29,6 @@ struct CreateCertificateCommand: CommonParsableCommand {
             csrContent: csrContent
         )
 
-        certificate.render(format: common.outputFormat)
+        certificate.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
@@ -62,7 +62,7 @@ struct ListCertificatesCommand: CommonParsableCommand {
             }
         }
 
-        certificates.render(format: common.outputFormat)
+        certificates.render(options: common.outputOptions)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ListCertificatesCommand.swift
@@ -56,7 +56,7 @@ struct ListCertificatesCommand: CommonParsableCommand {
                 let file = try certificateProcessor.write($0)
 
                 // Only print if the `PrintLevel` is set to verbose.
-                if common.printLevel == .verbose {
+                if common.outputOptions.printLevel == .verbose {
                     print("📥 Certificate '\($0.name ?? "")' downloaded to: \(file.path)")
                 }
             }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/ReadCertificateCommand.swift
@@ -29,11 +29,11 @@ struct ReadCertificateCommand: CommonParsableCommand {
             let file = try fileProcessor.write(certificate)
 
             // Only print if the `PrintLevel` is set to verbose.
-            if common.printLevel == .verbose {
+            if common.outputOptions.printLevel == .verbose {
                 print("📥 Certificate '\(certificate.name ?? "")' downloaded to: \(file.path)")
             }
         }
 
-        certificate.render(format: common.outputFormat)
+        certificate.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Certificates/RevokeCertificatesCommand.swift
@@ -26,7 +26,7 @@ struct RevokeCertificatesCommand: CommonParsableCommand {
         _ = try service.revokeCertificates(serials: serials)
 
         // Only print if the `PrintLevel` is set to verbose.
-        if common.printLevel == .verbose {
+        if common.outputOptions.printLevel == .verbose {
             serials.forEach {
                 print("🚮 Certificate `\($0)` revoked.")
             }

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -28,6 +28,9 @@ struct CommonOptions: ParsableArguments {
     @OptionGroup()
     var authOptions: AuthOptions
 
+    @OptionGroup()
+    var outputOptions: OutputOptions
+
     @Flag(default: .table, help: "Display results in specified format.")
     var outputFormat: OutputFormat
 
@@ -43,6 +46,18 @@ struct CommonOptions: ParsableArguments {
             return .quiet
         }
     }
+
+    /// Used to define the command's `PrintLevel`. Defaults to `false`.
+    @Flag(name: .shortAndLong, help: "Display extra messages as command is running.")
+    var verbose: Bool
+}
+
+struct OutputOptions: ParsableArguments {
+    @Flag(default: .table, help: "Display results in specified format.")
+    var outputFormat: OutputFormat
+
+    @Flag(help: "Display result in a human readable format.")
+    var pretty: Bool
 
     /// Used to define the command's `PrintLevel`. Defaults to `false`.
     @Flag(name: .shortAndLong, help: "Display extra messages as command is running.")

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -62,4 +62,17 @@ struct OutputOptions: ParsableArguments {
     /// Used to define the command's `PrintLevel`. Defaults to `false`.
     @Flag(name: .shortAndLong, help: "Display extra messages as command is running.")
     var verbose: Bool
+
+    /// The verbosity of the executed command.
+    var printLevel: PrintLevel {
+        // Commands are parsable by default except for `--table` which is intended to be interactive.
+        switch (verbose, outputFormat == .table) {
+        // if `--verbose` or `--table`is used then return a verbose print level
+        case (true, _), (_, true):
+            return .verbose
+        // if both `--verbose` and `--table` are not used, then return a quiet print level
+        case (false, false):
+            return .quiet
+        }
+    }
 }

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -30,26 +30,6 @@ struct CommonOptions: ParsableArguments {
 
     @OptionGroup()
     var outputOptions: OutputOptions
-
-    @Flag(default: .table, help: "Display results in specified format.")
-    var outputFormat: OutputFormat
-
-    /// The verbosity of the executed command.
-    var printLevel: PrintLevel {
-        // Commands are parsable by default except for `--table` which is intended to be interactive.
-        switch (verbose, outputFormat == .table) {
-        // if `--verbose` or `--table`is used then return a verbose print level
-        case (true, _), (_, true):
-            return .verbose
-        // if both `--verbose` and `--table` are not used, then return a quiet print level
-        case (false, false):
-            return .quiet
-        }
-    }
-
-    /// Used to define the command's `PrintLevel`. Defaults to `false`.
-    @Flag(name: .shortAndLong, help: "Display extra messages as command is running.")
-    var verbose: Bool
 }
 
 struct OutputOptions: ParsableArguments {

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
@@ -72,6 +72,6 @@ struct ListDevicesCommand: CommonParsableCommand {
             limit: limit
         )
 
-        devices.render(format: common.outputFormat)
+        devices.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ModifyDeviceCommand.swift
@@ -35,7 +35,7 @@ struct ModifyDeviceCommand: CommonParsableCommand {
             .map(Device.init)
             .await()
 
-        device.render(format: common.outputFormat)
+        device.render(options: common.outputOptions)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ReadDeviceInfoCommand.swift
@@ -50,7 +50,7 @@ struct ReadDeviceInfoCommand: CommonParsableCommand {
             .map(Device.init)
             .await()
 
-        device.render(format: common.outputFormat)
+        device.render(options: common.outputOptions)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/RegisterDeviceCommand.swift
@@ -31,6 +31,6 @@ struct RegisterDeviceCommand: CommonParsableCommand {
             .map(Device.init)
             .await()
 
-        device.render(format: common.outputFormat)
+        device.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/CreateProfileCommand.swift
@@ -51,7 +51,7 @@ struct CreateProfileCommand: CommonParsableCommand {
             deviceUDIDs: devicesUdids
         )
 
-        [profile].render(format: common.outputFormat)
+        [profile].render(options: common.outputOptions)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
@@ -49,6 +49,6 @@ struct ListProfilesByBundleIdCommand: CommonParsableCommand {
             }
         }
 
-        profiles.render(format: common.outputFormat)
+        profiles.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -85,12 +85,12 @@ struct ListProfilesCommand: CommonParsableCommand {
                 let file = try processor.write($0)
 
                 // Only print if the `PrintLevel` is set to verbose.
-                if common.printLevel == .verbose {
+                if common.outputOptions.printLevel == .verbose {
                     print("📥 Profile '\($0.name!)' downloaded to: \(file.path)")
                 }
             }
         }
 
-        profiles.render(format: common.outputFormat)
+        profiles.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ReadProfileCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ReadProfileCommand.swift
@@ -35,6 +35,6 @@ struct ReadProfileCommand: CommonParsableCommand {
             print("📥 Profile '\(profile.name!)' downloaded to: \(file.path)")
         }
 
-        [profile].render(format: common.outputFormat)
+        [profile].render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
@@ -37,6 +37,6 @@ struct ListAppsCommand: CommonParsableCommand {
             limit: limit
         )
 
-        apps.render(format: common.outputFormat)
+        apps.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ReadAppCommand.swift
@@ -22,6 +22,6 @@ struct ReadAppCommand: CommonParsableCommand {
 
         let app = try service.readApp(identifier: appLookupArgument.identifier)
 
-        app.render(format: common.outputFormat)
+        app.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/CreateBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/CreateBetaGroupCommand.swift
@@ -50,6 +50,6 @@ struct CreateBetaGroupCommand: CommonParsableCommand {
             publicLinkLimit: publicLinkLimit
         )
 
-        betaGroup.render(format: common.outputFormat)
+        betaGroup.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
@@ -49,6 +49,6 @@ struct ListBetaGroupsCommand: CommonParsableCommand {
             excludeInternal: excludeInternal
         )
 
-        betaGroups.render(format: common.outputFormat)
+        betaGroups.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ModifyBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ModifyBetaGroupCommand.swift
@@ -56,6 +56,6 @@ struct ModifyBetaGroupCommand: CommonParsableCommand {
             publicLinkLimitEnabled: publicLinkLimitEnabled
         )
 
-        betaGroup.render(format: common.outputFormat)
+        betaGroup.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ReadBetaGroupCommand.swift
@@ -26,6 +26,6 @@ struct ReadBetaGroupCommand: CommonParsableCommand {
 
         let betaGroup = try service.readBetaGroup(bundleId: appBundleId, groupName: groupName)
 
-        betaGroup.render(format: common.outputFormat)
+        betaGroup.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/InviteBetaTesterCommand.swift
@@ -43,6 +43,6 @@ struct InviteBetaTesterCommand: CommonParsableCommand {
             groupNames: groups
         )
 
-        betaTester.render(format: common.outputFormat)
+        betaTester.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByBuildsCommand.swift
@@ -82,7 +82,7 @@ struct ListBetaTesterByBuildsCommand: CommonParsableCommand {
             }
             .await()
 
-        betaTesters.render(format: common.outputFormat)
+        betaTesters.render(options: common.outputOptions)
     }
 
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByGroupCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTesterByGroupCommand.swift
@@ -26,6 +26,6 @@ struct ListBetaTesterByGroupCommand: CommonParsableCommand {
         let service = try makeService()
 
         let betaTesters = try service.listBetaTestersForGroup(identifier: appLookupArgument.identifier, groupName: groupName)
-        betaTesters.render(format: common.outputFormat)
+        betaTesters.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -89,6 +89,6 @@ struct ListBetaTestersCommand: CommonParsableCommand {
             relatedResourcesLimit: relatedResourcesLimit
         )
 
-        betaTesters.render(format: common.outputFormat)
+        betaTesters.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ReadBetaTesterCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ReadBetaTesterCommand.swift
@@ -36,6 +36,6 @@ struct ReadBetaTesterCommand: CommonParsableCommand {
                 limitBetaGroups: limitBetaGroups
             )
 
-        tester.render(format: common.outputFormat)
+        tester.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
@@ -84,6 +84,6 @@ struct ListBuildsCommand: CommonParsableCommand {
             limit: limit
         )
 
-        builds.render(format: common.outputFormat)
+        builds.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/CreateBuildLocalizationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/CreateBuildLocalizationsCommand.swift
@@ -36,6 +36,6 @@ struct CreateBuildLocalizationsCommand: CommonParsableCommand, CreateUpdateBuild
             whatsNew: readWhatsNew()
         )
 
-        [buildLocalization].render(format: common.outputFormat)
+        [buildLocalization].render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/ListBuildLocalizationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/ListBuildLocalizationsCommand.swift
@@ -27,6 +27,6 @@ struct ListBuildLocalizationsCommand: CommonParsableCommand {
             limit: limit
         )
 
-        localizations.render(format: common.outputFormat)
+        localizations.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/ReadBuildLocalizationCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/ReadBuildLocalizationCommand.swift
@@ -27,6 +27,6 @@ struct ReadBuildLocalizationCommand: CommonParsableCommand {
             locale: locale
         )
 
-        [buildLocalization].render(format: common.outputFormat)
+        [buildLocalization].render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/UpdateBuildLocalizationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/UpdateBuildLocalizationsCommand.swift
@@ -36,6 +36,6 @@ struct UpdateBuildLocalizationsCommand: CommonParsableCommand, CreateUpdateBuild
             whatsNew: readWhatsNew()
         )
 
-        [buildLocalization].render(format: common.outputFormat)
+        [buildLocalization].render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ReadBuildCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ReadBuildCommand.swift
@@ -27,6 +27,6 @@ struct ReadBuildCommand: CommonParsableCommand {
 
         let buildDetailsInfo = try service.readBuild(bundleId: bundleId, buildNumber: buildNumber, preReleaseVersion: preReleaseVersion)
 
-        buildDetailsInfo.render(format: common.outputFormat)
+        buildDetailsInfo.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ListPreReleaseVersionsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ListPreReleaseVersionsCommand.swift
@@ -51,6 +51,6 @@ struct ListPreReleaseVersionsCommand: CommonParsableCommand {
             sort: sort
         )
 
-        prereleaseVersions.render(format: common.outputFormat)
+        prereleaseVersions.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ReadPreReleaseVersionCommand.swift
@@ -25,6 +25,6 @@ struct ReadPreReleaseVersionCommand: CommonParsableCommand {
         let service = try makeService()
 
         let prereleaseVersion = try service.readPreReleaseVersion(filterIdentifier: appLookupArgument.identifier, filterVersion: version)
-        prereleaseVersion.render(format: common.outputFormat)
+        prereleaseVersion.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
@@ -26,6 +26,6 @@ struct GetUserInfoCommand: CommonParsableCommand {
             includeVisibleApps: includeVisibleApps
         )
 
-        user.render(format: common.outputFormat)
+        user.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
@@ -72,6 +72,6 @@ struct InviteUserCommand: CommonParsableCommand {
             .map { $0.data }
             .await()
 
-        invitation.render(format: common.outputFormat)
+        invitation.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -34,6 +34,6 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
             includeVisibleApps: includeVisibleApps
         )
 
-        invitations.render(format: common.outputFormat)
+        invitations.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -69,6 +69,6 @@ public struct ListUsersCommand: CommonParsableCommand {
                 includeVisibleApps: includeVisibleApps
             )
 
-        users.render(format: common.outputFormat)
+        users.render(options: common.outputOptions)
     }
 }

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -32,7 +32,7 @@ struct SyncUsersCommand: CommonParsableCommand {
 
     func run() throws {
         // Only print if the `PrintLevel` is set to verbose.
-        if common.printLevel == .verbose {
+        if common.outputOptions.printLevel == .verbose {
             print("## Dry run ##")
         }
 

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -14,25 +14,6 @@ protocol Renderer {
 }
 
 enum Renderers {
-    struct ResultRenderer<T: ResultRenderable>: Renderer {
-        typealias Input = T
-
-        let format: OutputFormat
-
-        func render(_ input: T) {
-            switch format {
-            case .csv:
-                print(input.renderAsCSV())
-            case .json:
-                print(input.renderAsJSON())
-            case .yaml:
-                print(input.renderAsYAML())
-            case .table:
-                print(input.renderAsTable())
-            }
-        }
-    }
-
     struct ResultRendererWithOptions<T: ResultRenderable>: Renderer {
         typealias Input = T
 
@@ -91,10 +72,6 @@ extension ResultRenderable {
         let yamlEncoder = YAMLEncoder()
         let yaml = try! yamlEncoder.encode(self) // swiftlint:disable:this force_try
         return yaml
-    }
-
-    func render(format: OutputFormat) {
-        Renderers.ResultRenderer(format: format).render(self)
     }
 
     func render(options: OutputOptions) {

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Renderers.swift
@@ -31,7 +31,25 @@ enum Renderers {
                 print(input.renderAsTable())
             }
         }
+    }
 
+    struct ResultRendererWithOptions<T: ResultRenderable>: Renderer {
+        typealias Input = T
+
+        let options: OutputOptions
+
+        func render(_ input: T) {
+            switch options.outputFormat {
+            case .csv:
+                print(input.renderAsCSV())
+            case .json:
+                print(input.renderAsJSON(pretty: options.pretty))
+            case .yaml:
+                print(input.renderAsYAML())
+            case .table:
+                print(input.renderAsTable())
+            }
+        }
     }
 }
 
@@ -62,6 +80,13 @@ extension ResultRenderable {
         return String(data: json, encoding: .utf8)!
     }
 
+    func renderAsJSON(pretty: Bool) -> String {
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = pretty ? [.prettyPrinted, .sortedKeys] : [.sortedKeys]
+        let json = try! jsonEncoder.encode(self) // swiftlint:disable:this force_try
+        return String(data: json, encoding: .utf8)!
+    }
+
     func renderAsYAML() -> String {
         let yamlEncoder = YAMLEncoder()
         let yaml = try! yamlEncoder.encode(self) // swiftlint:disable:this force_try
@@ -70,6 +95,10 @@ extension ResultRenderable {
 
     func render(format: OutputFormat) {
         Renderers.ResultRenderer(format: format).render(self)
+    }
+
+    func render(options: OutputOptions) {
+        Renderers.ResultRendererWithOptions(options: options).render(self)
     }
 }
 


### PR DESCRIPTION
This PR is for adding `pretty` flag to input options for closing #221 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Create `OutputOptions` and wrap existing output-related input options.
- Create `ResultRendererWithOptions` for taking options
- Update renderAsJSON function to taking pretty flag.

# ⚠️ Items of Note

This PR is a draft, more changes will come if this PR gets approved.

Planed changes
1. Remove `outputFormat`, `printLeve` and `verbose` in `CommonOptions`
2. Replace `ResultRenderer` with `ResultRendererWithOptions`
2. Update all the existing commands for adaptation.

# 🧐🗒 Reviewer Notes

## 💁 Example

Usage: 
```
asc certificates list <options>

--pretty                Display result in a human readable format. 
```

## 🔨 How To Test

```
swift run asc certificates list --json --pretty
```
