### PR TITLE
Add API calls for removing testers and group in sync push command

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -419,6 +419,24 @@ class AppStoreConnectService {
         try operation.execute(with: requestor).await()
     }
 
+    func removeTesterFromApps(email: String, appIds: [String]) throws {
+        let testerId = try GetBetaTesterOperation(
+            options: .init(identifier: .email(email))
+        )
+        .execute(with: requestor)
+        .await()
+        .betaTester
+        .id
+
+        let operation = RemoveTesterOperation(
+            options: .init(
+                removeStrategy: .removeTesterFromApps(testerId: testerId, appIds: appIds)
+            )
+        )
+
+        try operation.execute(with: requestor).await()
+    }
+
     func readBetaGroup(bundleId: String, groupName: String) throws -> Model.BetaGroup {
         let app = try ReadAppOperation(options: .init(identifier: .bundleId(bundleId)))
             .execute(with: requestor)
@@ -468,6 +486,12 @@ class AppStoreConnectService {
             .await()
 
         try DeleteBetaGroupOperation(options: .init(betaGroupId: betaGroup.id))
+            .execute(with: requestor)
+            .await()
+    }
+
+    func deleteBetaGroup(id: String) throws {
+        try DeleteBetaGroupOperation(options: .init(betaGroupId: id))
             .execute(with: requestor)
             .await()
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/RemoveTesterOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/RemoveTesterOperation.swift
@@ -10,6 +10,7 @@ struct RemoveTesterOperation: APIOperation {
         enum RemoveStrategy {
             case removeTestersFromGroup(testerIds: [String], groupId: String)
             case removeTesterFromGroups(testerId: String, groupIds: [String])
+            case removeTesterFromApps(testerId: String, appIds: [String])
         }
 
         let removeStrategy: RemoveStrategy
@@ -23,6 +24,8 @@ struct RemoveTesterOperation: APIOperation {
             return APIEndpoint.remove(betaTesterWithId: testerId, fromBetaGroupsWithIds: groupIds)
         case .removeTestersFromGroup(let testerIds, let groupId):
             return APIEndpoint.remove(betaTestersWithIds: testerIds, fromBetaGroupWithId: groupId)
+        case .removeTesterFromApps(let testerId, let appIds):
+            return APIEndpoint.remove(accessOfBetaTesterWithId: testerId, toAppsWithIds: appIds)
         }
     }
 


### PR DESCRIPTION
Add API calls for removing testers and group in sync push command

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add dry-run flag to push command
- Create required service function for push command
- Wire up removing logic in sync such command 

# 🧐🗒 Reviewer Notes

## 💁 Example

```
swift run asc testflight sync push --dry-run

Beta Tester with email: foo+91@gmail.com will be removed from groups: New Group 3 in apps: com.exmaple.foo
Beta Tester with email: foo+138@gmail.com will be removed from groups: New Group 3 in apps: com.exmaple.foo
Beta Tester with email: foo+142@gmail.com will be removed from groups: New Group 3 in apps: com.exmaple.foo
```

```
swift run asc testflight sync push 

✅  Beta Tester with email: foo+91@gmail.com will be removed from groups: New Group 3 in apps: com.exmaple.foo
✅  Beta Tester with email: foo+138@gmail.com will be removed from groups: New Group 3 in apps: com.exmaple.foo
✅  Beta Tester with email: foo+142@gmail.com will be removed from groups: New Group 3 in apps: com.exmaple.foo
```

## 🔨 How To Test

```
swift run asc testflight sync push --dry-run
```

```
swift run asc testflight sync push 
```
