### PR TITLE
Use beta group from API to refresh tester in getTestFlightProgram

### DIFF
--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -1078,10 +1078,27 @@ class AppStoreConnectService {
             .zip(betaGroupsOperation.execute(with: requestor))
             .await()
 
+        let betagroups = groups.map(Model.BetaGroup.init)
+
+        // Using beta groups from API to update beta groups in testers, for adding extra informations like app info in a group
+        let betatesters = testers.map(Model.BetaTester.init).map { tester -> Model.BetaTester in
+            var updatedTester = tester
+
+            updatedTester.betaGroups = tester.betaGroups.map { betagroupInTester in
+                if let betagroup = betagroups.first(where: { $0.id == betagroupInTester.id }) {
+                    return betagroup
+                }
+
+                return betagroupInTester
+            }
+
+            return updatedTester
+        }
+
         return TestFlightProgram(
             apps: apps.map(Model.App.init),
-            testers: testers.map(Model.BetaTester.init),
-            groups: groups.map(Model.BetaGroup.init)
+            testers: betatesters,
+            groups: betagroups
         )
     }
 


### PR DESCRIPTION
Currently, for test flight sync push command, beta group in `removeBetaTesterFromGroups` will have an empty app list.
Eg.

```
Beta Tester with email: foo+142@gmail.com will be removed from groups: New Group 3 in apps: 
```
we can see that apps are missing, this PR is for fixing that

# 📝 Summary of Changes

Changes proposed in this pull request:

- Use beta group from a separate API call to update beta group in beta tester

# 🧐🗒 Reviewer Notes

## 💁 Example

#### Before
```
swift run asc testflight sync push    

Beta Tester with email: foo+142@gmail.com will be removed from groups: New Group 3 in apps: 
```

#### After
```
swift run asc testflight sync push    

Beta Tester with email: foo+142@gmail.com will be removed from groups: New Group 3 in apps: com.example.foo
```

## 🔨 How To Test
Remove some testers in a group, then run
```
swift run asc testflight sync push    
```
