### PR TITLE
Ability to use capability: appleIdAuth

### DIFF
--- a/Sources/AppStoreConnectCLI/Model/API/CapabilityType+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/CapabilityType+ExpressibleByArgument.swift
@@ -32,6 +32,7 @@ extension CapabilityType: CaseIterable, ExpressibleByArgument, CustomStringConve
             .classkit,
             .autofillCredentialProvider,
             .accessWifiInformation,
+            .appleIdAuth,
         ]
     }
 


### PR DESCRIPTION
This adds ability to list, enable and disable the new capability.

Requires an update of SDK, which is sent here https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/121