### PR TITLE
Create ModifyUserCommand for adding modify user infos capability.

### DIFF
--- a/Sources/AppStoreConnectCLI/Arguments/UserInfoArguments.swift
+++ b/Sources/AppStoreConnectCLI/Arguments/UserInfoArguments.swift
@@ -1,0 +1,20 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+struct UserInfoArguments: ParsableArguments {
+    @Option(parsing: .upToNextOption, help: "Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform. \(UserRole.allCases)")
+    var roles: [UserRole]
+
+    @Flag(help: "Indicates that a user has access to all apps available to the team.")
+    var allAppsVisible: Bool
+
+    @Flag(help: "Indicates the user's specified role allows access to the provisioning functionality on the Apple Developer website.")
+    var provisioningAllowed: Bool
+
+    @Option(parsing: .upToNextOption,
+            help: "Array of bundle IDs that uniquely identifies the apps.")
+    var bundleIds: [String]
+}

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
@@ -37,7 +37,7 @@ struct InviteUserCommand: CommonParsableCommand {
             return
         }
 
-        if !userInfo.bundleIds.isEmpty {
+        if userInfo.bundleIds.isNotEmpty {
             let resourceIds = try service
                 .getAppResourceIdsFrom(bundleIds: userInfo.bundleIds)
                 .await()

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/InviteUserCommand.swift
@@ -26,30 +26,20 @@ struct InviteUserCommand: CommonParsableCommand {
     @Argument(help: "The user invitation recipient's last name.")
     var lastName: String
 
-    @Option(parsing: .upToNextOption, help: "Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform.")
-    var roles: [UserRole]
-
-    @Flag(help: "Indicates that a user has access to all apps available to the team.")
-    var allAppsVisible: Bool
-
-    @Flag(help: "Indicates the user's specified role allows access to the provisioning functionality on the Apple Developer website.")
-    var provisioningAllowed: Bool
-
-    @Option(parsing: .upToNextOption,
-            help: "Array of bundle IDs that uniquely identifies the apps.")
-    var bundleIds: [String]
+    @OptionGroup()
+    var userInfo: UserInfoArguments
 
     public func run() throws {
         let service = try makeService()
 
-        if allAppsVisible {
+        if userInfo.allAppsVisible {
             try inviteUserToTeam(by: service)
             return
         }
 
-        if !bundleIds.isEmpty {
+        if !userInfo.bundleIds.isEmpty {
             let resourceIds = try service
-                .getAppResourceIdsFrom(bundleIds: bundleIds)
+                .getAppResourceIdsFrom(bundleIds: userInfo.bundleIds)
                 .await()
 
             try inviteUserToTeam(with: resourceIds, by: service)
@@ -63,9 +53,9 @@ struct InviteUserCommand: CommonParsableCommand {
             userWithEmail: email,
             firstName: firstName,
             lastName: lastName,
-            roles: roles,
-            allAppsVisible: allAppsVisible,
-            provisioningAllowed: provisioningAllowed,
+            roles: userInfo.roles,
+            allAppsVisible: userInfo.allAppsVisible,
+            provisioningAllowed: userInfo.provisioningAllowed,
             appsVisibleIds: appsVisibleIds) // appsVisibleIds should be empty when allAppsVisible is true
 
         let invitation = try service.request(request)

--- a/Sources/AppStoreConnectCLI/Commands/Users/ModifyUserInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ModifyUserInfoCommand.swift
@@ -1,0 +1,40 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+struct ModifyUserInfoCommand: CommonParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "modify",
+        abstract: "Change a user's role, app visibility information, or other account details.")
+
+    @OptionGroup()
+    var common: CommonOptions
+
+    @Argument(help: "The email of the user to find.")
+    var email: String
+
+    @OptionGroup()
+    var userInfo: UserInfoArguments
+
+    func validate() throws {
+        if userInfo.bundleIds.isEmpty && userInfo.allAppsVisible == false {
+            throw ValidationError("Invalid Input: If you set allAppsVisible to false, you must provide at least one value for the visibleApps relationship.")
+        }
+    }
+
+    func run() throws {
+        let service = try makeService()
+
+        let user = try service.modifyUserInfo(
+            email: email,
+            roles: userInfo.roles,
+            allAppsVisible: userInfo.allAppsVisible,
+            provisioningAllowed: userInfo.provisioningAllowed,
+            bundleIds: userInfo.bundleIds
+        )
+
+        user.render(options: common.outputOptions)
+    }
+}

--- a/Sources/AppStoreConnectCLI/Commands/Users/UsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/UsersCommand.swift
@@ -8,14 +8,15 @@ struct UsersCommand: ParsableCommand {
         commandName: "users",
         abstract: "Manage users on your App Store Connect team.",
         subcommands: [
+            AddUserVisibleAppsCommand.self,
+            CancelUserInvitationsCommand.self,
+            GetUserInfoCommand.self,
             InviteUserCommand.self,
             ListUserInvitationsCommand.self,
-            CancelUserInvitationsCommand.self,
             // TODO: ListInvitedUserVisibleAppsCommand.self, // Get a list of apps that will be visible to a user with a pending invitation.
             ListUsersCommand.self,
-            GetUserInfoCommand.self,
             ListUserVisibleAppsCommand.self,
-            AddUserVisibleAppsCommand.self,
+            ModifyUserInfoCommand.self,
             RemoveUserVisibleAppsCommand.self,
             SetUserVisibleAppsCommand.self,
             SyncUsersCommand.self,

--- a/Sources/AppStoreConnectCLI/Model/API/UserRole+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/UserRole+ExpressibleByArgument.swift
@@ -4,8 +4,18 @@ import ArgumentParser
 import AppStoreConnect_Swift_SDK
 import Foundation
 
-extension UserRole: ExpressibleByArgument {
+extension UserRole: ExpressibleByArgument, CustomStringConvertible {
+    public typealias AllCases = [UserRole]
+
     public init?(argument: String) {
         self.init(rawValue: argument.uppercased())
+    }
+
+    public static var allCases: AllCases {
+        [.accessToReports, .accountHolder, .admin, .appManager, .customerSupport, .developer, .finance, .marketing, .readOnly, .sales, .technical]
+    }
+
+    public var description: String {
+        rawValue.lowercased()
     }
 }

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -93,6 +93,33 @@ class AppStoreConnectService {
             )
         )
         .execute(with: requestor)
+        .compactMap(Model.User.fromAPIUser)
+        .await()
+    }
+
+    func modifyUserInfo(
+        email: String,
+        roles: [UserRole],
+        allAppsVisible: Bool,
+        provisioningAllowed: Bool,
+        bundleIds: [String]
+    ) throws -> Model.User {
+        let userId = try GetUserInfoOperation(options: .init(email: email, includeVisibleApps: false))
+            .execute(with: requestor)
+            .await()
+            .id
+
+        return try ModifyUserOperation(
+            options: .init(
+                userId: userId,
+                allAppsVisible: allAppsVisible,
+                provisioningAllowed: provisioningAllowed,
+                roles: roles,
+                appsVisibleIds: bundleIds
+            )
+        )
+        .execute(with: requestor)
+        .compactMap(Model.User.fromAPIUser)
         .await()
     }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/GetUserInfoOperation.swift
@@ -36,15 +36,14 @@ struct GetUserInfoOperation: APIOperation {
         self.options = options
     }
 
-    func execute(with requestor: EndpointRequestor) -> AnyPublisher<User, Swift.Error> {
+    func execute(with requestor: EndpointRequestor) -> AnyPublisher<AppStoreConnect_Swift_SDK.User, Swift.Error> {
         requestor.request(endpoint)
             .tryMap { [options] response in
-                let users = User.fromAPIResponse(response)
-                guard let user = users.first, users.count == 1 else {
+                guard response.data.count == 1 else {
                     throw Error.couldNotFindUser(email: options.email)
                 }
 
-                return user
+                return response.data.first!
             }
             .eraseToAnyPublisher()
     }

--- a/Sources/AppStoreConnectCLI/Services/Operations/ModifyUserOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ModifyUserOperation.swift
@@ -1,0 +1,36 @@
+// Copyright 2020 Itty Bitty Apps Pty Ltd
+
+import AppStoreConnect_Swift_SDK
+import Combine
+import Foundation
+
+struct ModifyUserOperation: APIOperation {
+
+    struct Options {
+        let userId: String
+        let allAppsVisible: Bool
+        let provisioningAllowed: Bool
+        let roles: [UserRole]
+        let appsVisibleIds: [String]
+    }
+
+    private let options: Options
+
+    init(options: Options) {
+        self.options = options
+    }
+
+    func execute(with requestor: EndpointRequestor) throws -> AnyPublisher<User, Error> {
+        let buildModifyEndpoint = APIEndpoint.modify(
+            userWithId: options.userId,
+            allAppsVisible: options.allAppsVisible,
+            provisioningAllowed: options.provisioningAllowed,
+            roles: options.roles,
+            appsVisibleIds: options.appsVisibleIds
+        )
+
+        return requestor.request(buildModifyEndpoint)
+            .map { $0.data }
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
Current the CLI doesn't have a command to change the App Store Connect user information(roles, visible apps, etc.)
This PR is for adding this capability
 
# 📝 Summary of Changes

Changes proposed in this pull request:

- Create and add `ModifyUserInfoCommand` to `UsersCommand`.
- Create `ModifyUserOperation` and service functions.
- Separate `UserInfoArguments` from InviteUserCommand for reuse.
- Change the `GetUserInfoOperation` to return SDK User.

# 🧐🗒 Reviewer Notes

## 💁 Example

USAGE
```
asc users modify <options>
```

## 🔨 How To Test

```
swift run asc users modify foo@gmail.com --roles developer --all-apps-visible
```