### PR TITLE
Change Appstore Connect SDK dependency 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "AppStoreConnect-Swift-SDK",
-        "repositoryURL": "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
+        "repositoryURL": "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
         "state": {
-          "branch": "master",
-          "revision": "8ddedc1e6e19f027625f3835131df90930515af9",
-          "version": null
+          "branch": null,
+          "revision": "52d5f21b49b7efb424c077c7203585dd6a228674",
+          "version": "1.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
             .exact("0.0.2")
         ),
         .package(
-            url: "https://github.com/ittybittyapps/appstoreconnect-swift-sdk.git",
-            .branch("master")
+            url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
+            from: "1.0.0"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/Sources/AppStoreConnectCLI/Model/API/Platform+ExpressibleByArgument.swift
+++ b/Sources/AppStoreConnectCLI/Model/API/Platform+ExpressibleByArgument.swift
@@ -4,7 +4,7 @@ import ArgumentParser
 import AppStoreConnect_Swift_SDK
 import Foundation
 
-extension Platform: CaseIterable, ExpressibleByArgument, CustomStringConvertible {
+extension Platform: ExpressibleByArgument, CustomStringConvertible {
     public typealias AllCases = [Platform]
 
     public static var allCases: AllCases {


### PR DESCRIPTION
Updating the Appstore connect SDK to point to origin. 

From what I can tell, all changes stemming from the forked SDK have been merged upstream. If this is not the case or there is still a reason to keep using a fork, we can close this PR and instead keep the fork up to date, corresponding [PR here](https://github.com/ittybittyapps/appstoreconnect-swift-sdk/pull/8)

This initially generated a warning in `Platform+ExpressibleByArgument.swift` as CaseIterable is now declared in `Platform.swift`

Build and run succeeds and all tests pass. 

# 📝 Summary of Changes

Changes proposed in this pull request:

- Change Appstore Connect SDK dependency to the [origin repo](https://github.com/AvdLee/appstoreconnect-swift-sdk) 