### PR TITLE
Upgrade Swift Argument Parser to 1.1.3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 env:
-  DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,61 +1,59 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "AppStoreConnect-Swift-SDK",
-        "repositoryURL": "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
-        "state": {
-          "branch": null,
-          "revision": "52d5f21b49b7efb424c077c7203585dd6a228674",
-          "version": "1.3.0"
-        }
-      },
-      {
-        "package": "CodableCSV",
-        "repositoryURL": "https://github.com/dehesa/CodableCSV.git",
-        "state": {
-          "branch": null,
-          "revision": "2db5f560db5f8c3444f3a00fa145aa699efac3bf",
-          "version": "0.5.5"
-        }
-      },
-      {
-        "package": "Files",
-        "repositoryURL": "https://github.com/johnsundell/files.git",
-        "state": {
-          "branch": null,
-          "revision": "22fe84797d499ffca911ccd896b34efaf06a50b9",
-          "version": "4.1.1"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "35b76bf577d3cc74820f8991894ce3bcdf024ddc",
-          "version": "0.0.2"
-        }
-      },
-      {
-        "package": "SwiftyTextTable",
-        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
-        "state": {
-          "branch": null,
-          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-          "version": "0.9.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
-        }
+  "pins" : [
+    {
+      "identity" : "appstoreconnect-swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
+      "state" : {
+        "revision" : "6961347904eaad966f6eedc3b605f685dac429f8",
+        "version" : "1.7.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "codablecsv",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dehesa/CodableCSV.git",
+      "state" : {
+        "revision" : "2db5f560db5f8c3444f3a00fa145aa699efac3bf",
+        "version" : "0.5.5"
+      }
+    },
+    {
+      "identity" : "files",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnsundell/files.git",
+      "state" : {
+        "revision" : "22fe84797d499ffca911ccd896b34efaf06a50b9",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "df9ee6676cd5b3bf5b330ec7568a5644f547201b",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
+        "version" : "2.0.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -21,7 +21,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",
-            .exact("0.0.2")
+            exact: "1.1.3"
         ),
         .package(
             url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
@@ -43,14 +43,15 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "appstoreconnect-cli", dependencies: ["AppStoreConnectCLI"]),
+        .executableTarget(name: "appstoreconnect-cli", dependencies: ["AppStoreConnectCLI"]),
         .target(name: "Model"),
-        .target(name: "FileSystem",
-                dependencies: [
-                    .product(name: "CodableCSV", package: "CodableCSV"),
-                    .product(name: "Yams", package: "Yams"),
-                    .product(name: "Files", package: "Files"),
-                ]
+        .target(
+            name: "FileSystem",
+            dependencies: [
+                .product(name: "CodableCSV", package: "CodableCSV"),
+                .product(name: "Yams", package: "Yams"),
+                .product(name: "Files", package: "Files"),
+            ]
         ),
         .target(
             name: "AppStoreConnectCLI",
@@ -64,6 +65,12 @@ let package = Package(
                 .product(name: "CodableCSV", package: "CodableCSV")
             ]
         ),
-        .testTarget(name: "appstoreconnect-cliTests", dependencies: ["appstoreconnect-cli"]),
+        .testTarget(
+            name: "appstoreconnect-cliTests",
+            dependencies: ["appstoreconnect-cli"],
+            resources: [
+                .copy("Models/Fixtures.bundle")
+            ]
+        ),
     ]
 )

--- a/Sources/AppStoreConnectCLI/Arguments/AuthOptions.swift
+++ b/Sources/AppStoreConnectCLI/Arguments/AuthOptions.swift
@@ -11,7 +11,6 @@ struct AuthOptions: ParsableArguments {
     }
 
     @Option(
-        default: .environment("APPSTORE_CONNECT_ISSUER_ID"),
         help: ArgumentHelp(
             "An AppStore Connect API Key issuer ID.",
             discussion:
@@ -23,11 +22,10 @@ struct AuthOptions: ParsableArguments {
             valueName: "uuid"
         )
     )
-    var apiIssuer: IssuerID
+    var apiIssuer: IssuerID = .environment("APPSTORE_CONNECT_ISSUER_ID")
 
     // swiftlint:disable line_length
     @Option(
-        default: .environment("APPSTORE_CONNECT_API_KEY_ID"),
         help: ArgumentHelp(
             "An AppStoreConnect API Key ID.",
             discussion:
@@ -43,5 +41,5 @@ struct AuthOptions: ParsableArguments {
             valueName: "keyid"
         )
     )
-    var apiKeyId: APIKeyID
+    var apiKeyId: APIKeyID = .environment("APPSTORE_CONNECT_API_KEY_ID")
 }

--- a/Sources/AppStoreConnectCLI/Arguments/UserInfoArguments.swift
+++ b/Sources/AppStoreConnectCLI/Arguments/UserInfoArguments.swift
@@ -5,14 +5,17 @@ import AppStoreConnect_Swift_SDK
 import Foundation
 
 struct UserInfoArguments: ParsableArguments {
-    @Option(parsing: .upToNextOption, help: "Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform. \(UserRole.allCases)")
-    var roles: [UserRole]
+    @Option(
+        parsing: .upToNextOption,
+        help: "Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform. \(UserRole.allCases)"
+    )
+    var roles: [UserRole] = []
 
     @Flag(help: "Indicates that a user has access to all apps available to the team.")
-    var allAppsVisible: Bool
+    var allAppsVisible = false
 
     @Flag(help: "Indicates the user's specified role allows access to the provisioning functionality on the Apple Developer website.")
-    var provisioningAllowed: Bool
+    var provisioningAllowed = false
 
     @Option(parsing: .upToNextOption,
             help: "Array of bundle IDs that uniquely identifies the apps.")

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/ListBundleIdsCommand.swift
@@ -12,23 +12,26 @@ struct ListBundleIdsCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(help: "Limit the number of resources (maximum 200).")
+    @Option(
+        help: "Limit the number of resources (maximum 200).",
+        transform: { Int($0).map { min($0, 200) } }
+    )
     var limit: Int?
 
     @Option(parsing: .upToNextOption, help: "Filter the results by reverse-DNS bundle ID identifier (eg. com.example.app)")
-    var filterIdentifier: [String]
+    var filterIdentifier: [String] = []
 
     @Option(parsing: .upToNextOption, help: "Filter the results by app name")
-    var filterName: [String]
+    var filterName: [String] = []
 
     @Option(
         parsing: .upToNextOption,
         help: "Filter the results by platform (\(Platform.allCases.description))."
     )
-    var filterPlatform: [String]
+    var filterPlatform: [String] = []
 
     @Option(parsing: .upToNextOption, help: "Filter the results by seed ID")
-    var filterSeedId: [String]
+    var filterSeedId: [String] = []
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/BundleIds/RegisterBundleIdCommand.swift
@@ -20,11 +20,8 @@ struct RegisterBundleIdCommand: CommonParsableCommand {
     @Argument(help: "The new name for the bundle identifier.")
     var name: String
 
-    @Option(
-        default: .universal,
-        help: "The platform of the bundle identifier \(BundleIdPlatform.allCases)."
-    )
-    var platform: BundleIdPlatform
+    @Option(help: "The platform of the bundle identifier \(BundleIdPlatform.allCases).")
+    var platform: BundleIdPlatform = .universal
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -33,7 +33,7 @@ struct CommonOptions: ParsableArguments {
 }
 
 struct OutputOptions: ParsableArguments {
-    
+
     @Flag(help: "Display results in specified format.")
     var outputFormat: OutputFormat = .table
 

--- a/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/CommonParsableCommand.swift
@@ -33,15 +33,16 @@ struct CommonOptions: ParsableArguments {
 }
 
 struct OutputOptions: ParsableArguments {
-    @Flag(default: .table, help: "Display results in specified format.")
-    var outputFormat: OutputFormat
+    
+    @Flag(help: "Display results in specified format.")
+    var outputFormat: OutputFormat = .table
 
     @Flag(help: "Display result in a human readable format.")
-    var pretty: Bool
+    var pretty = false
 
     /// Used to define the command's `PrintLevel`. Defaults to `false`.
     @Flag(name: .shortAndLong, help: "Display extra messages as command is running.")
-    var verbose: Bool
+    var verbose = false
 
     /// The verbosity of the executed command.
     var printLevel: PrintLevel {

--- a/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Devices/ListDevicesCommand.swift
@@ -31,7 +31,7 @@ struct ListDevicesCommand: CommonParsableCommand {
         ),
         transform: { $0.lowercased() }
     )
-    var filterName: [String]
+    var filterName: [String] = []
 
     @Option(
         parsing: .upToNextOption,
@@ -40,7 +40,7 @@ struct ListDevicesCommand: CommonParsableCommand {
             valueName: "platform"
         )
     )
-    var filterPlatform: [Platform]
+    var filterPlatform: [Platform] = []
 
     @Option(
         help: ArgumentHelp(
@@ -58,7 +58,7 @@ struct ListDevicesCommand: CommonParsableCommand {
         ),
         transform: { $0.lowercased() }
     )
-    var filterUDID: [String]
+    var filterUDID: [String] = []
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesByBundleIdCommand.swift
@@ -22,7 +22,10 @@ struct ListProfilesByBundleIdCommand: CommonParsableCommand {
     )
     var bundleId: String
 
-    @Option(default: 200, help: "Limit the number of profiles to return (maximum 200).")
+    @Option(
+        help: "Limit the number of profiles to return (maximum 200).",
+        transform: { Int($0).map { min($0, 200) } }
+    )
     var limit: Int?
 
     @Option(help:

--- a/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Profiles/ListProfilesCommand.swift
@@ -29,7 +29,7 @@ struct ListProfilesCommand: CommonParsableCommand {
         parsing: .upToNextOption,
         help: "The resource id of the profile."
     )
-    var filterId: [String]
+    var filterId: [String] = []
 
     @Option(
         parsing: .upToNextOption,
@@ -38,7 +38,7 @@ struct ListProfilesCommand: CommonParsableCommand {
             valueName: "name"
         )
     )
-    var filterName: [String]
+    var filterName: [String] = []
 
     @Option(
         help: ArgumentHelp(
@@ -55,7 +55,7 @@ struct ListProfilesCommand: CommonParsableCommand {
             valueName: "type"
         )
     )
-    var filterProfileType: [ProfileType]
+    var filterProfileType: [ProfileType] = []
 
     @Option(help:
         ArgumentHelp(

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Apps/ListAppsCommand.swift
@@ -19,13 +19,13 @@ struct ListAppsCommand: CommonParsableCommand {
     var limit: Int?
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified bundle IDs")
-    var filterBundleIds: [String]
+    var filterBundleIds: [String] = []
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified app names")
-    var filterNames: [String]
+    var filterNames: [String] = []
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified app SKUs")
-    var filterSkus: [String]
+    var filterSkus: [String] = []
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaGroups/ListBetaGroupsCommand.swift
@@ -25,7 +25,8 @@ struct ListBetaGroupsCommand: CommonParsableCommand {
             """,
             valueName: "filter-names"
         )
-    ) var filterNames: [String]
+    )
+    var filterNames: [String] = []
 
     @Option(
         parsing: .unconditional,
@@ -33,11 +34,13 @@ struct ListBetaGroupsCommand: CommonParsableCommand {
             "Sort the results using the provided key \(ListBetaGroups.Sort.allCases).",
             discussion: "The `-` prefix indicates descending order."
         )
-    ) var sort: ListBetaGroups.Sort?
+    )
+    var sort: ListBetaGroups.Sort?
 
     @Flag(
         help: "Exclude apple store connect internal beta groups."
-    ) var excludeInternal: Bool
+    )
+    var excludeInternal = false
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/BetaTesters/ListBetaTestersCommand.swift
@@ -52,7 +52,8 @@ struct ListBetaTestersCommand: CommonParsableCommand {
             "TestFlight beta group names.",
             valueName: "group-name"
         )
-    ) var filterGroupNames: [String]
+    )
+    var filterGroupNames: [String] = []
 
     @Option(help: "Number of resources to return. (maximum: 200)")
     var limit: Int?
@@ -63,7 +64,8 @@ struct ListBetaTestersCommand: CommonParsableCommand {
             "Sort the results using the provided key \(ListBetaTesters.Sort.allCases).",
             discussion: "The `-` prefix indicates descending order."
         )
-    ) var sort: ListBetaTesters.Sort?
+    )
+    var sort: ListBetaTesters.Sort?
 
     @Option(help: "Number of included related resources to return.")
     var relatedResourcesLimit: Int?

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/ListBuildsCommand.swift
@@ -20,17 +20,16 @@ struct ListBuildsCommand: CommonParsableCommand {
             valueName: "bundle-id"
         )
     )
-    var filterBundleIds: [String]
+    var filterBundleIds: [String] = []
 
     @Flag(
-        default: true,
         inversion: .prefixedNo,
         exclusivity: .exclusive,
         help: ArgumentHelp(
             "Whether expired builds should be included."
         )
     )
-    var includeExpired: Bool
+    var includeExpired = true
 
     @Option(
         parsing: .upToNextOption,
@@ -39,7 +38,7 @@ struct ListBuildsCommand: CommonParsableCommand {
             valueName: "pre-release-version"
         )
     )
-    var filterPreReleaseVersions: [String]
+    var filterPreReleaseVersions: [String] = []
 
     @Option(
         parsing: .upToNextOption,
@@ -48,16 +47,16 @@ struct ListBuildsCommand: CommonParsableCommand {
             valueName: "build-number"
         )
     )
-    var filterBuildNumbers: [String]
+    var filterBuildNumbers: [String] = []
 
     @Option(
         parsing: .upToNextOption,
         help: ArgumentHelp(
             "Filter by the processing state a build \(ListBuilds.Filter.ProcessingState.allCases)",
             valueName: "processing-state"
-     )
+        )
     )
-    var filterProcessingStates: [ListBuilds.Filter.ProcessingState]
+    var filterProcessingStates: [ListBuilds.Filter.ProcessingState] = []
 
     @Option(
         parsing: .upToNextOption,
@@ -66,7 +65,7 @@ struct ListBuildsCommand: CommonParsableCommand {
             valueName: "beta-review-state"
         )
     )
-    var filterBetaReviewStates: [String]
+    var filterBetaReviewStates: [String] = []
 
     @Option(help: "Limit the number of individualTesters & betaBuildLocalizations")
     var limit: Int?

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ListPreReleaseVersionsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/PreReleaseVersion/ListPreReleaseVersionsCommand.swift
@@ -21,7 +21,7 @@ struct ListPreReleaseVersionsCommand: CommonParsableCommand {
             valueName: "platform"
         )
     )
-    var filterPlatforms: [String]
+    var filterPlatforms: [String] = []
 
     @Option(
         parsing: .upToNextOption,
@@ -30,7 +30,7 @@ struct ListPreReleaseVersionsCommand: CommonParsableCommand {
             valueName: "version"
         )
     )
-    var filterVersions: [String]
+    var filterVersions: [String] = []
 
     @Option(
         parsing: .unconditional,

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPullCommand.swift
@@ -18,12 +18,11 @@ struct TestFlightPullCommand: CommonParsableCommand {
     @Option(
         parsing: .upToNextOption,
         help: "Filter by only including apps with the specified bundleIds in the configuration"
-    ) var filterBundleIds: [String]
+    )
+    var filterBundleIds: [String] = []
 
-    @Option(
-        default: "./config/apps",
-        help: "Path to output/write the TestFlight configuration."
-    ) var outputPath: String
+    @Option(help: "Path to output/write the TestFlight configuration.")
+    var outputPath = "./config/apps"
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPushCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Sync/TestFlightPushCommand.swift
@@ -15,10 +15,8 @@ struct TestFlightPushCommand: CommonParsableCommand {
     @OptionGroup()
     var common: CommonOptions
 
-    @Option(
-        default: "./config/apps",
-        help: "Path to read in the TestFlight configuration."
-    ) var inputPath: String
+    @Option(help: "Path to read in the TestFlight configuration.")
+    var inputPath = "./config/apps"
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/GetUserInfoCommand.swift
@@ -16,7 +16,7 @@ struct GetUserInfoCommand: CommonParsableCommand {
     var email: String
 
     @Flag(help: "Include visible apps in results.")
-    var includeVisibleApps: Bool
+    var includeVisibleApps = false
 
     func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/Invitations/ListUserInvitationsCommand.swift
@@ -16,13 +16,13 @@ struct ListUserInvitationsCommand: CommonParsableCommand {
     var limitVisibleApps: Int?
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified username")
-    var filterEmail: [String]
+    var filterEmail: [String] = []
 
     @Option(parsing: .upToNextOption, help: "Filter the results by the specified roles, (eg. \(UserRole.allCases.compactMap { $0.rawValue.lowercased() })")
-    var filterRole: [UserRole]
+    var filterRole: [UserRole] = []
 
     @Flag(help: "Include visible apps in results.")
-    var includeVisibleApps: Bool
+    var includeVisibleApps = false
 
     public func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/ListUsersCommand.swift
@@ -32,13 +32,13 @@ public struct ListUsersCommand: CommonParsableCommand {
         help: "Filter the results by the specified username.",
         transform: { $0.lowercased() }
     )
-    var filterUsername: [String]
+    var filterUsername: [String] = []
 
     @Option(
         parsing: .upToNextOption,
         help: ArgumentHelp(stringLiteral: "Filter the results by the specified roles (\(UserRole.allCases.map { $0.rawValue.lowercased() }.joined(separator: ", "))).")
     )
-    var filterRole: [UserRole]
+    var filterRole: [UserRole] = []
 
     @Option(
         parsing: .upToNextOption,
@@ -50,10 +50,10 @@ public struct ListUsersCommand: CommonParsableCommand {
         ),
         transform: AppLookupIdentifier.init
     )
-    var filterVisibleApps: [AppLookupIdentifier]
+    var filterVisibleApps: [AppLookupIdentifier] = []
 
     @Flag(help: "Include visible apps in results.")
-    var includeVisibleApps: Bool
+    var includeVisibleApps = false
 
     public func run() throws {
         let service = try makeService()

--- a/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/Users/SyncUsersCommand.swift
@@ -21,14 +21,11 @@ struct SyncUsersCommand: CommonParsableCommand {
     @Argument(help: "Path to the file containing the information about users. Specify format with --input-format")
     var config: String
 
-    @Option(
-        default: .json,
-        help: "Read config file in provided format (\(InputFormat.allCases.map { $0.rawValue }.joined(separator: ", ")))."
-    )
-    var inputFormat: InputFormat
+    @Option(help: "Read config file in provided format (\(InputFormat.allCases.map { $0.rawValue }.joined(separator: ", "))).")
+    var inputFormat: InputFormat = .json
 
     @Flag(help: "Perform a dry run.")
-    var dryRun: Bool
+    var dryRun = false
 
     func run() throws {
         // Only print if the `PrintLevel` is set to verbose.

--- a/Sources/AppStoreConnectCLI/Readers and Renderers/Formats.swift
+++ b/Sources/AppStoreConnectCLI/Readers and Renderers/Formats.swift
@@ -4,7 +4,7 @@ import ArgumentParser
 import Foundation
 import FileSystem
 
-enum OutputFormat: String, CaseIterable, Codable {
+enum OutputFormat: String, CaseIterable, Codable, EnumerableFlag {
     case csv
     case json
     case table

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListPreReleaseVersionsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListPreReleaseVersionsOperation.swift
@@ -28,7 +28,7 @@ struct ListPreReleaseVersionsOperation: APIOperation {
 
         if options.filterAppIds.isNotEmpty { filters.append(.app(options.filterAppIds)) }
         if options.filterVersions.isNotEmpty { filters.append(.version(options.filterVersions)) }
-        if options.filterPlatforms.isNotEmpty { filters.append(.platform(options.filterPlatforms.map { .init(rawValue: $0) ?? .IOS } )) }
+        if options.filterPlatforms.isNotEmpty { filters.append(.platform(options.filterPlatforms.map { .init(rawValue: $0) ?? .IOS })) }
 
         let sort = [options.sort].compactMap { $0 }
 

--- a/Sources/AppStoreConnectCLI/Services/Operations/ListPreReleaseVersionsOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ListPreReleaseVersionsOperation.swift
@@ -28,7 +28,7 @@ struct ListPreReleaseVersionsOperation: APIOperation {
 
         if options.filterAppIds.isNotEmpty { filters.append(.app(options.filterAppIds)) }
         if options.filterVersions.isNotEmpty { filters.append(.version(options.filterVersions)) }
-        if options.filterPlatforms.isNotEmpty { filters.append(.platform(options.filterPlatforms)) }
+        if options.filterPlatforms.isNotEmpty { filters.append(.platform(options.filterPlatforms.map { .init(rawValue: $0) ?? .IOS } )) }
 
         let sort = [options.sort].compactMap { $0 }
 


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Upgrades Swift Argument Parser dependency to v1.1.3
- Updates usage to match newer API
- Updates project to use Swift 5.6 (Xcode 13.4.1)

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

Run various commands.
