### PR TITLE
Upgrade Package Minimums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/johnsundell/files.git",
-            from: "4.0.0"
+            from: "4.1.1"
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git",
-            from: "1.0.0"
+            from: "1.7.0"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/dehesa/CodableCSV.git",
-            from: "0.5.2"
+            from: "0.5.5"
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/scottrhoyt/SwiftyTextTable.git",
-            from: "0.5.0"
+            from: "0.9.0"
         ),
         .package(
             url: "https://github.com/dehesa/CodableCSV.git",


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Set min version of SwiftyTextTable to 0.9.0 in Package.swift
- Set min version of Files to 4.1.1 in Package.swift
- Set min version of appstoreconnect-swift-sdk to 1.7.0 in Package.swift

# ⚠️ Items of Note

This will require #252 to be merged first and this PR rebased on that.
