### PR TITLE
Allow for exact matching with build arguments

### DIFF
--- a/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/UpdateBuildLocalizationsCommand.swift
+++ b/Sources/AppStoreConnectCLI/Commands/TestFlight/Builds/Localizations/UpdateBuildLocalizationsCommand.swift
@@ -28,7 +28,7 @@ struct UpdateBuildLocalizationsCommand: CommonParsableCommand, CreateUpdateBuild
     func run() throws {
         let service = try makeService()
 
-        let buildLocalization = try service.upateBuildLocalization(
+        let buildLocalization = try service.updateBuildLocalization(
             bundleId: build.bundleId,
             buildNumber: build.buildNumber,
             preReleaseVersion: build.preReleaseVersion,

--- a/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
+++ b/Sources/AppStoreConnectCLI/Services/AppStoreConnectService.swift
@@ -1059,7 +1059,7 @@ class AppStoreConnectService {
         )
     }
 
-    func upateBuildLocalization(
+    func updateBuildLocalization(
         bundleId: String,
         buildNumber: String,
         preReleaseVersion: String,

--- a/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
+++ b/Sources/AppStoreConnectCLI/Services/Operations/ReadAppOperation.swift
@@ -8,6 +8,7 @@ struct ReadAppOperation: APIOperation {
 
     struct Options {
         let identifier: AppLookupIdentifier
+        var shouldMatchExactly: Bool = true
     }
 
     enum Error: LocalizedError {
@@ -51,7 +52,17 @@ struct ReadAppOperation: APIOperation {
                     case 1:
                         return response.data.first!
                     default:
-                        throw Error.notUnique(bundleId)
+                        guard options.shouldMatchExactly else {
+                            throw Error.notUnique(bundleId)
+                        }
+
+                        guard let match = response.data.first(where: {
+                            $0.attributes?.bundleId == bundleId
+                        }) else {
+                            throw Error.notFound(bundleId)
+                        }
+
+                        return match
                     }
                 }
                 .eraseToAnyPublisher()


### PR DESCRIPTION
In most cases we want to match the bundle id exactly when we’re specifying build arguments, especially when they’re being used to point to a specific build (rather than a filter for a list).

This is particularly problematic when we have multiple bundle ids that have the same prefix (e.g. com.company.appname, com.company.appname.development)